### PR TITLE
docs: 整理 Codex 参考知识库

### DIFF
--- a/docs/research/README.md
+++ b/docs/research/README.md
@@ -1,98 +1,82 @@
 # Agent 架构研究与学习路线
 
-本目录是 AI SEO Agent 的长期架构研究区。它不直接充当当前任务看板，而是回答三个问题：
+本目录是 AI SEO Agent 的长期架构研究区。它不直接充当当前任务看板，而是服务于三个目标：
 
-1. OpenAI Codex 作为成熟 Agent 产品，哪些架构思想值得学习？
-2. 这些思想如何转换为当前 NestJS + Vue 云端 Agent 的实现边界？
-3. 从当前阶段 5 开始，应该按什么顺序学习、实现和验证？
+1. 把 Codex 源码中值得长期借鉴的 Agent Runtime 设计沉淀为可复用知识库。
+2. 把这些设计翻译成当前 NestJS + Vue 云端 Agent 项目的工程边界。
+3. 在后续讨论 `agent` 项目的具体任务时，让 GPT 能按问题快速定位对应的 Codex 参考，而不是每次重新从源码开始。
 
 ## 当前结论
 
-当前项目已经完成 Session Chat、消息持久化、NDJSON Streaming、停止生成、`AgentRun` / `AgentStep`、内部 `AgentRuntimeEvent` 和 `SeoContextBuilder`。下一步不是复制 Codex，而是沿着下面的主线继续演进：
+当前项目已经不是模型 API Demo。`master@5f2ad11f2c65425e84392e81048364d55ec626ef` 已经具备：
+
+- Session Chat、消息持久化、NDJSON Streaming 与停止生成。
+- `Conversation` / `Message` / `AgentRun` / `AgentStep` 的最小持久化边界。
+- 内部 `AgentRuntimeEvent` 与外部 `ChatStreamEvent` 的分层。
+- provider-neutral `ModelStreamEvent`，可以表达文本、tool call、usage 与 response terminal。
+- 最小 `ToolDefinition` / `ToolRegistry` / `ToolInvocation` / `ToolResult` 边界。
+- `test:model-stream` 与 `test:tools` 两组 Node 原生测试。
+
+因此当前最近主线不是“从零建立 Tool Contract”，而是：
 
 ```text
-测试基座与现有状态机基线
-  -> Provider-neutral 模型事件
-  -> 最小 Tool Contract
-  -> 模型 Tool Call 解析
-  -> Tool 执行与 Observation 回填
-  -> Human-in-the-loop
-  -> Context 预算与压缩
-  -> 可恢复执行与幂等
-  -> 可观测性、评测和测试
-  -> 云端权限、多租户和资源治理
-  -> 扩展协议
-  -> 最后才考虑 Multi-agent
+复盘已完成的模型事件与工具契约
+  -> 单 Agent Tool Loop：tool call -> execute -> observation -> second sampling -> final answer
+  -> Tool 可靠性：timeout / cancel / error / recording / terminal exactly-once
+  -> Context：model-visible history、observation 截断、token budget
+  -> Durable recovery：crash reconciliation、idempotency、operation receipt
+  -> Human-in-the-loop / 权限 / 多租户
+  -> 扩展协议和 Multi-agent 只在单 Agent 稳定后评估
 ```
 
 ## 证据基线
 
-| 对象 | 本次研究快照 | 用途 |
+| 对象 | 本次基线 | 用途 |
 | --- | --- | --- |
