### PR TITLE
feat: 建立最小工具调用边界

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -10,6 +10,7 @@
     "dev:watch": "tsx watch --env-file-if-exists=../../.env src/main.ts",
     "start": "node dist/main.js",
     "test:model-stream": "tsx --test src/llm/clients/openai-compatible-stream.adapter.test.ts src/agent-runtime/agent-runtime.service.test.ts",
+    "test:tools": "tsx --test src/tools/**/*.test.ts",
     "pretypecheck": "pnpm --workspace-root prisma:generate",
     "typecheck": "tsc --noEmit",
     "lint": "eslint src",

--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -6,9 +6,10 @@ import { RequestIdMiddleware } from './common/middleware/request-id.middleware.j
 import { ConversationsModule } from './conversations/conversations.module.js'
 import { LlmModule } from './llm/llm.module.js'
 import { SeoModule } from './seo/seo.module.js'
+import { ToolsModule } from './tools/tools.module.js'
 
 @Module({
-  imports: [LlmModule, SeoModule, ConversationsModule],
+  imports: [LlmModule, SeoModule, ConversationsModule, ToolsModule],
   controllers: [AppController],
 })
 export class AppModule implements NestModule {

--- a/apps/api/src/llm/model-tool-spec.types.ts
+++ b/apps/api/src/llm/model-tool-spec.types.ts
@@ -1,0 +1,8 @@
+import type { JsonObjectSchema } from '../tools/tool.types.js'
+
+/** Provider-neutral 的模型可见工具说明，不包含任何服务端执行能力。 */
+export interface ModelToolSpec {
+  name: string
+  description: string
+  inputSchema: JsonObjectSchema
+}

--- a/apps/api/src/tools/model-tool-spec.mapper.ts
+++ b/apps/api/src/tools/model-tool-spec.mapper.ts
@@ -1,0 +1,10 @@
+import type { ModelToolSpec } from '../llm/model-tool-spec.types.js'
+import type { ToolDefinition } from './tool.types.js'
+
+export function toModelToolSpec(definition: ToolDefinition): ModelToolSpec {
+  return {
+    name: definition.name,
+    description: definition.description,
+    inputSchema: definition.input.schema,
+  }
+}

--- a/apps/api/src/tools/tool-invocation.service.ts
+++ b/apps/api/src/tools/tool-invocation.service.ts
@@ -19,6 +19,8 @@ export class ToolInvocationService {
     envelope: UnvalidatedToolCallEnvelope,
     context: ToolExecutionContext,
   ): Promise<ToolResult> {
+    context.signal.throwIfAborted()
+
     const tool = this.registry.get(envelope.toolName)
 
     if (!tool) {
@@ -26,6 +28,20 @@ export class ToolInvocationService {
         ok: false,
         code: 'unknown_tool',
         modelContent: `工具 ${envelope.toolName} 不存在。`,
+        retryable: false,
+      }
+    }
+
+    if (
+      tool.definition.requiresApproval
+      || tool.definition.risk.level !== 'low'
+      || tool.definition.risk.sideEffect !== 'none'
+      || tool.definition.risk.network
+    ) {
+      return {
+        ok: false,
+        code: 'execution_failed',
+        modelContent: `工具 ${envelope.toolName} 当前不允许执行。`,
         retryable: false,
       }
     }
@@ -52,10 +68,10 @@ export class ToolInvocationService {
       input,
     }
 
-    context.signal.throwIfAborted()
-
     try {
-      return await tool.executor.execute(invocation, context)
+      const result = await tool.executor.execute(invocation, context)
+      context.signal.throwIfAborted()
+      return result
     }
     catch (error) {
       if (context.signal.aborted || isAbortError(error))

--- a/apps/api/src/tools/tool-invocation.service.ts
+++ b/apps/api/src/tools/tool-invocation.service.ts
@@ -1,0 +1,76 @@
+import type {
+  ToolExecutionContext,
+  ToolResult,
+  UnvalidatedToolCallEnvelope,
+  ValidatedToolInvocation,
+} from './tool.types.js'
+import { Inject, Injectable } from '@nestjs/common'
+
+import { ToolRegistryService } from './tool-registry.service.js'
+
+@Injectable()
+export class ToolInvocationService {
+  constructor(
+    @Inject(ToolRegistryService)
+    private readonly registry: ToolRegistryService,
+  ) {}
+
+  async invoke(
+    envelope: UnvalidatedToolCallEnvelope,
+    context: ToolExecutionContext,
+  ): Promise<ToolResult> {
+    const tool = this.registry.get(envelope.toolName)
+
+    if (!tool) {
+      return {
+        ok: false,
+        code: 'unknown_tool',
+        modelContent: `工具 ${envelope.toolName} 不存在。`,
+        retryable: false,
+      }
+    }
+
+    let input: unknown
+
+    try {
+      input = tool.definition.input.parse(JSON.parse(envelope.rawArgumentsJson))
+    }
+    catch {
+      return {
+        ok: false,
+        code: 'invalid_arguments',
+        modelContent: `工具 ${envelope.toolName} 的参数无效。`,
+        retryable: false,
+      }
+    }
+
+    const invocation: ValidatedToolInvocation = {
+      callId: envelope.callId,
+      toolName: tool.definition.name,
+      toolVersion: tool.definition.version,
+      samplingAttemptId: envelope.samplingAttemptId,
+      input,
+    }
+
+    context.signal.throwIfAborted()
+
+    try {
+      return await tool.executor.execute(invocation, context)
+    }
+    catch (error) {
+      if (context.signal.aborted || isAbortError(error))
+        throw error
+
+      return {
+        ok: false,
+        code: 'execution_failed',
+        modelContent: `工具 ${envelope.toolName} 执行失败。`,
+        retryable: false,
+      }
+    }
+  }
+}
+
+function isAbortError(error: unknown): boolean {
+  return error instanceof Error && error.name === 'AbortError'
+}

--- a/apps/api/src/tools/tool-registry.service.ts
+++ b/apps/api/src/tools/tool-registry.service.ts
@@ -1,0 +1,42 @@
+import type { RegisteredTool, ToolDefinition } from './tool.types.js'
+import { Injectable } from '@nestjs/common'
+
+import { ToolRegistryError } from './tool.errors.js'
+
+const TOOL_NAME_PATTERN = /^[a-z][a-z0-9]*(?:_[a-z0-9]+)*$/
+
+@Injectable()
+export class ToolRegistryService {
+  private readonly tools = new Map<string, unknown>()
+
+  register<TInput, TOutput>(tool: RegisteredTool<TInput, TOutput>): void {
+    const { name } = tool.definition
+
+    if (!TOOL_NAME_PATTERN.test(name))
+      throw new ToolRegistryError('invalid_tool_name', `非法工具名：${name}`)
+
+    if (this.tools.has(name))
+      throw new ToolRegistryError('duplicate_tool', `工具已注册：${name}`)
+
+    this.tools.set(name, tool)
+  }
+
+  get(name: string): RegisteredTool | undefined {
+    return this.tools.get(name) as RegisteredTool | undefined
+  }
+
+  require(name: string): RegisteredTool {
+    const tool = this.get(name)
+
+    if (!tool)
+      throw new ToolRegistryError('unknown_tool', `未知工具：${name}`)
+
+    return tool
+  }
+
+  listDefinitions(): ToolDefinition[] {
+    return [...this.tools.keys()]
+      .sort((left, right) => left.localeCompare(right))
+      .map(name => this.require(name).definition)
+  }
+}

--- a/apps/api/src/tools/tool.errors.ts
+++ b/apps/api/src/tools/tool.errors.ts
@@ -1,0 +1,14 @@
+export type ToolRegistryErrorCode
+  = | 'duplicate_tool'
+    | 'invalid_tool_name'
+    | 'unknown_tool'
+
+export class ToolRegistryError extends Error {
+  constructor(
+    readonly code: ToolRegistryErrorCode,
+    message: string,
+  ) {
+    super(message)
+    this.name = 'ToolRegistryError'
+  }
+}

--- a/apps/api/src/tools/tool.types.ts
+++ b/apps/api/src/tools/tool.types.ts
@@ -1,0 +1,87 @@
+/** 当前工具输入需要的最小 JSON Schema 子集。 */
+export type JsonSchemaProperty
+  = | { type: 'boolean', description?: string }
+    | { type: 'integer', description?: string }
+    | { type: 'string', description?: string }
+
+export interface JsonObjectSchema {
+  type: 'object'
+  properties: Record<string, JsonSchemaProperty>
+  required: string[]
+  additionalProperties: false
+}
+
+/** 将模型可见 Schema 与服务端运行时解析绑定为同一个输入契约。 */
+export interface ToolInputContract<TInput> {
+  schema: JsonObjectSchema
+  parse: (value: unknown) => TInput
+}
+
+export interface ToolRisk {
+  level: 'high' | 'low' | 'medium'
+  sideEffect: 'external_write' | 'none'
+  network: boolean
+}
+
+/** 工具的服务端定义；执行器与运行上下文不会暴露给模型。 */
+export interface ToolDefinition<TInput = unknown> {
+  name: string
+  version: string
+  description: string
+  input: ToolInputContract<TInput>
+  timeoutMs: number
+  requiresApproval: boolean
+  idempotent: boolean
+  risk: ToolRisk
+}
+
+/** 模型提出、但尚未经过工具查找和参数验证的调用。 */
+export interface UnvalidatedToolCallEnvelope {
+  callId: string
+  toolName: string
+  rawArgumentsJson: string
+  samplingAttemptId: string
+}
+
+/** Registry 查找并验证参数后，Executor 唯一允许接收的调用。 */
+export interface ValidatedToolInvocation<TInput = unknown> {
+  callId: string
+  toolName: string
+  toolVersion: string
+  samplingAttemptId: string
+  input: TInput
+}
+
+/** 完全由服务端提供，不允许模型 arguments 覆盖。 */
+export interface ToolExecutionContext {
+  runId: string
+  conversationId: string
+  signal: AbortSignal
+  executionAttempt: number
+}
+
+export type ToolResult<T = unknown>
+  = | {
+    ok: true
+    data: T
+    modelContent: string
+  }
+  | {
+    ok: false
+    code: 'execution_failed' | 'invalid_arguments' | 'unknown_tool'
+    modelContent: string
+    retryable: boolean
+  }
+
+export interface ToolExecutor<TInput, TOutput> {
+  execute: (
+    invocation: ValidatedToolInvocation<TInput>,
+    context: ToolExecutionContext,
+  ) => Promise<ToolResult<TOutput>>
+}
+
+/** Definition 与对应 Executor 的显式组装边界。 */
+export interface RegisteredTool<TInput = unknown, TOutput = unknown> {
+  definition: ToolDefinition<TInput>
+  executor: ToolExecutor<TInput, TOutput>
+}

--- a/apps/api/src/tools/tools.module.ts
+++ b/apps/api/src/tools/tools.module.ts
@@ -1,0 +1,10 @@
+import { Module } from '@nestjs/common'
+
+import { ToolInvocationService } from './tool-invocation.service.js'
+import { ToolRegistryService } from './tool-registry.service.js'
+
+@Module({
+  providers: [ToolRegistryService, ToolInvocationService],
+  exports: [ToolRegistryService, ToolInvocationService],
+})
+export class ToolsModule {}

--- a/apps/api/src/tools/tools.test.ts
+++ b/apps/api/src/tools/tools.test.ts
@@ -1,0 +1,281 @@
+import type {
+  RegisteredTool,
+  ToolExecutionContext,
+  ToolExecutor,
+  ValidatedToolInvocation,
+} from './tool.types.js'
+import assert from 'node:assert/strict'
+// 项目本轮使用 Node 原生测试运行器，不引入额外测试框架。
+// eslint-disable-next-line test/no-import-node-test
+import { describe, it } from 'node:test'
+
+import { toModelToolSpec } from './model-tool-spec.mapper.js'
+import { ToolInvocationService } from './tool-invocation.service.js'
+import { ToolRegistryService } from './tool-registry.service.js'
+import { ToolRegistryError } from './tool.errors.js'
+import { ToolsModule } from './tools.module.js'
+
+interface EchoInput {
+  message: string
+}
+
+interface EchoOutput {
+  echoed: string
+}
+
+describe('ToolRegistryService', () => {
+  it('注册、查找并按名称稳定列出 Definition', () => {
+    const registry = new ToolRegistryService()
+    const zebra = createEchoTool('zebra_tool')
+    const alpha = createEchoTool('alpha_tool')
+
+    registry.register(zebra)
+    registry.register(alpha)
+
+    assert.equal(registry.get('zebra_tool'), zebra)
+    assert.deepEqual(
+      registry.listDefinitions().map(definition => definition.name),
+      ['alpha_tool', 'zebra_tool'],
+    )
+  })
+
+  it('拒绝非法名称和重复注册', () => {
+    const registry = new ToolRegistryService()
+
+    assert.throws(
+      () => registry.register(createEchoTool('Bad Tool')),
+      (error: unknown) => error instanceof ToolRegistryError
+        && error.code === 'invalid_tool_name',
+    )
+
+    registry.register(createEchoTool())
+    assert.throws(
+      () => registry.register(createEchoTool()),
+      (error: unknown) => error instanceof ToolRegistryError
+        && error.code === 'duplicate_tool',
+    )
+  })
+
+  it('require 对未知工具给出明确错误', () => {
+    const registry = new ToolRegistryService()
+
+    assert.throws(
+      () => registry.require('missing_tool'),
+      (error: unknown) => error instanceof ToolRegistryError
+        && error.code === 'unknown_tool',
+    )
+  })
+})
+
+describe('ToolInvocationService', () => {
+  it('未知工具返回结构化失败', async () => {
+    const service = new ToolInvocationService(new ToolRegistryService())
+
+    assert.deepEqual(
+      await service.invoke(createEnvelope('missing_tool'), createContext()),
+      {
+        ok: false,
+        code: 'unknown_tool',
+        modelContent: '工具 missing_tool 不存在。',
+        retryable: false,
+      },
+    )
+  })
+
+  it('拒绝非法 JSON、缺字段、错类型和额外字段，且不执行工具', async () => {
+    let executionCount = 0
+    const registry = new ToolRegistryService()
+    registry.register(createEchoTool('echo', async () => {
+      executionCount += 1
+      return { ok: true, data: { echoed: 'unexpected' }, modelContent: 'unexpected' }
+    }))
+    const service = new ToolInvocationService(registry)
+    const invalidArguments = [
+      '{',
+      '{}',
+      '{"message":1}',
+      '{"message":"hello","extra":true}',
+    ]
+
+    for (const rawArgumentsJson of invalidArguments) {
+      const result = await service.invoke(
+        { ...createEnvelope(), rawArgumentsJson },
+        createContext(),
+      )
+
+      assert.equal(result.ok, false)
+      assert.equal(result.ok ? undefined : result.code, 'invalid_arguments')
+    }
+
+    assert.equal(executionCount, 0)
+  })
+
+  it('合法调用只把已验证参数与 Registry 版本交给 Executor', async () => {
+    let receivedInvocation: ValidatedToolInvocation<EchoInput> | undefined
+    let receivedContext: ToolExecutionContext | undefined
+    const registry = new ToolRegistryService()
+    registry.register(createEchoTool('echo', async (invocation, context) => {
+      receivedInvocation = invocation
+      receivedContext = context
+      return {
+        ok: true,
+        data: { echoed: invocation.input.message },
+        modelContent: invocation.input.message,
+      }
+    }))
+    const service = new ToolInvocationService(registry)
+    const context = createContext()
+
+    const result = await service.invoke(createEnvelope(), context)
+
+    assert.deepEqual(result, {
+      ok: true,
+      data: { echoed: 'hello' },
+      modelContent: 'hello',
+    })
+    assert.deepEqual(receivedInvocation, {
+      callId: 'call-1',
+      toolName: 'echo',
+      toolVersion: '1',
+      samplingAttemptId: 'sampling-2',
+      input: { message: 'hello' },
+    })
+    assert.equal(receivedContext, context)
+  })
+
+  it('把普通执行异常转换为安全失败，不泄漏原始错误', async () => {
+    const registry = new ToolRegistryService()
+    registry.register(createEchoTool('echo', async () => {
+      throw new Error('database password: secret')
+    }))
+    const service = new ToolInvocationService(registry)
+
+    const result = await service.invoke(createEnvelope(), createContext())
+
+    assert.equal(result.ok, false)
+    assert.equal(result.ok ? undefined : result.code, 'execution_failed')
+    assert.doesNotMatch(result.modelContent, /password|secret/)
+  })
+
+  it('已触发的 AbortSignal 不执行工具，并继续抛出 Abort', async () => {
+    let executionCount = 0
+    const registry = new ToolRegistryService()
+    registry.register(createEchoTool('echo', async () => {
+      executionCount += 1
+      return { ok: true, data: { echoed: 'unexpected' }, modelContent: 'unexpected' }
+    }))
+    const service = new ToolInvocationService(registry)
+    const abortController = new AbortController()
+    abortController.abort()
+
+    await assert.rejects(
+      service.invoke(createEnvelope(), createContext(abortController.signal)),
+      { name: 'AbortError' },
+    )
+    assert.equal(executionCount, 0)
+  })
+
+  it('Executor 抛出的 AbortError 继续向上抛出', async () => {
+    const registry = new ToolRegistryService()
+    registry.register(createEchoTool('echo', async () => {
+      throw new DOMException('aborted', 'AbortError')
+    }))
+    const service = new ToolInvocationService(registry)
+
+    await assert.rejects(
+      service.invoke(createEnvelope(), createContext()),
+      { name: 'AbortError' },
+    )
+  })
+})
+
+describe('模型映射与 NestJS 模块', () => {
+  it('ModelToolSpec 只包含模型可见字段', () => {
+    const definition = createEchoTool().definition
+
+    assert.deepEqual(toModelToolSpec(definition), {
+      name: 'echo',
+      description: '回显输入消息。',
+      inputSchema: definition.input.schema,
+    })
+  })
+
+  it('ToolsModule 提供并导出 Registry 与 InvocationService', () => {
+    const providers = Reflect.getMetadata('providers', ToolsModule)
+    const exports = Reflect.getMetadata('exports', ToolsModule)
+
+    assert.deepEqual(providers, [ToolRegistryService, ToolInvocationService])
+    assert.deepEqual(exports, [ToolRegistryService, ToolInvocationService])
+  })
+})
+
+function createEchoTool(
+  name = 'echo',
+  execute: ToolExecutor<EchoInput, EchoOutput>['execute'] = async invocation => ({
+    ok: true,
+    data: { echoed: invocation.input.message },
+    modelContent: invocation.input.message,
+  }),
+): RegisteredTool<EchoInput, EchoOutput> {
+  return {
+    definition: {
+      name,
+      version: '1',
+      description: '回显输入消息。',
+      input: {
+        schema: {
+          type: 'object',
+          properties: { message: { type: 'string' } },
+          required: ['message'],
+          additionalProperties: false,
+        },
+        parse: parseEchoInput,
+      },
+      timeoutMs: 1_000,
+      requiresApproval: false,
+      idempotent: true,
+      risk: { level: 'low', sideEffect: 'none', network: false },
+    },
+    executor: { execute },
+  }
+}
+
+function parseEchoInput(value: unknown): EchoInput {
+  if (
+    typeof value !== 'object'
+    || value === null
+    || Array.isArray(value)
+  ) {
+    throw new Error('invalid echo input')
+  }
+
+  const record = value as Record<string, unknown>
+
+  if (
+    Object.keys(value).length !== 1
+    || !Object.hasOwn(value, 'message')
+    || typeof record.message !== 'string'
+  ) {
+    throw new Error('invalid echo input')
+  }
+
+  return { message: record.message }
+}
+
+function createEnvelope(toolName = 'echo') {
+  return {
+    callId: 'call-1',
+    toolName,
+    rawArgumentsJson: '{"message":"hello"}',
+    samplingAttemptId: 'sampling-2',
+  }
+}
+
+function createContext(signal = new AbortController().signal): ToolExecutionContext {
+  return {
+    runId: 'run-1',
+    conversationId: 'conversation-1',
+    signal,
+    executionAttempt: 1,
+  }
+}

--- a/apps/api/src/tools/tools.test.ts
+++ b/apps/api/src/tools/tools.test.ts
@@ -157,7 +157,43 @@ describe('ToolInvocationService', () => {
     assert.doesNotMatch(result.modelContent, /password|secret/)
   })
 
-  it('已触发的 AbortSignal 不执行工具，并继续抛出 Abort', async () => {
+  it('拒绝当前阶段不支持的风险和审批配置，且不执行工具', async () => {
+    let executionCount = 0
+    const execute: ToolExecutor<EchoInput, EchoOutput>['execute'] = async () => {
+      executionCount += 1
+      return { ok: true, data: { echoed: 'unexpected' }, modelContent: 'unexpected' }
+    }
+    const approvalTool = createEchoTool('approval_tool', execute)
+    const mediumRiskTool = createEchoTool('medium_risk_tool', execute)
+    const writeTool = createEchoTool('write_tool', execute)
+    const networkTool = createEchoTool('network_tool', execute)
+    approvalTool.definition.requiresApproval = true
+    mediumRiskTool.definition.risk.level = 'medium'
+    writeTool.definition.risk.sideEffect = 'external_write'
+    networkTool.definition.risk.network = true
+
+    const registry = new ToolRegistryService()
+    const tools = [approvalTool, mediumRiskTool, writeTool, networkTool]
+
+    for (const tool of tools)
+      registry.register(tool)
+
+    const service = new ToolInvocationService(registry)
+
+    for (const tool of tools) {
+      const result = await service.invoke(
+        createEnvelope(tool.definition.name),
+        createContext(),
+      )
+
+      assert.equal(result.ok, false)
+      assert.equal(result.ok ? undefined : result.code, 'execution_failed')
+    }
+
+    assert.equal(executionCount, 0)
+  })
+
+  it('已触发的 AbortSignal 优先于工具查找和参数验证，且不执行工具', async () => {
     let executionCount = 0
     const registry = new ToolRegistryService()
     registry.register(createEchoTool('echo', async () => {
@@ -168,11 +204,35 @@ describe('ToolInvocationService', () => {
     const abortController = new AbortController()
     abortController.abort()
 
+    const envelopes = [
+      createEnvelope('missing_tool'),
+      { ...createEnvelope(), rawArgumentsJson: '{' },
+      createEnvelope(),
+    ]
+
+    for (const envelope of envelopes) {
+      await assert.rejects(
+        service.invoke(envelope, createContext(abortController.signal)),
+        { name: 'AbortError' },
+      )
+    }
+
+    assert.equal(executionCount, 0)
+  })
+
+  it('Executor 返回期间触发的 AbortSignal 仍继续抛出 Abort', async () => {
+    const abortController = new AbortController()
+    const registry = new ToolRegistryService()
+    registry.register(createEchoTool('echo', async () => {
+      abortController.abort()
+      return { ok: true, data: { echoed: 'unexpected' }, modelContent: 'unexpected' }
+    }))
+    const service = new ToolInvocationService(registry)
+
     await assert.rejects(
       service.invoke(createEnvelope(), createContext(abortController.signal)),
       { name: 'AbortError' },
     )
-    assert.equal(executionCount, 0)
   })
 
   it('Executor 抛出的 AbortError 继续向上抛出', async () => {

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -4,7 +4,7 @@
 
 ## 当前判断
 
-项目已经完成从固定字段 SEO 生成器到 Session Chat 的迁移，并完成流式输出最终态一致性收口。阶段 4 Agent Runtime 基础已归档；阶段 5 正在进行，Task 0 已准备 68 篇中英文文章 Demo 数据，Task 1 已完成 provider-neutral `ModelStreamEvent` 与 Runtime 适配。下一步进入最小 Tool Contract 与 Registry，不要直接跳到工具实现、RAG 或多 Agent。
+项目已经完成从固定字段 SEO 生成器到 Session Chat 的迁移，并完成流式输出最终态一致性收口。阶段 4 Agent Runtime 基础已归档；阶段 5 继续进行，Task 0-2 已完成并通过验收，最小 Tool Contract、Registry、参数验证与执行边界已经建立。Task 3 保持 Planned、尚未开始，下一步再实现第一只只读工具 `search_articles`，不要直接跳到 Tool Loop、RAG 或多 Agent。
 
 ## 阶段路线
 
@@ -23,8 +23,8 @@
 
 | 优先级 | 任务 | 说明 |
 | --- | --- | --- |
-| P0 | 阶段 5 Task 2 | 定义最小 `ToolDefinition`、`ToolRegistry`、参数验证、执行与结果边界 |
-| P1 | 阶段 5 Task 3-5 | 依次完成 `search_articles`、单 Agent Tool Loop 和 `AgentStep` 记录 |
+| P0 | 阶段 5 Task 3（Planned） | 下一步实现 `search_articles`；当前尚未开始 |
+| P1 | 阶段 5 Task 4-5 | 后续依次完成单 Agent Tool Loop 和 `AgentStep` 记录 |
 | P2 | Context 管理增强 | 阶段 5 稳定后再加入页面数据、关键词、工具 Observation 和预算规则 |
 
 ## 现在暂不做

--- a/docs/tasks/README.md
+++ b/docs/tasks/README.md
@@ -6,7 +6,7 @@
 
 | 区域 | 状态 | 文档 | 说明 |
 | --- | --- | --- | --- |
-| 阶段 5 最小 Tool Calling | In Progress | [phase-05-tool-calling/README.md](./phase-05-tool-calling/README.md) | Task 0-1 已完成；下一步执行 Task 2，定义最小 Tool Contract、Registry、参数验证与执行边界 |
+| 阶段 5 最小 Tool Calling | In Progress | [phase-05-tool-calling/README.md](./phase-05-tool-calling/README.md) | Task 0-2 已完成；Task 3 保持 Planned，尚未开始 |
 | 阶段 4 Agent Runtime | Completed | [completed/phase-04-agent-runtime.md](./completed/phase-04-agent-runtime.md) | 已归档为可观测 Agent Run 的基础阶段 |
 | 阶段 3 收口 | Completed | [completed/phase-03-streaming-closeout.md](./completed/phase-03-streaming-closeout.md) | 已收口 `done/error/aborted` 最终态一致性 |
 | 阶段 2 | Completed | [completed/phase-02-agent-chat-session.md](./completed/phase-02-agent-chat-session.md) | 多会话和消息持久化已完成 |

--- a/docs/tasks/phase-05-tool-calling/README.md
+++ b/docs/tasks/phase-05-tool-calling/README.md
@@ -1,6 +1,6 @@
 # 阶段 5：最小 Tool Calling
 
-状态：进行中。Task 2 已实现，待验收。
+状态：进行中。Task 2 已完成并通过验收，Task 3 尚未开始。
 
 ## 阶段目标
 
@@ -40,7 +40,7 @@
 | --- | --- | --- |
 | Task 0 | Completed | 新增 `Article` 表并导入文章 Demo 数据，为只读工具提供稳定数据源 |
 | Task 1 | Completed | 将纯文本模型流升级为 provider-neutral `ModelStreamEvent`，让 Runtime 能识别文本、Tool Call 和本次 sampling 的结束原因 |
-| Task 2 | Implemented / Pending Acceptance | 定义最小 `ToolDefinition`、`ToolRegistry`、参数验证、执行与结果边界 |
+| Task 2 | Completed | 定义最小 `ToolDefinition`、`ToolRegistry`、参数验证、执行与结果边界 |
 | Task 3 | Planned | 实现第一只只读工具 `search_articles`，查询并返回精简文章信息 |
 | Task 4 | Planned | 实现单 Agent Tool Loop：模型请求工具、后端执行、Observation 回填、模型继续生成最终回答 |
 | Task 5 | Planned | 将模型调用、工具执行和工具结果记录到 `AgentStep`，保持当前前端 stream 协议稳定 |
@@ -55,14 +55,16 @@
 - 使用现有 `tsx` 和 Node 原生 `node:test` 增加 12 个最小回归用例，没有新增依赖。
 - `pnpm --filter @agent/api test:model-stream`、`pnpm --filter @agent/api lint`、`pnpm typecheck`、`git diff --check` 通过；全仓 `pnpm lint` 仍被既有 research Markdown 的 97 个错误阻断。
 
-## Task 2 实现结果（待验收）
+## Task 2 完成结果
 
 - 新增一级 `tools` 模块，明确 `ToolDefinition`、输入契约、Registry、已验证调用、Executor、执行上下文和 `ToolResult` 边界。
 - `ToolRegistryService` 对非法名称、重复注册和未知工具 fail fast，并按名称稳定列出 definitions。
-- `ToolInvocationService` 依次完成工具查找、JSON 解析、工具专属运行时验证和执行；参数失败不调用 Executor，普通异常转换为安全结果，Abort 继续向上抛出。
+- `ToolInvocationService` 依次完成工具查找、JSON 解析、工具专属运行时验证和执行；参数失败不调用 Executor，普通异常转换为安全结果。
+- Abort 在调用入口和 Executor 返回后检查，已取消调用不会被记录成工具失败；当前阶段对需审批、非低风险、有副作用或联网工具统一 fail closed。
 - 新增 provider-neutral `ModelToolSpec` 与纯映射，只暴露名称、描述和输入 Schema。
-- 使用无网络、无副作用的测试专用 `echo` 工具覆盖 11 个 Registry、Invocation、Mapper 和 NestJS 模块回归用例；未接入 Runtime Tool Loop，也未实现正式业务工具。
-- 实施状态：已实现；验收状态：待验收。Task 3 尚未开始。
+- 使用无网络、无副作用的测试专用 `echo` 工具覆盖 13 个 Registry、Invocation、Mapper 和 NestJS 模块回归用例；未接入 Runtime Tool Loop，也未实现正式业务工具。
+- `timeoutMs` 当前只保留为 server-owned metadata；工具超时执行逻辑按 Issue #1 明确留待后续任务，不阻塞 Task 2 验收。
+- 实施状态：已实现；验收状态：已通过；任务状态：Completed。Task 3 保持 Planned，尚未开始。
 
 ## 关键边界
 

--- a/docs/tasks/phase-05-tool-calling/README.md
+++ b/docs/tasks/phase-05-tool-calling/README.md
@@ -1,6 +1,6 @@
 # 阶段 5：最小 Tool Calling
 
-状态：进行中。
+状态：进行中。Task 2 已实现，待验收。
 
 ## 阶段目标
 
@@ -40,7 +40,7 @@
 | --- | --- | --- |
 | Task 0 | Completed | 新增 `Article` 表并导入文章 Demo 数据，为只读工具提供稳定数据源 |
 | Task 1 | Completed | 将纯文本模型流升级为 provider-neutral `ModelStreamEvent`，让 Runtime 能识别文本、Tool Call 和本次 sampling 的结束原因 |
-| Task 2 | Planned | 定义最小 `ToolDefinition`、`ToolRegistry`、参数验证、执行与结果边界 |
+| Task 2 | Implemented / Pending Acceptance | 定义最小 `ToolDefinition`、`ToolRegistry`、参数验证、执行与结果边界 |
 | Task 3 | Planned | 实现第一只只读工具 `search_articles`，查询并返回精简文章信息 |
 | Task 4 | Planned | 实现单 Agent Tool Loop：模型请求工具、后端执行、Observation 回填、模型继续生成最终回答 |
 | Task 5 | Planned | 将模型调用、工具执行和工具结果记录到 `AgentStep`，保持当前前端 stream 协议稳定 |
@@ -54,6 +54,15 @@
 - Provider error 和 Abort 继续只通过 async iterator throw 传播，前端 `ChatStreamEvent` 保持不变。
 - 使用现有 `tsx` 和 Node 原生 `node:test` 增加 12 个最小回归用例，没有新增依赖。
 - `pnpm --filter @agent/api test:model-stream`、`pnpm --filter @agent/api lint`、`pnpm typecheck`、`git diff --check` 通过；全仓 `pnpm lint` 仍被既有 research Markdown 的 97 个错误阻断。
+
+## Task 2 实现结果（待验收）
+
+- 新增一级 `tools` 模块，明确 `ToolDefinition`、输入契约、Registry、已验证调用、Executor、执行上下文和 `ToolResult` 边界。
+- `ToolRegistryService` 对非法名称、重复注册和未知工具 fail fast，并按名称稳定列出 definitions。
+- `ToolInvocationService` 依次完成工具查找、JSON 解析、工具专属运行时验证和执行；参数失败不调用 Executor，普通异常转换为安全结果，Abort 继续向上抛出。
+- 新增 provider-neutral `ModelToolSpec` 与纯映射，只暴露名称、描述和输入 Schema。
+- 使用无网络、无副作用的测试专用 `echo` 工具覆盖 11 个 Registry、Invocation、Mapper 和 NestJS 模块回归用例；未接入 Runtime Tool Loop，也未实现正式业务工具。
+- 实施状态：已实现；验收状态：待验收。Task 3 尚未开始。
 
 ## 关键边界
 

--- a/docs/work-log.md
+++ b/docs/work-log.md
@@ -6,7 +6,7 @@
 
 | 类型 | 当前记录 | 下一步 |
 | --- | --- | --- |
-| 当前阶段 | 阶段 4 Agent Runtime 基础已归档；阶段 5 进行中，Task 0-1 已完成，Task 2 已实现待验收 | 下一步验收 Task 2；Task 3 尚未开始 |
+| 当前阶段 | 阶段 4 Agent Runtime 基础已归档；阶段 5 进行中，Task 0-2 已完成，Task 2 已通过验收 | Task 3 保持 Planned，尚未开始 |
 | 文档结构 | docs 已重组为 `roadmap`、`tasks`、`research`、`work-log` 四类入口；当前任务以 `docs/tasks/README.md` 为准 | 后续 commit 按 task docs 和 work-log 分工更新 |
 | 任务规范 | 新任务使用 TDD 风格模板；已完成阶段保留在 `docs/tasks/completed/`，当前任务目录只保留可执行阶段入口 | 后续任务继续按 Red / Green / Refactor 推进 |
 | Codex 研究 | 已基于本地 Codex fork 与当前 Agent 源码重建 `docs/research/`：形成架构报告、学习清单、云端映射和 14 个分阶段学习目录 | 作为阶段 5 及后续任务的研究依据；真实执行状态仍以 `docs/tasks/` 为准 |
@@ -16,7 +16,8 @@
 
 | 日期 | 提交 | 类型 | 核心完成 | 关键文件 | 验证结果 |
 | --- | --- | --- | --- | --- | --- |
-| 2026-07-12 | 9825394 / Draft PR #2 | feat / Tool Calling | 完成 Issue #1 的最小 Tool Contract、Registry、参数验证、统一执行结果和 provider-neutral `ModelToolSpec` 映射；使用测试专用 `echo` 工具验证完整直接调用边界；实施状态已实现，验收状态待验收 | `apps/api/src/tools/**`、`apps/api/src/llm/model-tool-spec.types.ts`、`apps/api/src/app.module.ts`、`apps/api/package.json`、`docs/tasks/phase-05-tool-calling/README.md` | 11 个 tools 测试、12 个 model stream 回归、API typecheck/lint、workspace typecheck、`git diff --check` 通过；全仓 lint 仍被既有 research Markdown 的 97 个错误阻断 |
+| 2026-07-12 | PR #2 验收收口 | docs / Tool Calling | GPT 与用户确认 Issue #1 验收通过；Task 2 标记为 Completed，阶段 5 保持 In Progress，Task 3 保持 Planned；记录 Abort 前后检查、低风险 fail-closed 修复，以及 `timeoutMs` 仅保留 metadata、超时执行逻辑留待后续的范围裁定 | `docs/tasks/phase-05-tool-calling/README.md`、`docs/tasks/README.md`、`docs/roadmap.md`、`docs/work-log.md` | docs 结构与状态一致性检查、`git diff --check` 通过 |
+| 2026-07-12 | 9825394、a6bc873 / Draft PR #2 | feat / Tool Calling | 完成 Issue #1 的最小 Tool Contract、Registry、参数验证、统一执行结果和 provider-neutral `ModelToolSpec` 映射；Review 后补齐 Abort 前后检查与低风险 fail-closed；实施状态已实现，验收状态已通过 | `apps/api/src/tools/**`、`apps/api/src/llm/model-tool-spec.types.ts`、`apps/api/src/app.module.ts`、`apps/api/package.json`、`docs/tasks/phase-05-tool-calling/README.md` | 13 个 tools 测试、12 个 model stream 回归、API typecheck/lint、workspace typecheck、`git diff --check` 通过；全仓 lint 仍被既有 research Markdown 的 97 个错误阻断 |
 | 2026-07-11 | feat: 实现结构化模型流事件 | feat / Tool Calling | 完成阶段 5 Task 1：新增 provider-neutral `ModelStreamEvent`、OpenAI-compatible stream adapter 与 Tool Call 分片累积器；LLM stream 支持 text/tool/usage/completed，Runtime 对 Tool Call 临时 fail-fast，前端协议保持不变；补充 Node 原生最小回归测试 | `apps/api/src/llm/model-stream.types.ts`、`apps/api/src/llm/clients/openai-compatible-*.ts`、`apps/api/src/agent-runtime/agent-runtime.{errors,service}.ts`、对应测试文件、`apps/api/package.json` | 12 个模型流与 Runtime 测试通过；API lint、workspace typecheck、`git diff --check` 通过；全仓 lint 被既有 research Markdown 的 97 个错误阻断 |
 | 2026-07-11 | 3a77519 docs: refine phase 5 tool calling plan | docs / 技术决策 | 细化阶段 5 学习主线与任务顺序：先建立 provider-neutral `ModelStreamEvent`，再完成 Tool Contract、`search_articles`、单 Agent Tool Loop 和 `AgentStep` 记录；明确 sampling、Tool Call、Observation 与前端协议边界 | `docs/tasks/phase-05-tool-calling/README.md` | docs-only；未涉及代码验证 |
 | 2026-07-11 | feat: 准备 Tool Calling 文章数据 | feat / Tool Calling 前置 | 新增 `Article` 数据模型、migration 和幂等 Seed；导入 68 篇文章，优先使用 `zh-cn`，缺失时回退到 `en`，为后续只读文章列表 Tool 提供稳定数据源 | `prisma/schema.prisma`、`prisma/migrations/**`、`prisma/fixtures/articles.json`、`apps/api/scripts/seed.ts`、`docs/tasks/phase-05-tool-calling/README.md` | Prisma generate / validate / migrate deploy / db seed / migrate status 通过；数据库验证 68 篇；`pnpm typecheck`、本次文件定向 lint、`git diff --check` 通过；全仓 lint 被既有 research Markdown 的 97 个错误阻断 |

--- a/docs/work-log.md
+++ b/docs/work-log.md
@@ -6,7 +6,7 @@
 
 | 类型 | 当前记录 | 下一步 |
 | --- | --- | --- |
-| 当前阶段 | 阶段 4 Agent Runtime 基础已归档；阶段 5 进行中，Task 0-1 已完成 | 下一步执行阶段 5 Task 2，定义最小 Tool Contract、Registry、参数验证与执行边界 |
+| 当前阶段 | 阶段 4 Agent Runtime 基础已归档；阶段 5 进行中，Task 0-1 已完成，Task 2 已实现待验收 | 下一步验收 Task 2；Task 3 尚未开始 |
 | 文档结构 | docs 已重组为 `roadmap`、`tasks`、`research`、`work-log` 四类入口；当前任务以 `docs/tasks/README.md` 为准 | 后续 commit 按 task docs 和 work-log 分工更新 |
 | 任务规范 | 新任务使用 TDD 风格模板；已完成阶段保留在 `docs/tasks/completed/`，当前任务目录只保留可执行阶段入口 | 后续任务继续按 Red / Green / Refactor 推进 |
 | Codex 研究 | 已基于本地 Codex fork 与当前 Agent 源码重建 `docs/research/`：形成架构报告、学习清单、云端映射和 14 个分阶段学习目录 | 作为阶段 5 及后续任务的研究依据；真实执行状态仍以 `docs/tasks/` 为准 |
@@ -16,6 +16,7 @@
 
 | 日期 | 提交 | 类型 | 核心完成 | 关键文件 | 验证结果 |
 | --- | --- | --- | --- | --- | --- |
+| 2026-07-12 | 9825394 / Draft PR #2 | feat / Tool Calling | 完成 Issue #1 的最小 Tool Contract、Registry、参数验证、统一执行结果和 provider-neutral `ModelToolSpec` 映射；使用测试专用 `echo` 工具验证完整直接调用边界；实施状态已实现，验收状态待验收 | `apps/api/src/tools/**`、`apps/api/src/llm/model-tool-spec.types.ts`、`apps/api/src/app.module.ts`、`apps/api/package.json`、`docs/tasks/phase-05-tool-calling/README.md` | 11 个 tools 测试、12 个 model stream 回归、API typecheck/lint、workspace typecheck、`git diff --check` 通过；全仓 lint 仍被既有 research Markdown 的 97 个错误阻断 |
 | 2026-07-11 | feat: 实现结构化模型流事件 | feat / Tool Calling | 完成阶段 5 Task 1：新增 provider-neutral `ModelStreamEvent`、OpenAI-compatible stream adapter 与 Tool Call 分片累积器；LLM stream 支持 text/tool/usage/completed，Runtime 对 Tool Call 临时 fail-fast，前端协议保持不变；补充 Node 原生最小回归测试 | `apps/api/src/llm/model-stream.types.ts`、`apps/api/src/llm/clients/openai-compatible-*.ts`、`apps/api/src/agent-runtime/agent-runtime.{errors,service}.ts`、对应测试文件、`apps/api/package.json` | 12 个模型流与 Runtime 测试通过；API lint、workspace typecheck、`git diff --check` 通过；全仓 lint 被既有 research Markdown 的 97 个错误阻断 |
 | 2026-07-11 | 3a77519 docs: refine phase 5 tool calling plan | docs / 技术决策 | 细化阶段 5 学习主线与任务顺序：先建立 provider-neutral `ModelStreamEvent`，再完成 Tool Contract、`search_articles`、单 Agent Tool Loop 和 `AgentStep` 记录；明确 sampling、Tool Call、Observation 与前端协议边界 | `docs/tasks/phase-05-tool-calling/README.md` | docs-only；未涉及代码验证 |
 | 2026-07-11 | feat: 准备 Tool Calling 文章数据 | feat / Tool Calling 前置 | 新增 `Article` 数据模型、migration 和幂等 Seed；导入 68 篇文章，优先使用 `zh-cn`，缺失时回退到 `en`，为后续只读文章列表 Tool 提供稳定数据源 | `prisma/schema.prisma`、`prisma/migrations/**`、`prisma/fixtures/articles.json`、`apps/api/scripts/seed.ts`、`docs/tasks/phase-05-tool-calling/README.md` | Prisma generate / validate / migrate deploy / db seed / migrate status 通过；数据库验证 68 篇；`pnpm typecheck`、本次文件定向 lint、`git diff --check` 通过；全仓 lint 被既有 research Markdown 的 97 个错误阻断 |


### PR DESCRIPTION
Closes #1

## 改动摘要

- 新增一级 `tools` 模块，定义 Tool Contract、最小 JSON Schema、Registry、已验证调用、执行上下文和统一 ToolResult。
- 新增 `ToolInvocationService`，完成工具查找、JSON 解析、工具专属校验、Executor 执行及安全错误转换。
- 新增 provider-neutral `ModelToolSpec` 与纯映射。
- 使用测试专用 `echo` 工具覆盖 Registry、Invocation、Mapper 和 NestJS 模块边界。
- Review 修复：Abort 在调用入口和 Executor 返回后检查；当前阶段对需审批、非低风险、有副作用或联网工具 fail closed。

## 明确未做

- 未实现正式 `search_articles` 工具。
- 未接入 Agent Runtime Tool Loop、真实模型请求、Observation、AgentStep 或前端协议。
- 未新增 Schema 校验依赖、动态注册、超时、重试、并行、审批、权限、RAG 或 MCP。
- 未修改顶层任务看板；按 Issue #1 边界留到验收收口同步。

## 验证

通过：

- `pnpm --filter @agent/api test:tools`：13/13
- `pnpm --filter @agent/api test:model-stream`：12/12
- `pnpm --filter @agent/api typecheck`
- `pnpm --filter @agent/api lint`
- `pnpm typecheck`
- `git diff --check`

已知基线：

- `pnpm lint` 仍被 `docs/research/learning-roadmap/**` 中既有的 97 个 Markdown 代码块 lint 错误阻断；本次 API 定向 lint 通过，本次未新增该类错误。

## 建议阅读顺序

1. `apps/api/src/tools/tool.types.ts`
2. `apps/api/src/tools/tool-registry.service.ts`
3. `apps/api/src/tools/tool-invocation.service.ts`
4. `apps/api/src/llm/model-tool-spec.types.ts` 与 `apps/api/src/tools/model-tool-spec.mapper.ts`
5. `apps/api/src/tools/tools.test.ts`
6. `apps/api/src/tools/tools.module.ts` 与 `apps/api/src/app.module.ts`

## 真实调用链

`UnvalidatedToolCallEnvelope → Abort 检查 → ToolRegistryService.get() → 风险 gate → JSON.parse() → ToolInputContract.parse() → ValidatedToolInvocation → ToolExecutor.execute() → Abort 复查 → ToolResult`

当前状态：实施状态为已实现，验收状态为待验收；PR 保持 Draft。