-| 当前项目 | `/Users/ayu/Desktop/agent`，`master@0a0b835` | 判断已经完成什么、真实缺口是什么 |
-| Codex fork | `/Users/ayu/Desktop/codex`，`main@626147f72` | 阅读生产级客户端 Agent 的真实源码 |
-| 官方文档 | [Codex App Server](https://developers.openai.com/codex/app-server)、[Codex SDK](https://developers.openai.com/codex/sdk) | 校准公开术语和协议语义 |
+| 当前项目 | `mufeiyu-ayu/agent`，`master@5f2ad11f2c65425e84392e81048364d55ec626ef` | 判断已经完成什么、真实缺口是什么 |
+| Codex 源码 | 用户上传 `codex-main-ab6a7eb87.zip` | 提取成熟 Agent 系统的可迁移设计 |
+| 本轮整理 | GPT 受托整理到 `docs/research/codex-reference/**` | 后续技术讨论的优先参考入口 |
 
-源码会继续演进。文档中的路径和行号只对上述本地快照负责；架构结论优先引用稳定职责，不把某个临时类型名当成永恒设计。
+源码会继续演进。本文档中的 Codex 路径对上述 zip 快照负责；后续升级 Codex 快照时，应优先校验稳定符号和调用链，而不是盲目复用旧行号。
 
-## 文档索引
+## 优先阅读入口
 
-### Codex 架构研究
+### 后续讨论 Agent 项目时优先使用
 
-| 文档 | 回答的问题 |
+| 入口 | 用途 |
 | --- | --- |
-| [codex/README.md](./codex/README.md) | 研究入口、推荐阅读顺序和总览 |
-| [codex/research-method.md](./codex/research-method.md) | 本次研究如何取证、如何区分事实与迁移建议 |
-| [codex/architecture-report.md](./codex/architecture-report.md) | Codex Agent 架构详细报告 |
-| [codex/architecture-learning-checklist.md](./codex/architecture-learning-checklist.md) | 值得学习的完整架构清单和检查项 |
-| [codex/source-reading-map.md](./codex/source-reading-map.md) | 按调用链阅读 Codex 源码的地图 |
-| [codex/current-project-gap-analysis.md](./codex/current-project-gap-analysis.md) | 当前项目能力、证据和缺口 |
-| [codex/cloud-agent-mapping.md](./codex/cloud-agent-mapping.md) | 客户端 Codex 思想如何翻译为云端 NestJS Agent |
-| [codex/terminology-map.md](./codex/terminology-map.md) | Codex、当前项目和中文助记名的概念对照 |
+| [codex-reference/README.md](./codex-reference/README.md) | 新 Codex 参考知识库总入口 |
+| [codex-reference/how-to-use.md](./codex-reference/how-to-use.md) | GPT / 用户后续如何按问题查资料 |
+| [codex-reference/current-agent-baseline.md](./codex-reference/current-agent-baseline.md) | 当前项目真实能力、缺口和近期路线 |
+| [codex-reference/discussion-playbook.md](./codex-reference/discussion-playbook.md) | 以后做方案讨论时的检索表和决策模板 |
 
-### 分阶段学习路线
+### Codex 架构核心专题
 
-| 文档 | 用途 |
+| 专题 | 适合什么时候看 |
 | --- | --- |
-| [learning-roadmap/README.md](./learning-roadmap/README.md) | 总路线、阶段依赖、学习顺序 |
-| [learning-roadmap/progress-tracker.md](./learning-roadmap/progress-tracker.md) | 跨阶段进度与验收证据登记 |
-| [learning-roadmap/learning-method.md](./learning-roadmap/learning-method.md) | 每个阶段统一采用的学习与 TDD 方法 |
-| [learning-roadmap/checklist-phase-matrix.md](./learning-roadmap/checklist-phase-matrix.md) | 架构清单条目由哪个阶段建立、强化和收口 |
+| [core-runtime.md](./codex-reference/core-runtime.md) | 讨论 Thread / Turn / Task / StepContext / Runtime loop |
+| [tool-loop.md](./codex-reference/tool-loop.md) | 讨论 Tool Calling、Observation 回填、第二轮 sampling |
+| [context-history.md](./codex-reference/context-history.md) | 讨论 model history、UI transcript、token budget、compaction |
+| [durability-recovery.md](./codex-reference/durability-recovery.md) | 讨论持久化、恢复、幂等、crash reconciliation |
+| [safety-permission.md](./codex-reference/safety-permission.md) | 讨论权限、审批、sandbox、恶意 observation |
+| [extensibility-and-multi-agent.md](./codex-reference/extensibility-and-multi-agent.md) | 讨论 MCP、Plugin、Skill、Hook、Multi-agent；当前只作为未来参考 |
 
-每个学习阶段都有独立目录，并固定包含：
+### 旧研究资料
 
-- `README.md`：阶段目标、边界、架构设计和任务拆解。
-- `source-reading.md`：Codex 与当前项目的源码阅读路径。
-- `practice-and-acceptance.md`：练习、测试矩阵、验收证据和复盘问题。
+旧的 [codex/](./codex/README.md) 与 [learning-roadmap/](./learning-roadmap/README.md) 仍保留历史价值，但如果它们与 `codex-reference/**` 或当前代码事实冲突，优先使用：
 
-## 推荐阅读路径
-
-### 第一次阅读
-
-1. [Codex 架构详细报告](./codex/architecture-report.md)
-2. [当前项目差距分析](./codex/current-project-gap-analysis.md)
-3. [云端架构映射](./codex/cloud-agent-mapping.md)
-4. [学习路线总览](./learning-roadmap/README.md)
-5. 当前阶段目录
-
-### 准备实现某一阶段
-
-1. 阅读阶段 `README.md`，先确认范围和不做什么。
-2. 按 `source-reading.md` 沿一条真实调用链阅读。
-3. 在 `practice-and-acceptance.md` 中先写 Red 验证，再做最小实现。
-4. 把实现任务落到 `docs/tasks/`，不要直接把研究文档当任务单。
-
-### 阶段收口
-
-1. 用真实测试和运行结果填写验收证据。
-2. 更新 [progress-tracker.md](./learning-roadmap/progress-tracker.md)。
-3. 再同步 `docs/tasks/README.md`、`docs/roadmap.md` 和必要的工作记录。
+```text
+当前代码事实
+  > codex-reference/**
+  > 旧 research 文档
+  > PR 或 Codex 自述
+```
 
 ## Research 与 Tasks 的边界
 
 | 目录 | 负责什么 | 不负责什么 |
 | --- | --- | --- |
-| `docs/research/` | 研究结论、架构地图、长期学习路线 | 宣称当前代码已经实现 |
+| `docs/research/` | 研究结论、源码地图、学习路线、设计参考 | 宣称当前代码已经实现 |
 | `docs/tasks/` | 当前可执行任务、TDD 步骤和验收状态 | 存放长篇外部项目研究 |
 | `docs/roadmap.md` | 项目阶段状态总览 | 展开每个架构主题的细节 |
 

--- a/docs/research/codex-reference/README.md
+++ b/docs/research/codex-reference/README.md
@@ -1,0 +1,67 @@
+# Codex Reference Knowledge Base
+
+本目录是 GPT 受托整理的 Codex 源码参考库，基于用户上传的 `codex-main-ab6a7eb87.zip`。它不是 Codex 源码百科，也不是当前项目任务看板，而是后续设计 `mufeiyu-ayu/agent` 时可查的架构案例库。
+
+## 使用定位
+
+这套文档解决一个问题：以后我们讨论 Agent 项目时，如何快速借鉴 Codex 的成熟设计，而不是每次重新阅读 6000+ 个源码文件。
+
+它遵守三条边界：
+
+1. **Codex 源码事实**：只写 zip 快照中能定位到的路径、符号和调用链。
+2. **架构解释**：提炼控制权、状态所有权、失败收口和工程取舍。
+3. **迁移建议**：翻译成当前 NestJS + Vue 云端 Agent 项目的最小可落地方案。
+
+不要把“Codex 这样做”直接等同于“当前项目现在就要做”。Codex 是本地/客户端优先的成熟 Agent 产品，当前项目是云端 AI SEO Agent，需要选择性迁移。
+
+## 阅读顺序
+
+### 第一遍，只看四个文件
+
+1. [how-to-use.md](./how-to-use.md)：以后如何让 GPT 查这套资料。
+2. [current-agent-baseline.md](./current-agent-baseline.md)：当前项目已经有什么、下一步缺什么。
+3. [core-runtime.md](./core-runtime.md)：Codex 的 Thread / Turn / Task / sampling loop。
+4. [tool-loop.md](./tool-loop.md)：当前最需要迁移的 Tool loop 不变量。
+
+### 实现前按问题查
+
+| 你要讨论的问题 | 先看 |
+| --- | --- |
+| 单 Agent Tool Loop | [tool-loop.md](./tool-loop.md) |
+| 工具结果是否应该进入 Message 表 | [tool-loop.md](./tool-loop.md)、[context-history.md](./context-history.md) |
+| 工具失败是否终止 Run | [tool-loop.md](./tool-loop.md) |
+| Context 爆掉怎么办 | [context-history.md](./context-history.md) |
+| 如何做可恢复执行 | [durability-recovery.md](./durability-recovery.md) |
+| 写操作工具如何保护 | [safety-permission.md](./safety-permission.md) |
+| 什么时候做 MCP / Multi-agent | [extensibility-and-multi-agent.md](./extensibility-and-multi-agent.md) |
+| 如何把讨论变成正式任务 | [discussion-playbook.md](./discussion-playbook.md) |
+
+## 文档索引
+
+| 文件 | 核心用途 |
+| --- | --- |
+| [how-to-use.md](./how-to-use.md) | 后续 GPT / 用户如何使用本知识库 |
+| [source-snapshot.md](./source-snapshot.md) | 源码快照、取证方法和路径地图 |
+| [current-agent-baseline.md](./current-agent-baseline.md) | 当前项目真实能力、缺口和近期路线 |
+| [core-runtime.md](./core-runtime.md) | 产品入口、协议、Thread、Turn、Task、runtime loop |
+| [tool-loop.md](./tool-loop.md) | ToolRouter、ToolRegistry、ToolCallRuntime、Observation、follow-up sampling |
+| [context-history.md](./context-history.md) | model-visible history、UI transcript、normalization、compaction |
+| [durability-recovery.md](./durability-recovery.md) | rollout、ThreadStore、flush、resume、fork、crash window |
+| [safety-permission.md](./safety-permission.md) | permission、approval、sandbox、恶意 observation |
+| [extensibility-and-multi-agent.md](./extensibility-and-multi-agent.md) | MCP、Plugin、Skill、Hook、Goal、Memory、Multi-agent 的迁移边界 |
+| [discussion-playbook.md](./discussion-playbook.md) | 以后做方案讨论时的查阅和决策模板 |
+
+## 对当前阶段的结论
+
+当前最重要的任务不是 MCP、RAG 或 Multi-agent，而是把已有的模型事件边界和工具契约连接成真正的 Agent loop：
+
+```text
+第一轮 sampling 产生 tool call
+  -> server 验证 tool name / schema / policy
+  -> executor 执行只读工具
+  -> tool result 作为 observation 回填 model-visible history
+  -> 第二轮 sampling 生成最终回答
+  -> UI Message 只保存最终用户可见内容
+```
+
+这条链路跑通后，才值得进入 Tool 可靠性、Context、Recovery、HITL 和多租户。

--- a/docs/research/codex-reference/context-history.md
+++ b/docs/research/codex-reference/context-history.md
@@ -1,0 +1,155 @@
+# Context 与 History：model-visible history 不等于 UI transcript
+
+## 1. 核心结论
+
+Codex 的 Context 设计最值得当前项目学习的一点是：
+
+```text
+model-visible history
+UI transcript
+runtime events
+durable rollout facts
+analytics / telemetry
+```
+
+这些不是同一种数据。把它们混成一个 `messages[]`，在纯聊天阶段可以工作；进入 Tool Calling 后会迅速失控。
+
+## 2. Codex 源码事实
+
+关键路径：
+
+- `codex-rs/core/src/context_manager/history.rs`
+- `codex-rs/core/src/context_manager/normalize.rs`
+- `codex-rs/core/src/context_manager/updates.rs`
+- `codex-rs/core/src/session/turn.rs`
+- `codex-rs/core/tests/suite/token_budget.rs`
+
+`ContextManager` 内部持有：
+
+- `items: Vec<ResponseItem>`：模型历史。
+- `history_version`：历史被 compaction / rollback 重写时递增。
+- `token_info`：上下文窗口使用信息。
+- `reference_context_item`：用于 diff 的上下文基线。
+- `world_state_baseline`：世界状态基线。
+
+`for_prompt()` 会在发送模型前 normalization，删除不适合模型输入的项、修复 call/output 对、按模型能力处理图片等。
+
+## 3. 高价值不变量
+
+### 3.1 Conversation Message 不是 Model History
+
+当前项目的 `Message` 是 UI transcript：用户和 assistant 最终可见消息。
+
+Tool loop 需要的 model history 还包括：
+
+- assistant tool call。
+- tool result。
+- 中间 assistant text。
+- context fragments。
+- prompt/system/developer instructions。
+- future summary / compaction。
+
+这些不应该全部塞进 `Message.content`。
+
+### 3.2 call/output pairing 是上下文不变量
+
+Codex 在 normalization 中会处理：
+
+- missing function output。
+- orphan output。
+- 不支持 image input 时替换图片内容。
+- tool output truncation。
+
+当前项目最小迁移：
+
+- 每个 tool call 必须有同 callId tool result。
+- invalid / unknown tool 也应该生成失败 observation，避免 call 无 output。
+- 如果 Run abort，已经完成的 call/output 尽量保持配对；无法完成时要有明确 aborted observation 或 durable error。
+
+### 3.3 Tool output 是 untrusted data
+
+Tool output 可能来自网页、文件、API、RAG 检索或用户输入。它不能被拼进 system prompt，也不能改变权限策略。
+
+当前项目在第二轮 sampling 中应把 observation 映射为 tool role / tool result，而不是 user message 或 system message。
+
+### 3.4 Context budget 要先从 observation 开始
+
+进入 Tool loop 后，最先爆掉上下文的通常不是聊天历史，而是工具输出。
+
+当前项目最小策略：
+
+```ts
+type ObservationBudget = {
+  maxBytes: number
+  maxApproxTokens: number
+  truncateMarker: string
+}
+```
+
+每个 `ToolResult.modelContent` 进入 model history 前要经过：
+
+1. 大小限制。
+2. 敏感信息策略。
+3. 来源标记。
+4. 截断说明。
+
+完整 compaction 可以后置。
+
+## 4. 当前项目迁移路线
+
+### Phase 03：内存 model history
+
+目标：跑通单次 tool loop。
+
+- 从当前 `SeoContextBuilder` 输出初始 messages。
+- 转为内部 `ModelInputItem[]`。
+- sampling #1 后追加 `assistant_tool_call`。
+- tool 执行后追加 `tool_result`。
+- sampling #2 产生 final answer。
+- 本阶段不持久化完整 model history。
+
+### Phase 04：Tool step recording
+
+目标：记录可审计事实。
+
+- AgentStep 或新表记录 tool call / result。
+- 记录 raw arguments、validated input 摘要、tool version、status、error code。
+- 不记录敏感完整 payload，或者做字段级脱敏。
+
+### Phase 06：Context budget
+
+目标：避免 history 和 observation 失控。
+
+- 对 message history、tool result、context fragment 分来源设预算。
+- 固定优先级：system/developer > current user input > recent tool output > recent messages > older summary。
+- 引入 summary / compaction 前先把截断策略测试清楚。
+
+## 5. 前端类比
+
+你可以把 model history 和 UI transcript 的关系类比成：
+
+```text
+Pinia internal state / cache / request metadata
+  != 页面上渲染的 message list
+```
+
+前端组件只展示最终用户可见状态，但内部 store 可能还保存 loading、request id、rollback snapshot、optimistic mutation、error receipt。Agent 的 model history 也是这样：它服务于下一次模型请求，不等于用户要看到的聊天记录。
+
+## 6. 必测用例
+
+| 场景 | 关键断言 |
+| --- | --- |
+| tool result 不进入 UI Message | 数据库 assistant Message 只有最终回答 |
+| tool result 进入第二轮 model input | captured request 中存在 tool role / tool_result |
+| mixed text + call | 中间文本进入 assistant_tool_call.content，不展示给 UI |
+| malicious observation | 仍是 tool role，不能覆盖 system/developer |
+| oversized observation | 被截断并保留来源/截断说明 |
+| missing output | 产生失败/aborted observation 或明确 FAILED |
+
+## 7. 暂时不做
+
+- 不立刻实现完整 Codex ContextManager。
+- 不做复杂 memory pipeline。
+- 不做自动长期摘要。
+- 不把每个 token delta 写数据库。
+- 不做全量 replay history projection。

--- a/docs/research/codex-reference/core-runtime.md
+++ b/docs/research/codex-reference/core-runtime.md
@@ -1,0 +1,164 @@
+# Core Runtime：从产品入口到 run_turn
+
+## 1. Codex 解决的问题
+
+Codex 不是“Controller 直接调一次模型”的结构。它把一次用户请求拆成多个稳定层：
+
+```text
+Product entry
+  -> protocol facade
+  -> ThreadManager
+  -> CodexThread / Session
+  -> submission queue
+  -> Task / RegularTask
+  -> run_turn
+  -> sampling loop
+  -> events + durable facts
+```
+
+这种分层的价值是：多个产品入口可以共享同一个 runtime，用户请求可以排队、取消、恢复、fork，工具和 context 可以在 Turn 内演进，而外部协议仍保持稳定。
+
+## 2. 源码事实
+
+### 2.1 产品入口不是 Runtime
+
+主要路径：
+
+- `codex-rs/cli/src/main.rs`
+- `codex-rs/app-server/src/message_processor.rs`
+- `codex-rs/app-server-protocol/src/protocol/common.rs`
+- `codex-rs/app-server/src/request_processors/**`
+- `codex-rs/core/src/thread_manager.rs`
+
+App Server 协议定义了 `thread/start`、`thread/resume`、`thread/fork`、`turn/start`、`turn/steer`、`turn/interrupt` 等方法。协议层负责校验、转换和回执，不直接承担 Agent loop。
+
+### 2.2 Thread 是长期工作线
+
+`ThreadManager` 负责创建、恢复、fork 和管理内存中的 threads。源码中 `ThreadManager` 持有：
+
+- loaded `CodexThread` map。
+- `ThreadStore`。
+- model manager。
+- environment manager。
+- skills / plugins / MCP manager。
+- extension registry。
+
+这说明 Thread 不只是聊天记录 ID，而是运行环境、持久化、扩展、权限和上下文的聚合边界。
+
+当前项目映射：
+
+| Codex | 当前项目 | 迁移判断 |
+| --- | --- | --- |
+| Thread | `Conversation` | 已有最小会话身份，但缺 owner、archive、active run 投影 |
+| ThreadManager | 暂无同等对象 | 未来可由 application service + repository + runner 组合承担 |
+| ThreadStore | PostgreSQL + Prisma | 当前还没有完整 replay / resume 语义 |
+
+### 2.3 Turn 是一次工作边界
+
+`Op::UserInput` 不是直接模型请求，而是提交给 Session 的 submission queue。`turn/start` 请求会变成内部 `Op::UserInput`，再由 `submission_loop` 消费并创建 `RegularTask`。
+
+核心路径：
+
+```text
+turn/start
+  -> TurnRequestProcessor
+  -> Op::UserInput
+  -> CodexThread.submit
+  -> Session submission channel
+  -> submission_loop
+  -> RegularTask::run
+  -> run_turn
+```
+
+对当前项目的启发：
+
+- HTTP request accepted 不等于 AgentRun 已经 started。
+- streaming endpoint 可以先保持同步执行，但一旦引入 queue / worker / reconnect，就要显式区分 accepted、running、terminal。
+- 同一 Conversation 是否允许并发 Run，必须成为明确策略，不能靠偶然实现。
+
+### 2.4 StepContext 是单次 sampling 的能力快照
+
+`StepContext` 包含：
+
+- `TurnContext`。
+- environment snapshot。
+- selected capability roots。
+- MCP runtime snapshot。
+- 当前 sampling 的 MCP tool list。
+- 当前环境下的 AGENTS.md。
+
+关键不变量：
+
+```text
+model saw tool spec / environment / capability generation G
+  => returned call must execute against generation G
+```
+
+不能在模型输出回来后用“当前最新工具表”重新解释它。否则工具 schema、权限或环境变化会导致模型看到的 contract 与实际执行 contract 分裂。
+
+当前项目最小迁移：
+
+- Phase 03 可以不立刻实现完整 `StepContext` 类。
+- 但每轮 sampling 应构造一个不可变 `samplingContext`，至少包含：model id、tool definitions、tool registry generation、conversationId、runId、signal。
+- 第二轮 sampling 必须显式携带前一轮 call/output，而不是重新从 UI messages 拼接。
+
+## 3. run_turn 的核心不变量
+
+`run_turn` 的主循环不是一次模型调用。它会：
+
+1. 运行 pre-sampling compaction。
+2. 捕获第一轮 StepContext。
+3. 记录 context updates 和 user input。
+4. 构造 model-visible input。
+5. 调用 `run_sampling_request`。
+6. 处理 response events。
+7. 如果有 tool call 或 pending input，则继续下一轮。
+8. 如果没有 follow-up，运行 stop hooks 并完成 Turn。
+
+关键点：
+
+- `ModelClientSession` 是 Turn-scoped，可在 Turn 内复用 transport / sticky routing，不跨 Turn 泄漏。
+- `needs_follow_up` 是 Agent loop 的核心控制信号。
+- `response_completed(tool_calls)` 只说明本轮 sampling 结束，不说明整个 Turn 完成。
+- pending user input、tool output、auto compaction 都可能触发下一轮。
+
+当前项目最近应迁移的不是完整 submission queue，而是这个最小循环：
+
+```ts
+while (true) {
+  const decision = await sampleOnce(modelHistory, samplingContext)
+
+  if (decision.type === 'final_answer') return final
+
+  const result = await invokeTool(decision.call)
+  modelHistory = appendToolObservation(modelHistory, decision.call, result)
+}
+```
+
+## 4. 当前项目迁移建议
+
+### 近期要做
+
+- 抽出 `sampleOnce` 概念，即使代码仍在 `AgentRuntimeService` 内。
+- 引入 model-visible history union，支持 assistant tool call 和 tool result。
+- 为每轮 sampling 生成 server-owned `samplingAttemptId`。
+- 给 loop 设置硬上限：`maxSamplingRounds`、`maxToolCalls`。
+- 保持外部 `ChatStreamEvent` 类型不变，先只输出 final answer。
+
+### 暂时不用做
+
+- 不做完整 `ThreadManager`。
+- 不做跨进程 submission queue。
+- 不做 resume / fork。
+- 不做多客户端 listener。
+- 不做 StepContext 的全部 environment / MCP / AGENTS.md 能力。
+
+## 5. 验收问题
+
+不看文档时应能回答：
+
+1. 为什么 `turn/start` 不应该直接等于模型请求？
+2. Thread、Turn、Task、StepContext 分别解决什么问题？
+3. 为什么一次 AgentRun 可以包含多次 sampling？
+4. 为什么 model saw 的 tool specs 必须和实际执行 registry 同代？
+5. 当前项目 Phase 03 为什么不需要先实现完整 queue？

--- a/docs/research/codex-reference/current-agent-baseline.md
+++ b/docs/research/codex-reference/current-agent-baseline.md
@@ -1,0 +1,166 @@
+# 当前 Agent 项目基线与最近路线
+
+## 1. 结论
+
+以 `master@5f2ad11f2c65425e84392e81048364d55ec626ef` 为基线，当前项目已经从“文本流式 Chat Runtime”推进到“具备模型事件边界和最小工具契约的 Agent Runtime 前夜”。
+
+更准确地说：
+
+```text
+已完成：模型事件边界 + 工具定义/注册/验证/直接执行
+未完成：模型驱动 tool call 后，把 observation 回填到第二轮 sampling
+```
+
+所以近期不应继续创建“从零定义 ModelStreamEvent”或“从零建立 ToolRegistry”的任务；应该复盘已完成边界，然后进入 **单 Agent Tool Loop**。
+
+## 2. 已具备能力
+
+### 2.1 会话、消息、流式输出
+
+已具备：
+
+- `Conversation` 长期会话。
+- `Message` 用户可见消息。
+- USER / ASSISTANT role。
+- PENDING / STREAMING / COMPLETED / FAILED / ABORTED 状态。
+- PostgreSQL 持久化。
+- NDJSON streaming 与 stop generation。
+
+仍缺：
+
+- 用户 / 租户所有权。
+- archive / share / permission 等资源语义。
+- active run 并发准入规则。
+- 多实例 cancellation 路由。
+
+### 2.2 AgentRun / AgentStep
+
+已具备：
+
+- streaming 用户输入创建 `AgentRun`。
+- 粗粒度 `AgentStep`：接收消息、加载历史、调用模型、流式回复。
+- terminal status、startedAt / endedAt、input/output JSON snapshot。
+
+仍缺：
+
+- sampling attempt 与 tool execution attempt 区分。
+- Tool call / observation / approval 的细粒度 durable record。
+- stale RUNNING recovery。
+- trace id / request id / usage metadata。
+
+### 2.3 模型事件边界
+
+已具备：
+
+- provider-neutral `ModelStreamEvent`。
+- `text_delta`、`tool_call_completed`、`usage`、`response_completed` 四类事件。
+- `ModelFinishReason`：`stop`、`tool_calls`、`length`、`content_filter`、`unknown`。
+- Tool loop 未实现时对 `tool_call_completed` fail-fast，而不是静默忽略。
+
+这意味着旧文档里“provider-neutral model event 尚无”的判断已经过期。
+
+### 2.4 Tool Contract / Registry / Invocation
+
+已具备：
+
+- `ToolDefinition`、`RegisteredTool`、`ToolExecutor`、`ToolResult` 等最小工具类型。
+- `ToolRegistryService`：工具注册、查找、重复名称拒绝、稳定排序输出 definitions。
+- `ToolInvocationService`：unknown tool、JSON parse、schema parse、risk gate、validated invocation、executor 调用。
+- 低风险 / 无副作用 / 不联网 / 无审批工具才允许执行，其他 fail closed。
+- `ModelToolSpec` mapper：只暴露模型可见字段。
+
+这意味着旧文档里“Tool contract 无”的判断已经过期。
+
+### 2.5 测试
+
+已具备：
+
+- `test:model-stream`。
+- `test:tools`。
+- model stream runtime 行为测试。
+- tools registry / invocation / invalid args / risk / abort 测试。
+
+仍缺：
+
+- 外部 NDJSON parser contract 测试。
+- Tool loop 的两轮 sampling 集成测试。
+- recorder transaction / AgentStep 状态测试。
+- sync endpoint 与 stream endpoint 共用 runner 的测试。
+
+## 3. 当前真实缺口
+
+| 能力 | 当前成熟度 | 目标成熟度 | 优先级 | 下一步 |
+| --- | --- | --- | --- | --- |
+| Model event | 已有基础 | provider profile + request mapper 完整 | P1 | 随 Tool loop 补 request tools / `parallel_tool_calls=false` |
+| Tool contract | 已有基础 | 可接入 Agent loop | P0 | router / executor 与 runtime loop 连接 |
+| Tool loop | 未形成闭环 | call -> observation -> second sampling -> final | P0 | Phase 03 |
+| Model history | 纯消息为主 | message + assistant_tool_call + tool_result | P0 | 定义内部 `ModelInputItem` |
+| UI transcript | 可用 | 与 model history 明确分层 | P0 | final answer 才进 UI Message |
+| Run/Step recording | 粗粒度 | sampling/tool/observation 可审计 | P1 | Phase 04 |
+| Context budget | 固定条数 | token/priority/truncation | P1 | 先做 observation byte/token 限制 |
+| Permission/HITL | risk metadata fail closed | 可持久审批和 policy | P1 | 写工具前做 |
+| Recovery | 基础持久化 | crash reconciliation | P2 | 长任务/多实例前做 |
+| MCP/Multi-agent | 无 | 可选扩展 | P3 | 单 Agent 稳定后再评估 |
+
+## 4. 最近三个里程碑
+
+### 里程碑 A：单 Agent Tool Loop
+
+目标：让模型能真正驱动一个只读工具，并用工具结果生成最终回答。
+
+最小闭环：
+
+```text
+sampling #1 -> tool_call_completed
+  -> ToolInvocationService 验证并执行
+  -> append tool_result observation to model history
+sampling #2 -> final text
+  -> stream / persist final assistant Message
+```
+
+验收重点：
+
+- 捕获至少两次 model sampling。
+- 第二轮输入包含同 callId 的 tool result。
+- tool JSON 不进入 UI assistant Message。
+- unknown / invalid / throw 形成结构化 observation 或明确失败。
+- abort 只能进入 ABORTED，不能被迟到完成覆盖。
+
+### 里程碑 B：Tool 可靠性与记录
+
+目标：把 tool call 从“运行时临时动作”变成可审计执行事实。
+
+最小能力：
+
+- Tool call record / observation record。
+- timeout / cancel / execution error taxonomy。
+- output truncation。
+- AgentStep terminal exactly-once。
+- sensitive data 与大 output 策略。
+
+### 里程碑 C：Context 与恢复基础
+
+目标：避免 tool output 让 context 失控，并为长任务恢复做准备。
+
+最小能力：
+
+- model-visible history 与 UI transcript 分离。
+- observation byte/token budget。
+- context source / priority。
+- stale RUNNING sweep。
+- request id / trace id / operation identity。
+
+## 5. 现在不要做什么
+
+现在可以先不用做：
+
+- MCP server 动态接入。
+- Plugin marketplace。
+- Multi-agent child thread。
+- Goal runtime。
+- Memory pipeline。
+- OS sandbox。
+- 通用 workflow engine。
+- 完整 RAG 平台。
+
+这些能力可以在 `codex-reference` 中保留为资料，但不应进入近期实现。

--- a/docs/research/codex-reference/discussion-playbook.md
+++ b/docs/research/codex-reference/discussion-playbook.md
@@ -1,0 +1,135 @@
+# Discussion Playbook：后续方案讨论如何借鉴 Codex
+
+## 1. 默认决策流程
+
+以后讨论 `agent` 项目任何 Agent Runtime 相关设计时，按这个流程：
+
+```text
+1. 先确认当前项目事实
+2. 定位 codex-reference 对应专题
+3. 提取 Codex 不变量
+4. 删掉当前不需要的成熟复杂度
+5. 给出 NestJS / Vue 最小方案
+6. 写出测试和验收标准
+7. 如需实现，再进入 Issue / PR 流程
+```
+
+## 2. 按问题查资料
+
+| 问题 | 查阅文件 | 应重点提取 |
+| --- | --- | --- |
+| 怎么做单 Agent Tool Loop | `tool-loop.md`、`core-runtime.md` | needs_follow_up、call/output pairing、第二轮 sampling |
+| 工具结果要不要展示给用户 | `context-history.md`、`tool-loop.md` | UI transcript 与 model history 分离 |
+| 工具失败怎么办 | `tool-loop.md`、`durability-recovery.md` | observation failure vs runtime fatal |
+| 如何避免无限工具调用 | `core-runtime.md`、`tool-loop.md` | loop bounds、samplingAttemptId、toolCallCount |
+| 中断怎么处理 | `tool-loop.md`、`durability-recovery.md` | terminal exactly-once、late settlement |
+| Context 太长怎么办 | `context-history.md` | observation budget、source priority、compaction 后置 |
+| 写工具怎么保证安全 | `safety-permission.md`、`durability-recovery.md` | permission、approval、operation identity |
+| 多实例/重启怎么恢复 | `durability-recovery.md` | durable facts、stale RUNNING、receipt |
+| 是否要做 MCP | `extensibility-and-multi-agent.md` | 内置工具稳定前不做 |
+| 是否要做 Multi-agent | `extensibility-and-multi-agent.md` | child Thread 成本和边界 |
+
+## 3. 方案讨论输出模板
+
+```md
+## 推荐方案
+
+用一句话说明当前最小方案。
+
+## 当前项目事实
+
+列出现有代码、测试和缺口。
+
+## Codex 参考
+
+列出对应源码设计和不变量，不要逐文件摘要。
+
+## 迁移判断
+
+- 直接迁移什么。
+- 简化迁移什么。
+- 暂时不迁移什么。
+
+## 前端需要做什么
+
+Vue / Nuxt / Chat UI / streaming / timeline / approval UI。
+
+## 后端需要做什么
+
+NestJS service、types、Prisma、测试、错误收口。
+
+## LLM / Agent 需要做什么
+
+prompt、model event、tool call、observation、context。
+
+## 测试和验收
+
+列 Red-Green-Refactor 和必要测试。
+```
+
+## 4. 当前阶段优先级
+
+### P0：近期必须完成
+
+- 单 Agent Tool Loop。
+- ModelInputItem / provider request mapper。
+- observation 回填。
+- 第二轮 sampling 测试。
+- tool call 不污染 UI Message。
+- abort / invalid / unknown / loop limit 测试。
+
+### P1：近中期
+
+- Tool execution record。
+- timeout / cancel / error taxonomy。
+- observation truncation。
+- context budget interface。
+- sync endpoint 与 stream endpoint 统一 runner。
+- Run/Step timeline 查询。
+
+### P2：中后期
+
+- HITL approval。
+- user / tenant ownership。
+- idempotency / operation receipt。
+- stale RUNNING recovery。
+- eval / observability。
+
+### P3：只作为参考
+
+- MCP。
+- Plugin / Skill。
+- Goal。
+- Memory。
+- Multi-agent。
+- Remote exec。
+
+## 5. 任务转化规则
+
+一个 Codex 设计只有满足以下条件，才应进入正式 Issue：
+
+1. 当前项目存在同类真实约束。
+2. 可以切成一个明确 task。
+3. 有最小测试能证明不变量。
+4. 不依赖尚未完成的前置能力。
+5. 不会顺手推进多个阶段。
+
+例子：
+
+```text
+Codex ToolCallRuntime 很复杂
+  -> 当前只迁移 terminal exactly-once 的思想
+  -> 任务切成“abort tool 后不启动下一轮 sampling”
+  -> 不实现并行工具和 hook
+```
+
+## 6. 给 GPT 的自检清单
+
+每次引用本知识库时，GPT 应自检：
+
+- 有没有把 Codex 源码事实和迁移建议混写？
+- 有没有把旧 research 的过期当前项目状态当真？
+- 有没有建议当前阶段不该做的高级能力？
+- 有没有说明哪些东西现在可以先不用学？
+- 有没有给出 TypeScript / NestJS 可落地边界？
+- 有没有给出测试标准？

--- a/docs/research/codex-reference/durability-recovery.md
+++ b/docs/research/codex-reference/durability-recovery.md
@@ -1,0 +1,180 @@
+# Durability 与 Recovery：持久事实、恢复和幂等边界
+
+## 1. 核心结论
+
+Codex 的持久化设计不是“把每个流式 delta 存下来”，而是围绕可恢复、可审计的关键事实组织：
+
+```text
+Thread identity
+Turn lifecycle
+Response items
+Tool call/output pairing
+Context / world-state updates
+Metadata projection
+Flush / shutdown / resume / fork
+```
+
+当前项目已经有 PostgreSQL `Message` / `AgentRun` / `AgentStep` 基础，但还没有真正的 replay、resume、crash reconciliation 和 operation receipt。
+
+## 2. Codex 源码事实
+
+关键路径：
+
+- `codex-rs/thread-store/src/store.rs`
+- `codex-rs/thread-store/src/types.rs`
+- `codex-rs/thread-store/src/live_thread.rs`
+- `codex-rs/core/src/session/mod.rs`
+- `codex-rs/core/src/session/rollout_reconstruction*`
+- `codex-rs/core/src/stream_events_utils.rs`
+
+`ThreadStore` 是 storage-neutral persistence boundary，包含：
+
+- `create_thread`
+- `resume_thread`
+- `append_items`
+- `persist_thread`
+- `flush_thread`
+- `shutdown_thread`
+- `discard_thread`
+- `load_history`
+- `read_thread`
+- `list_threads`
+- `list_turns`
+- `list_items`
+- `archive_thread`
+- `delete_thread`
+
+这说明 Codex 把 live runtime 与 durable store 分开。存储可以是 local rollout，也可以通过接口换成其他实现。
+
+## 3. 可迁移设计
+
+### 3.1 持久化服务于恢复和审计，不服务于复制传输过程
+
+流式 delta 是传输事件，不是主要持久事实。当前项目应优先持久化：
+
+- Run started / terminal。
+- user input。
+- final assistant answer。
+- tool requested call。
+- tool produced output / error / abort。
+- approval requested / decided。
+- operation receipt。
+
+不要为了“看起来完整”把每个 token delta 入库。
+
+### 3.2 call 和 output 是两个事实
+
+crash window 必须显式承认：
+
+```text
+call persisted
+  -> process crashes before tool execution
+  -> 可以恢复为未执行或失败 observation
+
+external side effect committed
+  -> process crashes before output persisted
+  -> ambiguous commit，需要 operation receipt / reconciliation
+```
+
+只读工具可以简单处理；写工具必须有 operation identity 和幂等策略。
+
+### 3.3 flush 是边界，不是装饰
+
+Codex 区分 append、persist、flush、shutdown、discard。当前项目的数据库事务也要明确：
+
+- 哪些状态必须和 Message 一起提交。
+- 哪些 Step 可以稍后补充。
+- 连接断开时 Run 应该 ABORTED、FAILED，还是继续后台执行。
+- 服务重启后如何处理 RUNNING。
+
+### 3.4 resume / fork 是高阶能力，近期只学思想
+
+当前项目暂时不需要完整 Thread fork，但需要理解其核心思想：
+
+- resume：从 durable history 恢复同一工作线。
+- fork：复制历史前缀，形成新工作线。
+- rollback：回到某个历史点，不能让副作用假装回滚。
+
+对 AI SEO Agent，近期只需要：
+
+- stale RUNNING sweep。
+- Run terminal reconciliation。
+- tool execution id / receipt。
+- idempotency key。
+
+## 4. 当前项目近期最小方案
+
+### Phase 04：Tool durable facts
+
+建议新增或扩展记录：
+
+```ts
+type ToolExecutionRecord = {
+  executionId: string
+  runId: string
+  stepId?: string
+  callId: string
+  samplingAttemptId: string
+  toolName: string
+  toolVersion: string
+  status: 'pending' | 'running' | 'succeeded' | 'failed' | 'aborted'
+  inputSummary?: unknown
+  outputSummary?: unknown
+  errorCode?: string
+  startedAt?: Date
+  endedAt?: Date
+}
+```
+
+先不必单独建表；可以先映射到 AgentStep 的 input/output JSON。但类型语义要清楚。
+
+### Phase 07：Recovery policy
+
+最小策略：
+
+- 服务启动时扫描 오래 RUNNING 的 AgentRun。
+- 没有后台 worker 的 Run 标为 FAILED 或 ABORTED，并记录 recovery reason。
+- 如果 tool execution 有 committed receipt，则不能盲重试。
+- 如果只有 call 无 output，生成失败/aborted observation 或要求用户重新运行。
+
+### 写工具前：Operation identity
+
+任何外部副作用工具都需要：
+
+```ts
+operationId
+idempotencyKey
+owner scope
+payloadHash
+attempt
+receipt
+status
+```
+
+否则 crash 后无法区分：
+
+- 没执行。
+- 执行了但 response 丢了。
+- 执行失败。
+- 重试会重复副作用。
+
+## 5. 必测用例
+
+| 场景 | 关键断言 |
+| --- | --- |
+| Run started 后 provider 抛错 | Run / Message / Step 全部 terminal FAILED |
+| Abort 后 provider late final | 不能覆盖 ABORTED |
+| tool call 后 executor 抛错 | 有失败 observation 或失败 record |
+| tool 执行中 abort | terminal exactly once |
+| stale RUNNING | sweeper 收口且记录 reason |
+| same idempotency key same payload | 返回原 receipt |
+| same idempotency key different payload | conflict，不执行 |
+| external committed then timeout | 进入 Unknown / reconcile，不生成新 key 盲重试 |
+
+## 6. 暂时不做
+
+- 不做完整 rollout JSONL。
+- 不做 Thread fork。
+- 不做多 DB state runtime。
+- 不做后台 worker lease，除非引入真正异步长任务。
+- 不做通用 Saga 框架。

--- a/docs/research/codex-reference/extensibility-and-multi-agent.md
+++ b/docs/research/codex-reference/extensibility-and-multi-agent.md
@@ -1,0 +1,127 @@
+# Extensibility 与 Multi-agent：保留资料，不抢当前主线
+
+## 1. 核心结论
+
+Codex 有大量扩展能力：MCP、Skill、Plugin、Hook、App、Environment、Goal、Memory、Multi-agent、Code Mode、Exec Server 等。它们很有研究价值，但当前 AI SEO Agent 不应过早照搬。
+
+当前判断：
+
+```text
+内置工具 + 单 Agent Tool Loop 未稳定前
+  -> 不做 MCP / Plugin / Multi-agent
+```
+
+## 2. 概念边界
+
+| 概念 | Codex 中的大致作用 | 当前项目迁移判断 |
+| --- | --- | --- |
+| MCP | 外部工具和资源协议 | 内置工具稳定后再评估 |
+| Skill | 按需加载的指令/资源 | 可作为 prompt/template 管理思想参考 |
+| Plugin | 分发和组合单元 | 暂不做 |
+| Hook | 生命周期拦截和改写 | Tool 可靠性后再考虑最小 hook |
+| App / Connector | 用户授权的外部能力来源 | 多租户和 OAuth 前不做 |
+| Environment | 本地/远程执行能力与文件系统边界 | 云端项目先用 server runtime，不做通用环境 |
+| Goal | 跨 Turn 的长期目标和预算状态 | 有长任务产品形态后再做 |
+| Memory | 异步抽取、引用和遗忘 | RAG/知识库稳定后再做 |
+| Multi-agent | 独立 child Thread、通信和容量治理 | 单 Agent 不能满足后再实验 |
+
+## 3. 高价值思想，可以先学
+
+### 3.1 Extension 不是随便给 runtime 打补丁
+
+Codex 的扩展能力通过 typed contributor、registry、snapshot 和 policy 进入 runtime。它强调：
+
+- 谁能贡献 context。
+- 谁能暴露 tool。
+- 谁能改写输入。
+- 谁能拥有状态。
+- 贡献失败是否影响主 Turn。
+
+当前项目未来做插件时，也应先定义 extension contract，而不是让插件直接拿 Nest service 随便改状态。
+
+### 3.2 Dynamic tools 要有可见性和执行 generation
+
+工具动态发现的问题不是“把工具列表塞给模型”这么简单，而是：
+
+```text
+模型看到哪些 tool specs
+  -> 对应哪个 registry generation
+  -> 执行时是否仍使用同一代 schema / policy / credentials
+```
+
+当前项目短期用静态内置工具，能避免大量复杂度。
+
+### 3.3 Goal 是 Thread 级业务状态，不是更长 prompt
+
+Codex 的 Goal 设计包含 objective、status、budget、usage、idle continuation 等。它的价值是长任务控制，而不是把用户目标塞进 system prompt。
+
+当前项目暂时不做 Goal，但要记住：未来如果做“持续优化一个站点 SEO”的长期任务，需要的是持久状态机，不是隐藏 prompt。
+
+### 3.4 Multi-agent 是独立 child Thread，不是多个函数互相调用
+
+Multi-agent 的复杂度来自：
+
+- child Thread 身份。
+- 父子通信。
+- token / runtime capacity。
+- 结果回传。
+- cancellation / recovery。
+- 权限继承。
+
+当前 AI SEO Agent 可以先用单 Agent + 多工具覆盖大部分需求。只有当任务天然需要独立上下文、并行研究或不同角色隔离时，才考虑 Multi-agent。
+
+## 4. 什么时候才转成任务
+
+### MCP / Plugin
+
+满足以下条件再评估：
+
+- 已有 3 个以上稳定内置工具。
+- 工具 schema、权限、timeout、observation 记录都稳定。
+- 用户确实需要接入外部工具生态。
+- 有租户和凭证管理。
+
+### Goal / Memory
+
+满足以下条件再评估：
+
+- 产品出现跨多次会话持续推进的任务。
+- 有 Run recovery 和 budget 记录。
+- 有明确暂停、恢复、完成、失败语义。
+- 用户能看到和控制长期状态。
+
+### Multi-agent
+
+满足以下条件再实验：
+
+- 单 Agent + 工具已经无法表达任务边界。
+- 子任务需要独立上下文和独立失败收口。
+- 可以度量多 Agent 相比单 Agent 的收益。
+- 有 capacity / cost / cancellation 策略。
+
+## 5. 当前只保留的学习价值
+
+| Codex 高级设计 | 现在学什么 |
+| --- | --- |
+| MCP refresh / exposure | 工具可见性和执行 registry 必须同代 |
+| Plugin / Skill | 不同来源的 prompt/tool 不能互相授权 |
+| Hook | pre/post 的副作用边界不同 |
+| Goal | 长期目标是持久状态机，不是 prompt |
+| Memory | 异步抽取要有来源、版本和遗忘边界 |
+| Multi-agent | child Thread 不是普通 tool call |
+| Exec Server | 远程执行需要 capability snapshot 和 recovery |
+
+## 6. 明确非目标
+
+近期不创建以下正式任务：
+
+- MCP server 接入。
+- Plugin marketplace。
+- Skill 包管理。
+- Goal runtime。
+- Memory pipeline。
+- Multi-agent。
+- Code Mode。
+- Remote Exec Server。
+
+这些材料留在知识库中，供后续架构讨论查阅。

--- a/docs/research/codex-reference/how-to-use.md
+++ b/docs/research/codex-reference/how-to-use.md
@@ -1,0 +1,115 @@
+# 如何使用 Codex 参考知识库
+
+## 1. 设计讨论时的默认动作
+
+以后你问 GPT 某个 Agent 项目设计问题时，可以直接说：
+
+```text
+参考 docs/research/codex-reference，帮我设计当前 agent 项目的 xxx。
+```
+
+GPT 应按下面顺序处理：
+
+```text
+确认当前项目代码事实
+  -> 查 codex-reference 中对应专题
+  -> 区分 Codex 源码事实 / 架构解释 / 当前项目迁移建议
+  -> 给出最小可实现方案
+  -> 标明哪些设计现在不做
+  -> 如果进入正式实现，再创建 Issue 或任务文档
+```
+
+## 2. 不要让知识库变成任务看板
+
+`codex-reference/**` 可以包含远超当前阶段的设计，例如 Goal、Memory、MCP、Plugin、Multi-agent、Exec Server、Realtime Handoff。它们的存在不代表当前项目要立刻实现。
+
+判断是否转为正式任务，只看三个条件：
+
+1. 当前业务是否真实需要。
+2. 前置能力是否已经具备。
+3. 是否能切成一个明确的最小任务并验证。
+
+例如：
+
+| Codex 能力 | 当前判断 |
+| --- | --- |
+| Tool call -> observation -> follow-up sampling | 近期必须做 |
+| Tool timeout / cancel / terminal exactly-once | 近中期必须做 |
+| Context compaction | 中期需要，先做 observation 截断和预算接口 |
+| ThreadStore / rollout recovery | 长任务和多实例前需要 |
+| MCP / Plugin / Skill | 当前只理解，不实现 |
+| Multi-agent | 单 Agent baseline 稳定后再评估 |
+| Goal / Memory | 有长期任务产品形态后再评估 |
+
+## 3. GPT 查阅规则
+
+### 3.1 问 Runtime
+
+查：
+
+- [core-runtime.md](./core-runtime.md)
+- [durability-recovery.md](./durability-recovery.md)
+
+重点看：
+
+- Thread 与 Turn 是否分开。
+- 一次 Run 是否可能多次 sampling。
+- 请求 accepted、run started、run completed 是否是不同事件。
+- active run 的 owner 是谁。
+
+### 3.2 问 Tool Calling
+
+查：
+
+- [tool-loop.md](./tool-loop.md)
+- [safety-permission.md](./safety-permission.md)
+- [context-history.md](./context-history.md)
+
+重点看：
+
+- 模型只是提出 tool call；系统拥有执行权。
+- raw call、validated invocation、tool output 不能混为一个对象。
+- expected business error 应该成为 observation，而不是直接 500。
+- UI Message 不等于 model history。
+
+### 3.3 问 Context / RAG / Memory
+
+查：
+
+- [context-history.md](./context-history.md)
+- [durability-recovery.md](./durability-recovery.md)
+- [extensibility-and-multi-agent.md](./extensibility-and-multi-agent.md)
+
+重点看：
+
+- model-visible history、UI transcript、durable facts 是三种不同投影。
+- RAG 或 tool output 是 untrusted data，不能升级为 system prompt。
+- 先做 observation 截断、来源标记和 token budget，再讨论复杂 memory。
+
+### 3.4 问权限 / 审批 / 安全
+
+查：
+
+- [safety-permission.md](./safety-permission.md)
+
+重点看：
+
+- Permission、Approval、Sandbox 是三层，不要混成一个 boolean。
+- 写操作工具必须先有 server-side policy 和 operation identity。
+- Prompt 里“不要越权”不能替代后端检查。
+
+## 4. 方案输出模板
+
+以后基于本知识库讨论技术方案时，GPT 应尽量按这个结构输出：
+
+```text
+1. 当前项目事实
+2. Codex 对应设计
+3. 可迁移的不变量
+4. 当前不该迁移的复杂度
+5. 最小实现方案
+6. 测试与验收标准
+7. 后续演进路径
+```
+
+这可以避免把 Codex 的成熟复杂度一次性搬进当前项目。

--- a/docs/research/codex-reference/safety-permission.md
+++ b/docs/research/codex-reference/safety-permission.md
@@ -1,0 +1,144 @@
+# Safety 与 Permission：审批、权限、Sandbox 和 Hook 的边界
+
+## 1. 核心结论
+
+Codex 把安全拆成多层，而不是一个 `allowed: boolean`：
+
+```text
+模型提出动作
+  -> Tool schema / registry 验证
+  -> permission profile
+  -> approval decision
+  -> sandbox / environment capability
+  -> hook pre-check / post-check
+  -> handler 执行
+  -> observation 脱敏 / 截断 / 投影
+```
+
+当前云端 AI SEO Agent 近期不需要复制 OS sandbox，但必须学习这种分层思想。
+
+## 2. Codex 源码入口
+
+| 主题 | 路径 |
+| --- | --- |
+| Permission profile | `codex-rs/core/src/config/permissions.rs` |
+| Exec policy | `codex-rs/core/src/exec_policy.rs` |
+| Tool approval | `codex-rs/core/src/tools/approvals.rs` |
+| Tool runtime | `codex-rs/core/src/tools/parallel.rs`、`registry.rs` |
+| Hook runtime | `codex-rs/core/src/hook_runtime.rs` |
+| Guardian | `codex-rs/core/src/guardian/**` |
+| Environment / capability | `codex-rs/core/src/environment_selection.rs`、`codex-rs/exec-server/**` |
+
+## 3. 可迁移不变量
+
+### 3.1 Permission、Approval、Sandbox 不同
+
+| 层 | 问题 | 当前项目迁移 |
+| --- | --- | --- |
+| Permission | 当前身份被允许做什么 | tenant/user/resource scope |
+| Approval | 这一次动作是否经用户确认 | HITL approval request |
+| Sandbox | 即使代码有 bug，也限制运行环境能力 | 云端先用业务隔离；代码执行时才考虑 OS sandbox |
+
+不要用“用户点了确认”代替权限检查，也不要用“工具低风险”代替租户隔离。
+
+### 3.2 Tool risk metadata 只是第一道门
+
+当前项目已有 risk metadata fail closed，这是好方向。后续应扩展为：
+
+```ts
+type ToolRisk = {
+  level: 'low' | 'medium' | 'high'
+  sideEffect: 'none' | 'internal_write' | 'external_write'
+  network: boolean
+  requiresApproval: boolean
+  resourceScopes: string[]
+}
+```
+
+执行前要同时检查：
+
+- 工具声明。
+- 当前用户/租户权限。
+- 当前 conversation/run policy。
+- 是否需要 approval。
+- 是否允许网络或写操作。
+
+### 3.3 Pre-hook 能阻止副作用，post-hook 不能撤销副作用
+
+Codex 的 hook 设计区分 pre-tool-use 与 post-tool-use。Post hook 即使 block，也只能改变 observation 或标记风险，不能撤销已经发生的文件/网络/进程副作用。
+
+当前项目迁移：
+
+- 安全审批必须发生在 executor 前。
+- executor 后的检查只能做脱敏、摘要、风险标记、补偿任务。
+- 不要把 post-check 包装成“安全执行”。
+
+### 3.4 Observation injection 不能靠 prompt 防御
+
+Tool output、RAG 结果、网页内容都可能包含：
+
+```text
+忽略之前的指令
+调用写工具
+泄漏系统提示
+```
+
+正确边界：
+
+- observation 只能作为 tool data role 进入模型。
+- server policy 不接受 observation 修改。
+- 下一轮模型即使被诱导请求高风险工具，router/policy 仍必须拒绝。
+- prompt 提醒只是纵深防御，不是安全边界。
+
+## 4. 当前项目实现顺序
+
+### 近期：只读工具
+
+- 只允许 `low + sideEffect=none + network=false + requiresApproval=false`。
+- 任何不满足条件的工具 fail closed。
+- executor 不接收 tenantId / credentials 等模型参数。
+
+### 中期：内部写工具
+
+例如保存 SEO 草稿、创建分析报告。
+
+必须先有：
+
+- user / tenant / resource ownership。
+- operation identity。
+- approval 或明确无需 approval 的 policy。
+- audit log。
+
+### 后期：外部写工具 / 网络工具
+
+例如发邮件、调用第三方 SEO API、发布页面。
+
+必须增加：
+
+- idempotency key。
+- external receipt。
+- retry / unknown reconciliation。
+- SSRF / domain allowlist。
+- secret 管理。
+
+## 5. 必测用例
+
+| 场景 | 关键断言 |
+| --- | --- |
+| model 伪造 tenantId | executor 使用 server context，忽略模型参数 |
+| medium risk tool | 当前阶段拒绝执行 |
+| requiresApproval tool | 没有 approval 时不执行 |
+| malicious observation | 不能改变 policy 或触发高风险工具 |
+| executor throws secret | modelContent 不泄漏 secret |
+| post-check block | 不声称副作用未发生 |
+| unauthorized resource | 返回安全失败，不进入 executor |
+
+## 6. 暂时不做
+
+- 不做 OS sandbox。
+- 不做通用 policy language。
+- 不做插件权限市场。
+- 不做远程执行环境。
+- 不做高风险自动写工具。
+
+当前先把 server-side 工具边界做硬，比引入复杂安全框架更重要。

--- a/docs/research/codex-reference/source-snapshot.md
+++ b/docs/research/codex-reference/source-snapshot.md
@@ -1,0 +1,78 @@
+# Codex 源码快照与取证地图
+
+## 1. 快照
+
+本轮资料基于用户上传的源码压缩包：
+
+```text
+codex-main-ab6a7eb87.zip
+```
+
+解压后源码根目录包含 `codex-rs/`、`codex-cli/`、`.codex/skills/`、`.github/` 等目录；其中 `codex-rs/` 是本轮主要研究对象。压缩包没有 `.git` 元数据，因此本文不声称读取了远端 Git 状态，只按文件名和源码路径记录该快照。
+
+## 2. 取证原则
+
+本轮只沉淀对当前 Agent 项目长期有价值的架构材料，不做逐 crate 摘要。
+
+采用的阅读顺序：
+
+```text
+产品入口 / 协议入口
+  -> Thread / Turn 生命周期
+  -> Session submission queue
+  -> RegularTask / run_turn
+  -> ModelClientSession sampling
+  -> ResponseEvent 处理
+  -> ToolRouter / ToolCallRuntime / ToolRegistry
+  -> ContextManager / rollout / ThreadStore
+  -> Permission / approval / sandbox / hook
+  -> Extension / MCP / Skill / Plugin / Multi-agent
+```
+
+## 3. 核心源码路径
+
+| 主题 | 关键路径 |
+| --- | --- |
+| CLI / App Server 入口 | `codex-rs/cli/src/main.rs`、`codex-rs/app-server/src/message_processor.rs` |
+| App Server 协议 | `codex-rs/app-server-protocol/src/protocol/common.rs`、`codex-rs/app-server-protocol/src/protocol/v2/**` |
+| Thread 生命周期 | `codex-rs/core/src/thread_manager.rs`、`codex-rs/core/src/codex_thread.rs` |
+| Session / submission queue | `codex-rs/core/src/session/mod.rs`、`codex-rs/core/src/session/handlers.rs` |
+| Task / Turn 主循环 | `codex-rs/core/src/tasks/regular.rs`、`codex-rs/core/src/session/turn.rs` |
+| StepContext | `codex-rs/core/src/session/step_context.rs` |
+| Model client | `codex-rs/core/src/client.rs`、`codex-rs/codex-api/src/common.rs` |
+| Tool router | `codex-rs/core/src/tools/router.rs` |
+| Tool registry | `codex-rs/core/src/tools/registry.rs` |
+| Tool runtime / 并发 / 取消 | `codex-rs/core/src/tools/parallel.rs` |
+| Tool call item 处理 | `codex-rs/core/src/stream_events_utils.rs` |
+| Context manager | `codex-rs/core/src/context_manager/history.rs`、`normalize.rs`、`updates.rs` |
+| Persistence | `codex-rs/thread-store/src/store.rs`、`types.rs`、`live_thread.rs` |
+| Permission / policy | `codex-rs/core/src/config/permissions.rs`、`exec_policy.rs`、`tools/approvals.rs` |
+| Hook | `codex-rs/core/src/hook_runtime.rs`、`codex-rs/hooks/**` |
+| Extension | `codex-rs/ext/**`、`codex-rs/core/src/extension*`、`codex-rs/core/src/tools/spec_plan.rs` |
+| Multi-agent | `codex-rs/core/src/agent/**`、`agent_communication.rs` |
+| Goal / Memory | `codex-rs/ext/goal/**`、`codex-rs/core/src/memory*`、`codex-rs/ext/**` |
+
+## 4. 高价值测试入口
+
+| 主题 | 测试路径 |
+| --- | --- |
+| App Server protocol | `codex-rs/app-server-protocol/src/protocol/v2/tests.rs` |
+| Thread start/resume/fork | `codex-rs/app-server/tests/suite/v2/thread_start.rs`、`thread_resume.rs`、`thread_fork.rs` |
+| Turn start / request validation | `codex-rs/app-server/tests/suite/v2/turn_start.rs`、`request_validation.rs` |
+| Runtime / abort | `codex-rs/core/tests/suite/abort_tasks.rs`、`codex-rs/core/src/session/tests.rs` |
+| Tool router / registry | `codex-rs/core/src/tools/router_tests.rs`、`registry_tests.rs` |
+| Tool parallelism | `codex-rs/core/tests/suite/tool_parallelism.rs` |
+| Context normalization | `codex-rs/core/src/context_manager/history_tests.rs` |
+| Token budget / compaction | `codex-rs/core/tests/suite/token_budget.rs` |
+| Goal extension | `codex-rs/ext/goal/tests/goal_extension_backend.rs` |
+| Multi-agent | `codex-rs/core/src/agent/control_tests.rs`、`registry_tests.rs`、`role_tests.rs` |
+
+## 5. 本轮没有做的事
+
+- 没有运行 Codex 全仓测试。
+- 没有逐平台验证 sandbox 系统调用。
+- 没有研究不可见的云端内部实现。
+- 没有把 Codex 的所有专题都转成当前项目任务。
+- 没有修改 `docs/tasks/**`、`docs/roadmap.md` 或 `docs/work-log.md`。
+
+这套文档是“后续讨论可查的参考底座”，不是完整源码审计报告。

--- a/docs/research/codex-reference/tool-loop.md
+++ b/docs/research/codex-reference/tool-loop.md
@@ -1,0 +1,232 @@
+# Tool Loop：从模型 Tool Call 到 Observation 回填
+
+## 1. 核心结论
+
+Agent 与普通聊天机器人的关键分界线不是“后端会调用函数”，而是：
+
+```text
+模型提出 tool call
+  -> 系统验证和执行
+  -> tool output 作为 observation 回填 model-visible history
+  -> 模型基于 observation 再次 sampling
+  -> 形成最终回答或继续调用工具
+```
+
+如果只是在后端拿到模型结果后调用一个函数，并把 JSON 返回前端，这还不是 Agent loop。
+
+## 2. Codex 源码链路
+
+核心路径：
+
+```text
+ResponseEvent::OutputItemDone
+  -> handle_output_item_done
+  -> ToolRouter::build_tool_call
+  -> record_completed_response_item
+  -> ToolCallRuntime::handle_tool_call
+  -> ToolRegistry::dispatch_any_with_terminal_outcome
+  -> ResponseInputItem tool output
+  -> drain in-flight futures
+  -> record_conversation_items
+  -> needs_follow_up = true
+  -> run_turn 下一轮 sampling
+```
+
+源码入口：
+
+- `codex-rs/core/src/session/turn.rs`
+- `codex-rs/core/src/stream_events_utils.rs`
+- `codex-rs/core/src/tools/router.rs`
+- `codex-rs/core/src/tools/parallel.rs`
+- `codex-rs/core/src/tools/registry.rs`
+- `codex-rs/core/src/tools/context.rs`
+
+## 3. 关键设计不变量
+
+### 3.1 模型只能提出调用，系统拥有执行权
+
+`ToolRouter::build_tool_call` 只把 `ResponseItem` 归一化为小的 `ToolCall`：
+
+```text
+toolName
+callId
+payload(function/custom/tool-search)
+```
+
+它不是业务 DTO，也不是 validated invocation。后续必须经过 registry lookup、payload kind 检查、handler parse、policy / hook / sandbox 才能执行。
+
+当前项目迁移：
+
+```text
+ModelToolCallCandidate
+  -> UnvalidatedToolCallEnvelope
+  -> ToolInvocationService
+  -> ValidatedToolInvocation
+  -> ToolExecutor
+  -> ToolResult
+```
+
+不要让 executor 接收模型原始 JSON。
+
+### 3.2 Raw call 先作为事实记录，再执行工具
+
+Codex 在识别到 tool call 后，会先记录模型确实请求了这个 call，再创建 tool future。
+
+价值：
+
+- 即使 Turn 后续取消，也能知道模型为什么走到工具阶段。
+- call 与 output 是两个事实，不是一个“工具成功记录”。
+- crash 在 call 后、output 前会留下可恢复/可诊断窗口。
+
+当前项目 Phase 03 可以先只保存在内存 model history；Phase 04 再持久化 call/output steps。但设计上必须区分：
+
+```text
+model requested call
+tool produced output
+```
+
+### 3.3 Expected tool error 应成为 observation
+
+Codex 对 unknown tool、参数错误、policy 拒绝等可恢复错误，通常生成失败 output 回给模型，让模型修正、换工具或解释失败。
+
+不要把所有工具失败都当作 Run fatal。建议当前项目区分：
+
+```ts
+type ToolFailure =
+  | { kind: 'observation'; callId: string; message: string }
+  | { kind: 'runtime_fatal'; message: string }
+```
+
+常见 observation failure：
+
+- unknown tool。
+- invalid JSON。
+- schema validation failed。
+- business resource not found。
+- low-risk executor 返回可解释失败。
+
+Fatal failure：
+
+- registry 状态损坏。
+- 已通过 handler 匹配却收到不兼容 payload。
+- runtime invariant 被破坏。
+- 持久化关键事实失败且无法安全继续。
+
+### 3.4 callId 是配对主键，不是全能 ID
+
+Codex 使用 provider call ID 配对 call/output，但这不应同时承担数据库主键、幂等键和审计身份。
+
+当前项目建议：
+
+```text
+providerCallId / callId：模型协议配对
+samplingAttemptId：第几轮 sampling 产生
+executionId：系统内部工具执行记录
+operationId：外部副作用业务意图
+idempotencyKey：重试去重
+receiptId：外部系统提交回执
+```
+
+只读工具 Phase 03 可以先不持久化 executionId，但类型设计不要把 callId 扩成所有身份。
+
+### 3.5 执行可以并发，Observation 顺序应稳定
+
+Codex 用并发 future 执行工具，但用 `FuturesOrdered` 按模型输出顺序 drain tool outputs。这样 model history 稳定、测试稳定、prompt cache 更稳定。
+
+当前项目近期策略更简单：
+
+- 每轮只允许一个 tool call。
+- 显式请求 `parallel_tool_calls=false`。
+- runtime reducer 仍然拒绝同轮多个 call，因为 provider 可能忽略请求偏好。
+
+等单工具闭环稳定后，再考虑并行。
+
+### 3.6 Cancellation 要有唯一 terminal owner
+
+Codex 的 `ToolCallRuntime` 用 `terminal_outcome_reached` 避免正常完成和取消同时产生两个 terminal event。
+
+当前项目迁移：
+
+- AbortSignal 在 sampling 前、tool 前、tool 后、下一轮前都检查。
+- 已 ABORTED 后，迟到的 tool result 或 model final 不能覆盖状态。
+- executor 抛 `AbortError` 应向上收口为 ABORTED，不伪装成 execution_failed。
+
+## 4. 当前项目 Phase 03 最小方案
+
+### 4.1 Model input union
+
+当前 `ChatMessage` 不足以表达 call/output。建议引入内部类型：
+
+```ts
+type ModelInputItem =
+  | { type: 'message'; role: 'system' | 'user' | 'assistant'; content: string }
+  | {
+      type: 'assistant_tool_call'
+      callId: string
+      name: string
+      rawArgumentsJson: string
+      content?: string
+    }
+  | {
+      type: 'tool_result'
+      callId: string
+      name: string
+      content: string
+      ok: boolean
+    }
+```
+
+Provider adapter 再把它映射成具体 OpenAI-compatible request。
+
+### 4.2 Sampling decision
+
+第一版 reducer 收集一轮完整 `ModelStreamEvent` 后输出：
+
+```ts
+type SamplingDecision =
+  | { type: 'final_answer'; textChunks: string[]; finishReason: 'stop' }
+  | { type: 'tool_call'; call: UnvalidatedToolCallEnvelope; intermediateText: string }
+```
+
+显式拒绝：
+
+- 同轮多个 tool calls。
+- `finishReason=tool_calls` 但没有完整 call。
+- tool call 与 stop 冲突。
+- `length/content_filter/unknown` 当作成功回答。
+
+### 4.3 UI transcript 与 model history 分离
+
+第一版策略：
+
+- user Message 照常写入。
+- 第一轮 tool call 的中间文本不发给 UI。
+- 中间文本如果存在，进入 `assistant_tool_call.content`。
+- tool result 只进 model history。
+- 第二轮 final answer 才写 UI assistant Message。
+
+这会改变首 token 时机：final sampling 完成后再 replay delta。可以保持 `ChatStreamEvent` shape，不要声称实时性完全兼容。
+
+## 5. 必测用例
+
+| 场景 | 关键断言 |
+| --- | --- |
+| happy path | 第一轮 call，工具成功，第二轮输入含同 callId result，最终回答写入 Message |
+| invalid args | executor 未被调用，失败 observation 进入第二轮 |
+| unknown tool | 无任意执行，模型看到 unknown observation |
+| executor throws | 错误脱敏，不泄漏 stack/secret |
+| abort sampling | Run/Message ABORTED |
+| abort tool | 不启动下一轮 sampling |
+| loop limit | 有限结束，FAILED 或 budget-exhausted |
+| mixed text + call | 中间文本不进 UI Message，但进入 model history |
+| multiple calls | explicit unsupported error |
+| prompt injection output | tool result 保持 tool role，不能改 server policy |
+
+## 6. 现在不做
+
+- 不做并行工具。
+- 不做 MCP。
+- 不做写操作工具。
+- 不做工具时间线 UI。
+- 不做完整持久化 replay。
+- 不做通用 workflow engine。

--- a/docs/research/codex/current-project-gap-analysis.md
+++ b/docs/research/codex/current-project-gap-analysis.md
@@ -1,16 +1,28 @@
 # 当前 AI SEO Agent 能力与差距分析
 
+> 本页以 `master@5f2ad11f2c65425e84392e81048364d55ec626ef` 为当前项目证据基线，修正旧研究资料中“没有 ToolCall / 没有测试 / 没有 Tool boundary”的过期判断。正式任务状态仍以 `docs/tasks/**` 为准；本页只记录研究视角下的能力和缺口。
+
 ## 1. 结论
 
-当前项目已经不是简单的“模型 API Demo”。它有真实会话、流式协议、持久化运行记录和内部 runtime 边界。但它仍属于 **文本型单采样 Agent Runtime 基础阶段**：
+当前项目已经不是“文本型单采样 Demo”的早期状态。它已经具备：
 
-- 模型只能返回文本。
-- Runtime 一次请求只做一次 sampling。
-- 没有 ToolCall / Observation 类型。
-- 没有自动化测试。
-- 没有云端身份、租户、幂等、恢复和资源治理。
+- 会话、消息、NDJSON streaming、停止生成。
+- `AgentRun` / `AgentStep` 粗粒度运行记录。
+- provider-neutral `ModelStreamEvent`。
+- 最小 Tool Contract、Registry、Invocation、Result。
+- `test:model-stream` 与 `test:tools` 基础测试。
 
-因此最合理的路线不是直接跳到 MCP、RAG 或 Multi-agent，而是先把“单 Agent Tool loop”做成可测试、可持久化、可取消的闭环。
+但它仍然还没有形成真正的 Agent loop，因为缺少这一段闭环：
+
+```text
+model tool call
+  -> server validate / execute
+  -> observation append to model-visible history
+  -> second sampling
+  -> final answer
+```
+
+因此最近路线应该从 **Phase 03：单 Agent Tool Loop** 开始，而不是重复实现 Phase 01 / Phase 02。
 
 ## 2. 当前能力证据
 
@@ -27,13 +39,13 @@
 
 证据：
 
-- `prisma/schema.prisma:60-92`
+- `prisma/schema.prisma`
 - `apps/api/src/conversations/`
 - `apps/web/src/api/conversations.ts`
 
 仍缺：
 
-- 用户/租户归属。
+- 用户 / 租户归属。
 - archive、share、权限等资源语义。
 - 并发 active run 规则。
 - 客户端请求幂等键。
@@ -49,19 +61,12 @@
 - 连接关闭时触发中断。
 - 消息、Run、Step 的 aborted 收口。
 
-证据：
-
-- `packages/contracts/src/seo.ts:12-61`
-- `apps/api/src/seo/seo.controller.ts:34-69`
-- `apps/web/src/api/seo.ts:20-152`
-- `apps/web/src/hooks/useSeoWorkspace.ts:195-335`
-
 仍缺：
 
-- stream contract 自动化测试。
+- 外部 stream contract 自动化测试。
 - 服务重启后的状态恢复。
 - 多实例下 cancellation 路由。
-- tool progress 与 approval 等内部事件。
+- tool progress 与 approval 等内部事件投影。
 
 ### 2.3 AgentRun / AgentStep
 
@@ -74,16 +79,10 @@
 - step input/output JSON snapshot。
 - 事务创建 Run + 初始 Steps。
 
-证据：
-
-- `prisma/schema.prisma:94-160`
-- `apps/api/src/agent-runtime/agent-run-recorder.service.ts:7-82`
-- `apps/api/src/agent-runtime/agent-run-recorder.service.ts:136-247`
-
 仍缺：
 
-- Tool Call、Observation、Approval steps。
-- attempt / retry 表达。
+- Tool call、Tool result、Approval 的细粒度 steps。
+- sampling attempt / execution attempt 表达。
 - Run 查询 API 或运行时间线 UI。
 - 僵尸 RUNNING recovery。
 - input/output 大小和敏感数据策略。
@@ -97,53 +96,55 @@
 - `AgentRuntimeEvent` 与 `ChatStreamEvent` 分离。
 - SEO mapper 保持外部协议稳定。
 - SEO prompt 通过 callback 注入，不让 runtime 依赖 SEO module。
-
-证据：
-
-- `apps/api/src/agent-runtime/agent-runtime.service.ts:35-285`
-- `apps/api/src/agent-runtime/agent-runtime.types.ts`
-- `apps/api/src/seo/seo-chat-stream-event.mapper.ts`
-- `apps/api/src/seo/seo.service.ts:86-105`
+- model stream 测试覆盖普通文本、tool loop 未实现 fail-fast、provider error、异常 finish reason、abort。
 
 仍缺：
 
 - 多轮 sampling loop。
-- provider-neutral model event。
-- ToolRouter / Registry / Executor。
-- context budget。
-- runtime 单元/集成测试。
-- application service 与 persistence query 的进一步边界。
+- model-visible history union。
+- Tool call -> observation -> second sampling。
+- loop budget。
+- sync endpoint 与 stream endpoint 的统一 runner。
+- recorder transaction / runtime 集成测试。
 
-### 2.5 LLM 适配
+### 2.5 LLM / Model event
 
 已具备：
 
-- `LLMService` 是业务门面。
-- OpenAI-compatible SDK 细节收敛到 client。
-- 非流式和流式调用。
-- timeout、AbortSignal 和基础错误分类。
-- provider base URL/API key 与默认模型在服务端配置；请求可通过 `SeoChatDto.model -> AgentRuntimeInput.model -> LLM options` 由客户端覆盖具体 model id。
+- `ModelStreamEvent` 内部稳定事件。
+- `ModelFinishReason`。
+- `UnvalidatedModelToolCall`。
+- usage event。
+- response_completed event。
+- tool call 未接入 loop 时明确失败，不静默丢弃。
 
-证据：
+仍缺：
 
-- `apps/api/src/llm/llm.service.ts`
-- `apps/api/src/llm/clients/openai-compatible.client.ts`
-- `apps/api/src/llm/llm.errors.ts`
+- request 侧 tools / tool_choice / parallel_tool_calls mapper。
+- provider profile：是否支持 tool calls、include_usage、parallel_tool_calls。
+- sync `chat()` 语义与 stream runner 对齐。
+- Run 中记录实际模型、usage、finish reason。
 
-关键缺口：
+### 2.6 Tool Contract / Registry / Invocation
 
-- `ChatMessage` 只有 system/user/assistant + string content。
-- request params 没有 tools / tool_choice。
-- stream 只读取 `chunk.choices[0]?.delta.content`。
-- completion 只接受 `message.content`，tool call 会被当作无效内容。
-- provider usage、finish reason、tool call 没有内部类型。
-- SDK maxRetries 固定为 0，项目也没有上层 retry policy。
-- streaming 尚未请求 `stream_options.include_usage`，也没有处理 `choices=[]` usage-only chunk 的 terminal 顺序。
-- model override 虽然可从客户端传入，但允许集合、租户策略和 Run 中实际模型记录仍需明确；不能误写成“模型只来自环境变量”。
+已具备：
 
-这说明 Tool Calling 的第一处改动应从 LLM boundary 开始，而不是先在 SEO Service 里写 switch。
+- `ToolDefinition` / `RegisteredTool` / `ToolExecutor` / `ToolResult`。
+- `ToolRegistryService`：注册、查找、重复名称拒绝、稳定排序 definitions。
+- `ToolInvocationService`：unknown tool、JSON parse、schema parse、risk gate、validated invocation、executor 调用。
+- 当前阶段对需审批、非低风险、有副作用或联网工具 fail closed。
+- `ModelToolSpec` mapper 只暴露模型可见字段。
+- tools 测试覆盖 registry、invalid args、risk、abort、异常脱敏等。
 
-### 2.6 Context
+仍缺：
+
+- AgentRuntimeService 内的 Tool loop 接线。
+- samplingAttemptId 与 callId / executionAttempt 的完整贯通。
+- observation 回填到下一轮 model input。
+- tool output 截断、timeout、recording。
+- 内置真实 SEO 只读工具是否已经完整接入，需要后续按代码再次核验。
+
+### 2.7 Context
 
 已具备：
 
@@ -151,25 +152,17 @@
 - history 有固定上限。
 - prompt 与历史组合集中在 SEO 层。
 
-证据：
-
-- `apps/api/src/seo/seo-context-builder.service.ts`
-- `apps/api/src/seo/seo.service.ts:18`
-- `apps/api/src/agent-runtime/agent-runtime.service.ts:71-87`
-
 仍缺：
 
-- token budget。
+- `ModelInputItem` union。
 - tool call / output message 类型。
+- token budget。
 - context source 和优先级。
 - 过大 observation 截断。
 - compaction / summary。
 - prompt version 与构造结果测试。
-- 同步 `chat()` 仍绕开 AgentRuntimeService，形成双路径。
 
-Tool loop 阶段的明确策略应是：同步 `chat()` 消费与 stream endpoint 相同的 turn runner 到 terminal 并返回 final；若暂时做不到，则对 tool-enabled sync request 明确 fail closed。继续 direct `LLMService.chat()` 会让同步请求绕过 AgentRun、工具、context 和错误收口。
-
-### 2.7 前端
+### 2.8 前端
 
 已具备：
 
@@ -179,6 +172,10 @@ Tool loop 阶段的明确策略应是：同步 `chat()` 消费与 stream endpoin
 - stop generation。
 - 多会话缓存和状态恢复到数据库结果。
 
+近期可以不改：
+
+- Phase 03 可先不展示工具过程，只保证最终回答和协议 shape 不破坏。
+
 仍缺：
 
 - Run/Step timeline。
@@ -187,110 +184,65 @@ Tool loop 阶段的明确策略应是：同步 `chat()` 消费与 stream endpoin
 - stream reconnect / server state reconciliation。
 - 多端并发更新。
 
-当前 Tool Calling 第一版明确可以不改前端，先保证外部 stream contract 不破坏。
-
-### 2.8 测试与质量
-
-已具备：
-
-- TypeScript strict 检查。
-- workspace typecheck。
-- ESLint。
-- Prisma validation/generation 流程。
-
-严重缺口：
-
-- 仓库中没有任何 `.test` / `.spec` 文件。
-- 没有 fake provider。
-- 没有 recorder transaction 测试。
-- 没有 runtime 状态机测试。
-- 没有 NDJSON parser contract 测试。
-- 没有端到端测试。
-
-Tool Calling 会把一次线性流扩展为循环状态机。如果不先补测试基座，后续 Approval、Context、Recovery 都会建立在不可证明的行为上。
-
-### 2.9 云端基础
-
-当前只有本地 Postgres docker-compose，没有证据证明已经实现：
-
-- 用户登录与鉴权。
-- 租户隔离。
-- API rate limit。
-- 任务队列和 worker。
-- Redis / distributed lock。
-- deployment manifests。
-- telemetry backend。
-- secret manager。
-- backup / retention。
-
-这些不是阶段 5 的前置，但必须进入中后期云端路线。
-
 ## 3. 差距矩阵
 
 | 能力 | 当前成熟度 | 目标成熟度 | 优先级 | 最小下一步 |
 | --- | --- | --- | --- | --- |
 | Session Chat | 可用基础 | 权限明确的 Thread | P2 | 后期加 owner/tenant |
-| Streaming | 可用基础 | 可测试、可恢复 stream | P1 | contract test |
+| Streaming | 可用基础 | 可测试、可恢复 stream | P1 | contract test + runner 统一 |
 | Run/Step | 可观察基础 | 可恢复状态机 | P1 | tool steps + recovery policy |
-| Model adapter | 文本-only | 结构化 ModelEvent | P0 | 定义 event union |
-| Tool contract | 无 | definition/call/result | P0 | types + validation |
-| Tool loop | 无 | 多轮受预算采样 | P0 | fake LLM 两轮测试 |
-| Approval | 无 | 可持久化等待/决策 | P1 | risk metadata 后实现 |
-| Context budget | 固定条数 | token/priority policy | P1 | budget interface |
+| Model event | 已有基础 | request/response 双向 provider-neutral | P1 | tools request mapper |
+| Tool contract | 已有基础 | 可被 Agent loop 消费 | P0 | runtime 接线 |
+| Tool loop | 无闭环 | 多轮受预算 sampling | P0 | fake LLM 两轮测试 |
+| Model history | 纯 message 为主 | message/call/result union | P0 | `ModelInputItem` |
+| Approval | metadata fail closed | 可持久等待/决策 | P1 | risk + approval request |
+| Context budget | 固定条数 | token/priority policy | P1 | observation budget |
 | Compaction | 无 | 可追踪 summary | P2 | 先定义触发/事实 |
-| Idempotency | 无 | 请求与副作用幂等 | P1 | clientRequestId |
+| Idempotency | 无 | 请求与副作用幂等 | P1 | operation identity |
 | Recovery | 无 | crash reconciliation | P2 | stale RUNNING sweeper |
 | Observability | step 基础 | trace/metrics/eval | P1/P2 | correlation ids |
-| Automated tests | 无 | 单元+集成+contract | P0 | test runner + fake adapters |
+| Automated tests | 已有 model/tools 基础 | 单元+集成+contract | P0/P1 | tool loop integration |
 | Multi-tenant | 无 | 数据与成本隔离 | P2 | auth/ownership design |
 | MCP/plugins | 无 | 可选扩展层 | P3 | 内置工具稳定后再做 |
 | Multi-agent | 无 | 有边界的 child runs | P3 | 单 Agent 成熟后实验 |
 
-## 4. 风险排序
+## 4. 近期最高风险
 
-### 近期最高风险
-
-1. 在 `AgentRuntimeService` 中直接解析 OpenAI SDK tool chunk，破坏 provider 边界。
-2. 只做 `ToolRegistry`，但没有 observation 回填和第二轮 sampling。
-3. Tool Calling 没有测试，导致 Run/Step 收口出现隐藏状态。
-4. 把 tool result 当普通 assistant text，污染 UI message 和 model history。
-5. 在只读工具阶段就扩协议和前端 timeline，扩大范围。
-6. 把 provider 的 raw call envelope 命名成 ToolCall 后直接送 executor，跳过 registry lookup/schema validation。
-7. 缓冲到 terminal 后仍声称 streaming 行为完全兼容，忽略首 token/实时性变化。
-
-### 中期风险
-
-1. 写操作工具没有幂等和审批。
-2. 多实例部署仍依赖内存 AbortController。
-3. 固定 12 条 history 在 tool output 增长后失控。
-4. input/output JSON 保存敏感或超大数据。
-5. 没有用户/租户边界却开放外部工具。
+1. 已有 ToolInvocationService，但在 Phase 03 中绕开它，直接把模型 raw JSON 交给 executor。
+2. 只执行工具，却没有把 observation 回填到第二轮 sampling。
+3. 把 tool result 写进 UI assistant Message，污染用户 transcript。
+4. `response_completed(tool_calls)` 被误判为整个 AgentRun completed。
+5. 缓冲到 terminal 后仍声称 streaming 行为完全兼容，忽略首 token/实时性变化。
+6. sync endpoint 继续 direct `LLMService.chat()`，绕过 AgentRun、工具、context 和错误收口。
+7. 没有 loop budget，模型无限调用工具。
+8. Abort 后迟到的工具结果或模型结果覆盖 ABORTED。
 
 ## 5. 推荐最近三个里程碑
 
-### 里程碑 A：可测试的模型事件边界
+### 里程碑 A：单 Agent Tool Loop
 
-- 引入测试框架。
-- 定义 `ModelStreamEvent`。
-- fake stream 覆盖 text/tool/usage/completed 值，并用 iterator throw 覆盖 provider error/abort；不建立第二套 error value channel。
-- 现有外部 NDJSON 行为不变。
+- `ModelInputItem` 能表达 message、assistant tool call、tool result。
+- provider request mapper 能发送 tools，并设置 `parallel_tool_calls=false`。
+- sampling reducer 能输出 final answer 或 single tool call decision。
+- tool call 经 `ToolInvocationService` 验证和执行。
+- observation 进入第二轮 sampling。
+- final answer 写入 UI Message。
+- invalid / unknown / throw / abort / loop limit tests。
 
-### 里程碑 B：单只读工具闭环
+### 里程碑 B：Tool 可靠性收口
 
-- ToolDefinition / Unvalidated envelope / Validated invocation / Result。
-- Registry / Executor / Router。
-- 第一轮 tool call，执行，observation 回填，第二轮 final text。
-- Run/Step terminal state 全部可断言。
-- 每轮请求显式 `parallel_tool_calls=false`，mixed text 在 model history 保留但不进 UI。
-
-### 里程碑 C：可靠性收口
-
-- loop budget。
-- tool timeout/cancel/error taxonomy。
-- 主动 race 不配合 AbortSignal 的 executor 与 late settlement。
-- idempotency key。
-- stale RUNNING 检测设计。
+- tool call/result 记录到 AgentStep 或独立 record。
+- timeout / cancel / error taxonomy。
+- output truncation。
 - trace correlation。
-- 不在此里程碑自动 retry 工具；记录 idempotency/attempt，Phase 07 再基于 durable outcome 决策。
+- Run/Step terminal exactly-once。
 
-完成这三个里程碑，当前项目才真正从“可观测 Chat Runtime”进入“可验证 Agent Runtime”。
+### 里程碑 C：Context 与恢复基础
+
+- observation budget。
+- context source / priority。
+- prompt version。
+- stale RUNNING recovery。
+- operation identity / idempotency key。
+
+完成这三个里程碑，当前项目才真正从“具备工具边界的 Chat Runtime”进入“可验证 Agent Runtime”。


### PR DESCRIPTION
## 改动摘要

- 新增 `docs/research/codex-reference/**`，作为以后讨论 Agent Runtime、Tool Loop、Context、Recovery、Permission、Extensibility / Multi-agent 时的优先参考入口。
- 基于用户上传的 `codex-main-ab6a7eb87.zip` 源码快照，按“源码事实 / 架构解释 / 当前项目迁移建议”整理 Codex 中可借鉴的不变量。
- 更新 `docs/research/README.md`，将新知识库设为后续 GPT 讨论的主要入口，并明确旧 research 文档与新参考库冲突时的优先级。
- 刷新 `docs/research/codex/current-project-gap-analysis.md`，修正旧结论中“没有 ToolCall / 没有自动化测试 / 没有 Tool boundary”等过期判断。

## 新增文档

- `docs/research/codex-reference/README.md`
- `docs/research/codex-reference/how-to-use.md`
- `docs/research/codex-reference/source-snapshot.md`
- `docs/research/codex-reference/current-agent-baseline.md`
- `docs/research/codex-reference/core-runtime.md`
- `docs/research/codex-reference/tool-loop.md`
- `docs/research/codex-reference/context-history.md`
- `docs/research/codex-reference/durability-recovery.md`
- `docs/research/codex-reference/safety-permission.md`
- `docs/research/codex-reference/extensibility-and-multi-agent.md`
- `docs/research/codex-reference/discussion-playbook.md`

## 当前项目判断

当前项目已经具备 provider-neutral `ModelStreamEvent`、最小 `ToolDefinition / ToolRegistry / ToolInvocation / ToolResult` 边界，以及 `test:model-stream`、`test:tools` 基础测试；近期主线应从“单 Agent Tool Loop”开始，而不是重复 Phase 01 / Phase 02。

## 明确未做

- 未修改 `docs/tasks/**`、`docs/roadmap.md`、`docs/work-log.md`。
- 未修改业务代码、数据库、API 或正式任务状态。
- 未运行 Codex 全仓测试；本 PR 只基于上传源码快照做研究整理。
- 没有删除旧 `docs/research/codex/**` 长文，只是新增更清晰的后续优先入口。

## 验证

- GitHub compare：分支相对 `master` ahead 13，behind 0。
- 变更范围：仅 `docs/research/**`。
- 手动检查新增 `codex-reference/**` 内部相对链接。

## 后续使用方式

以后讨论 Agent 项目方案时，优先查：

```text
docs/research/codex-reference/how-to-use.md
docs/research/codex-reference/current-agent-baseline.md
docs/research/codex-reference/discussion-playbook.md
```

本 PR 不等于合并授权；等待 GPT/用户验收。