### PR TITLE
[Phase 5 Task 3] 实现只读文章查询工具 search_articles

### DIFF
--- a/apps/api/src/tools/search-articles.tool.test.ts
+++ b/apps/api/src/tools/search-articles.tool.test.ts
@@ -1,0 +1,214 @@
+import type { PrismaService } from '../prisma/prisma.service.js'
+import type { SearchArticlesOutput } from './search-articles.tool.js'
+import type { ToolExecutionContext } from './tool.types.js'
+import assert from 'node:assert/strict'
+// 项目本轮使用 Node 原生测试运行器，不引入额外测试框架。
+// eslint-disable-next-line test/no-import-node-test
+import { describe, it } from 'node:test'
+
+import { toModelToolSpec } from './model-tool-spec.mapper.js'
+import {
+  searchArticlesDefinition,
+  SearchArticlesTool,
+} from './search-articles.tool.js'
+import { ToolInvocationService } from './tool-invocation.service.js'
+import { ToolRegistryService } from './tool-registry.service.js'
+import { ToolsModule } from './tools.module.js'
+
+const FULL_CONTENT = `<p>${'alpha article content '.repeat(20)}</p>`
+
+describe('search_articles', () => {
+  it('注册模型可见定义，并保持低风险只读边界', () => {
+    const { registry, toolsModule } = createTools()
+    const definition = registry.require('search_articles').definition
+
+    assert.ok(toolsModule)
+    assert.deepEqual(
+      registry.listDefinitions().map(item => item.name),
+      ['search_articles'],
+    )
+    assert.equal(definition, searchArticlesDefinition)
+    assert.deepEqual(definition.risk, {
+      level: 'low',
+      sideEffect: 'none',
+      network: false,
+    })
+    assert.equal(definition.requiresApproval, false)
+    assert.deepEqual(toModelToolSpec(definition), {
+      name: 'search_articles',
+      description: definition.description,
+      inputSchema: definition.input.schema,
+    })
+  })
+
+  it('校验并规范化参数，查询总数和受控精简结果', async () => {
+    const fakePrisma = new FakePrismaService({
+      total: 12,
+      records: [{
+        sourceId: 7,
+        slug: 'alpha-article',
+        languageCode: 'zh-cn',
+        title: 'Alpha Article',
+        seoTitle: 'Alpha SEO',
+        seoDescription: null,
+        content: FULL_CONTENT,
+      }],
+    })
+    const { invocationService } = createTools(fakePrisma)
+
+    const result = await invocationService.invoke(
+      createEnvelope({ query: '  Alpha  ', languageCode: ' ZH-CN ', limit: 3 }),
+      createContext(),
+    )
+
+    assert.equal(result.ok, true)
+    assert.deepEqual(
+      fakePrisma.countArguments[0]?.where,
+      fakePrisma.findManyArguments[0]?.where,
+    )
+    assert.equal(fakePrisma.findManyArguments[0]?.take, 3)
+    assert.equal(fakePrisma.findManyArguments[0]?.where.languageCode, 'zh-cn')
+
+    if (!result.ok)
+      return
+
+    const data = result.data as SearchArticlesOutput
+
+    assert.equal(data.total, 12)
+    assert.deepEqual(data.articles.map(({ excerpt, ...article }) => article), [{
+      sourceId: 7,
+      slug: 'alpha-article',
+      languageCode: 'zh-cn',
+      title: 'Alpha Article',
+      seoTitle: 'Alpha SEO',
+      seoDescription: null,
+    }])
+    assert.equal(data.articles[0]?.excerpt.length, 200)
+    assert.equal(Object.hasOwn(data.articles[0] ?? {}, 'content'), false)
+    assert.doesNotMatch(result.modelContent, new RegExp(FULL_CONTENT))
+    assert.doesNotMatch(result.modelContent, /<p>|<\/p>/)
+  })
+
+  it('拒绝空 query、超限 limit 和额外字段，且不查询数据库', async () => {
+    const fakePrisma = new FakePrismaService()
+    const { invocationService } = createTools(fakePrisma)
+    const invalidInputs = [
+      { query: '   ' },
+      { query: 'alpha', limit: 11 },
+      { query: 'alpha', extra: true },
+    ]
+
+    for (const input of invalidInputs) {
+      const result = await invocationService.invoke(
+        createEnvelope(input),
+        createContext(),
+      )
+
+      assert.equal(result.ok, false)
+      assert.equal(result.ok ? undefined : result.code, 'invalid_arguments')
+    }
+
+    assert.equal(fakePrisma.countArguments.length, 0)
+    assert.equal(fakePrisma.findManyArguments.length, 0)
+  })
+
+  it('无结果时返回成功、空列表和可用于 Observation 的说明', async () => {
+    const fakePrisma = new FakePrismaService()
+    const { invocationService } = createTools(fakePrisma)
+
+    const result = await invocationService.invoke(
+      createEnvelope({ query: 'missing' }),
+      createContext(),
+    )
+
+    assert.equal(fakePrisma.findManyArguments[0]?.take, 5)
+    assert.deepEqual(result, {
+      ok: true,
+      data: {
+        query: 'missing',
+        total: 0,
+        articles: [],
+      },
+      modelContent: '没有找到与“missing”匹配的文章。',
+    })
+  })
+})
+
+interface FakeArticleRecord {
+  sourceId: number
+  slug: string
+  languageCode: string
+  title: string
+  seoTitle: string | null
+  seoDescription: string | null
+  content: string
+}
+
+interface FakePrismaOptions {
+  total?: number
+  records?: FakeArticleRecord[]
+}
+
+class FakePrismaService {
+  readonly countArguments: FakeCountArguments[] = []
+  readonly findManyArguments: FakeFindManyArguments[] = []
+  readonly article = {
+    count: async (arguments_: FakeCountArguments) => {
+      this.countArguments.push(arguments_)
+      return this.options.total ?? 0
+    },
+    findMany: async (arguments_: FakeFindManyArguments) => {
+      this.findManyArguments.push(arguments_)
+      return this.options.records ?? []
+    },
+  }
+
+  constructor(private readonly options: FakePrismaOptions = {}) {}
+}
+
+interface FakeWhere {
+  languageCode?: string
+  [key: string]: unknown
+}
+
+interface FakeCountArguments {
+  where: FakeWhere
+}
+
+interface FakeFindManyArguments {
+  where: FakeWhere
+  take: number
+  [key: string]: unknown
+}
+
+function createTools(fakePrisma = new FakePrismaService()) {
+  const registry = new ToolRegistryService()
+  const searchArticlesTool = new SearchArticlesTool(
+    fakePrisma as unknown as PrismaService,
+  )
+  const toolsModule = new ToolsModule(registry, searchArticlesTool)
+
+  return {
+    registry,
+    toolsModule,
+    invocationService: new ToolInvocationService(registry),
+  }
+}
+
+function createEnvelope(input: Record<string, unknown>) {
+  return {
+    callId: 'call-search-1',
+    toolName: 'search_articles',
+    rawArgumentsJson: JSON.stringify(input),
+    samplingAttemptId: 'sampling-1',
+  }
+}
+
+function createContext(): ToolExecutionContext {
+  return {
+    runId: 'run-1',
+    conversationId: 'conversation-1',
+    signal: new AbortController().signal,
+    executionAttempt: 1,
+  }
+}

--- a/apps/api/src/tools/search-articles.tool.test.ts
+++ b/apps/api/src/tools/search-articles.tool.test.ts
@@ -57,7 +57,7 @@ describe('search_articles', () => {
     const { invocationService } = createTools(fakePrisma)
 
     const result = await invocationService.invoke(
-      createEnvelope({ query: '  Alpha  ', languageCode: ' ZH-CN ', limit: 3 }),
+      createEnvelope({ query: '  Alpha%_\\  ', languageCode: ' ZH-CN ', limit: 3 }),
       createContext(),
     )
 
@@ -67,13 +67,23 @@ describe('search_articles', () => {
       fakePrisma.findManyArguments[0]?.where,
     )
     assert.equal(fakePrisma.findManyArguments[0]?.take, 3)
-    assert.equal(fakePrisma.findManyArguments[0]?.where.languageCode, 'zh-cn')
+    assert.deepEqual(fakePrisma.findManyArguments[0]?.where, {
+      languageCode: 'zh-cn',
+      OR: [
+        { title: { contains: 'Alpha\\%\\_\\\\', mode: 'insensitive' } },
+        { slug: { contains: 'Alpha\\%\\_\\\\', mode: 'insensitive' } },
+        { seoTitle: { contains: 'Alpha\\%\\_\\\\', mode: 'insensitive' } },
+        { seoDescription: { contains: 'Alpha\\%\\_\\\\', mode: 'insensitive' } },
+        { content: { contains: 'Alpha\\%\\_\\\\', mode: 'insensitive' } },
+      ],
+    })
 
     if (!result.ok)
       return
 
     const data = result.data as SearchArticlesOutput
 
+    assert.equal(data.query, 'Alpha%_\\')
     assert.equal(data.total, 12)
     assert.deepEqual(data.articles.map(({ excerpt, ...article }) => article), [{
       sourceId: 7,

--- a/apps/api/src/tools/search-articles.tool.ts
+++ b/apps/api/src/tools/search-articles.tool.ts
@@ -1,0 +1,185 @@
+import type { Prisma } from '../generated/prisma/client.js'
+import type {
+  ToolDefinition,
+  ToolExecutor,
+  ValidatedToolInvocation,
+} from './tool.types.js'
+import { Inject, Injectable } from '@nestjs/common'
+
+import { PrismaService } from '../prisma/prisma.service.js'
+
+const DEFAULT_LIMIT = 5
+const MAX_LIMIT = 10
+const MAX_QUERY_LENGTH = 100
+const MAX_LANGUAGE_CODE_LENGTH = 20
+const EXCERPT_LENGTH = 200
+
+export interface SearchArticlesInput {
+  query: string
+  languageCode?: string
+  limit: number
+}
+
+export interface SearchArticleSummary {
+  sourceId: number
+  slug: string
+  languageCode: string
+  title: string
+  seoTitle: string | null
+  seoDescription: string | null
+  excerpt: string
+}
+
+export interface SearchArticlesOutput {
+  query: string
+  languageCode?: string
+  total: number
+  articles: SearchArticleSummary[]
+}
+
+export const searchArticlesDefinition: ToolDefinition<SearchArticlesInput> = {
+  name: 'search_articles',
+  version: '1',
+  description: '按关键词查询文章，返回总数和最多 10 条不含正文的精简结果。',
+  input: {
+    schema: {
+      type: 'object',
+      properties: {
+        query: { type: 'string', description: '搜索关键词，最多 100 个字符。' },
+        languageCode: { type: 'string', description: '可选语言代码，例如 zh-cn 或 en。' },
+        limit: { type: 'integer', description: '返回条数，范围 1-10，默认 5。' },
+      },
+      required: ['query'],
+      additionalProperties: false,
+    },
+    parse: parseSearchArticlesInput,
+  },
+  timeoutMs: 5_000,
+  requiresApproval: false,
+  idempotent: true,
+  risk: { level: 'low', sideEffect: 'none', network: false },
+}
+
+@Injectable()
+export class SearchArticlesTool implements ToolExecutor<SearchArticlesInput, SearchArticlesOutput> {
+  constructor(
+    @Inject(PrismaService)
+    private readonly prismaService: PrismaService,
+  ) {}
+
+  async execute(
+    invocation: ValidatedToolInvocation<SearchArticlesInput>,
+  ) {
+    const { languageCode, limit, query } = invocation.input
+    const where: Prisma.ArticleWhereInput = {
+      ...(languageCode ? { languageCode } : {}),
+      OR: [
+        { title: { contains: query, mode: 'insensitive' } },
+        { slug: { contains: query, mode: 'insensitive' } },
+        { seoTitle: { contains: query, mode: 'insensitive' } },
+        { seoDescription: { contains: query, mode: 'insensitive' } },
+        { content: { contains: query, mode: 'insensitive' } },
+      ],
+    }
+
+    const [total, records] = await Promise.all([
+      this.prismaService.article.count({ where }),
+      this.prismaService.article.findMany({
+        where,
+        select: {
+          sourceId: true,
+          slug: true,
+          languageCode: true,
+          title: true,
+          seoTitle: true,
+          seoDescription: true,
+          content: true,
+        },
+        orderBy: [
+          { updatedAt: 'desc' },
+          { sourceId: 'asc' },
+        ],
+        take: limit,
+      }),
+    ])
+    const articles = records.map(({ content, ...article }) => ({
+      ...article,
+      excerpt: toExcerpt(content),
+    }))
+    const data: SearchArticlesOutput = {
+      query,
+      ...(languageCode ? { languageCode } : {}),
+      total,
+      articles,
+    }
+
+    return {
+      ok: true as const,
+      data,
+      modelContent: articles.length === 0
+        ? `没有找到与“${query}”匹配的文章。`
+        : `共找到 ${total} 篇匹配文章，以下是 ${articles.length} 条精简结果：\n${JSON.stringify(articles)}`,
+    }
+  }
+}
+
+function parseSearchArticlesInput(value: unknown): SearchArticlesInput {
+  if (typeof value !== 'object' || value === null || Array.isArray(value))
+    throw new Error('invalid search_articles input')
+
+  const record = value as Record<string, unknown>
+  const allowedKeys = new Set(['query', 'languageCode', 'limit'])
+
+  if (Object.keys(record).some(key => !allowedKeys.has(key)))
+    throw new Error('invalid search_articles input')
+
+  if (typeof record.query !== 'string')
+    throw new Error('invalid search_articles query')
+
+  const query = record.query.trim()
+
+  if (query.length === 0 || query.length > MAX_QUERY_LENGTH)
+    throw new Error('invalid search_articles query')
+
+  let languageCode: string | undefined
+
+  if (Object.hasOwn(record, 'languageCode')) {
+    if (typeof record.languageCode !== 'string')
+      throw new Error('invalid search_articles languageCode')
+
+    languageCode = record.languageCode.trim().toLowerCase()
+
+    if (languageCode.length === 0 || languageCode.length > MAX_LANGUAGE_CODE_LENGTH)
+      throw new Error('invalid search_articles languageCode')
+  }
+
+  let limit = DEFAULT_LIMIT
+
+  if (Object.hasOwn(record, 'limit')) {
+    if (
+      typeof record.limit !== 'number'
+      || !Number.isInteger(record.limit)
+      || record.limit < 1
+      || record.limit > MAX_LIMIT
+    ) {
+      throw new Error('invalid search_articles limit')
+    }
+
+    limit = record.limit
+  }
+
+  return {
+    query,
+    ...(languageCode ? { languageCode } : {}),
+    limit,
+  }
+}
+
+function toExcerpt(content: string): string {
+  const plainText = content
+    .replace(/<[^>]*>/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim()
+
+  return [...plainText].slice(0, EXCERPT_LENGTH).join('')
+}

--- a/apps/api/src/tools/search-articles.tool.ts
+++ b/apps/api/src/tools/search-articles.tool.ts
@@ -71,14 +71,15 @@ export class SearchArticlesTool implements ToolExecutor<SearchArticlesInput, Sea
     invocation: ValidatedToolInvocation<SearchArticlesInput>,
   ) {
     const { languageCode, limit, query } = invocation.input
+    const queryPattern = query.replace(/[\\%_]/g, '\\$&')
     const where: Prisma.ArticleWhereInput = {
       ...(languageCode ? { languageCode } : {}),
       OR: [
-        { title: { contains: query, mode: 'insensitive' } },
-        { slug: { contains: query, mode: 'insensitive' } },
-        { seoTitle: { contains: query, mode: 'insensitive' } },
-        { seoDescription: { contains: query, mode: 'insensitive' } },
-        { content: { contains: query, mode: 'insensitive' } },
+        { title: { contains: queryPattern, mode: 'insensitive' } },
+        { slug: { contains: queryPattern, mode: 'insensitive' } },
+        { seoTitle: { contains: queryPattern, mode: 'insensitive' } },
+        { seoDescription: { contains: queryPattern, mode: 'insensitive' } },
+        { content: { contains: queryPattern, mode: 'insensitive' } },
       ],
     }
 

--- a/apps/api/src/tools/tools.module.ts
+++ b/apps/api/src/tools/tools.module.ts
@@ -1,10 +1,26 @@
-import { Module } from '@nestjs/common'
+import { Inject, Module } from '@nestjs/common'
 
+import { PrismaModule } from '../prisma/prisma.module.js'
+import { searchArticlesDefinition, SearchArticlesTool } from './search-articles.tool.js'
 import { ToolInvocationService } from './tool-invocation.service.js'
 import { ToolRegistryService } from './tool-registry.service.js'
 
 @Module({
-  providers: [ToolRegistryService, ToolInvocationService],
+  imports: [PrismaModule],
+  providers: [ToolRegistryService, ToolInvocationService, SearchArticlesTool],
   exports: [ToolRegistryService, ToolInvocationService],
 })
-export class ToolsModule {}
+export class ToolsModule {
+  constructor(
+    @Inject(ToolRegistryService)
+    registry: ToolRegistryService,
+
+    @Inject(SearchArticlesTool)
+    searchArticlesTool: SearchArticlesTool,
+  ) {
+    registry.register({
+      definition: searchArticlesDefinition,
+      executor: searchArticlesTool,
+    })
+  }
+}

--- a/apps/api/src/tools/tools.test.ts
+++ b/apps/api/src/tools/tools.test.ts
@@ -9,7 +9,9 @@ import assert from 'node:assert/strict'
 // eslint-disable-next-line test/no-import-node-test
 import { describe, it } from 'node:test'
 
+import { PrismaModule } from '../prisma/prisma.module.js'
 import { toModelToolSpec } from './model-tool-spec.mapper.js'
+import { SearchArticlesTool } from './search-articles.tool.js'
 import { ToolInvocationService } from './tool-invocation.service.js'
 import { ToolRegistryService } from './tool-registry.service.js'
 import { ToolRegistryError } from './tool.errors.js'
@@ -261,10 +263,16 @@ describe('模型映射与 NestJS 模块', () => {
   })
 
   it('ToolsModule 提供并导出 Registry 与 InvocationService', () => {
+    const imports = Reflect.getMetadata('imports', ToolsModule)
     const providers = Reflect.getMetadata('providers', ToolsModule)
     const exports = Reflect.getMetadata('exports', ToolsModule)
 
-    assert.deepEqual(providers, [ToolRegistryService, ToolInvocationService])
+    assert.deepEqual(imports, [PrismaModule])
+    assert.deepEqual(providers, [
+      ToolRegistryService,
+      ToolInvocationService,
+      SearchArticlesTool,
+    ])
     assert.deepEqual(exports, [ToolRegistryService, ToolInvocationService])
   })
 })

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -4,7 +4,7 @@
 
 ## 当前判断
 
-项目已经完成从固定字段 SEO 生成器到 Session Chat 的迁移，并完成流式输出最终态一致性收口。阶段 4 Agent Runtime 基础已归档；阶段 5 继续进行，Task 0-2 已完成并通过验收，最小 Tool Contract、Registry、参数验证与执行边界已经建立。Task 3 保持 Planned、尚未开始，下一步再实现第一只只读工具 `search_articles`，不要直接跳到 Tool Loop、RAG 或多 Agent。
+项目已经完成从固定字段 SEO 生成器到 Session Chat 的迁移，并完成流式输出最终态一致性收口。阶段 4 Agent Runtime 基础已归档；阶段 5 继续进行，Task 0-2 已完成并通过验收，最小 Tool Contract、Registry、参数验证与执行边界已经建立。Task 3 的第一只只读工具 `search_articles` 已实现、待验收，尚未标记 Completed；下一步先完成 GPT / 用户验收，不推进 Task 4、RAG 或多 Agent。
 
 ## 阶段路线
 
@@ -23,8 +23,8 @@
 
 | 优先级 | 任务 | 说明 |
 | --- | --- | --- |
-| P0 | 阶段 5 Task 3（Planned） | 下一步实现 `search_articles`；当前尚未开始 |
-| P1 | 阶段 5 Task 4-5 | 后续依次完成单 Agent Tool Loop 和 `AgentStep` 记录 |
+| P0 | 阶段 5 Task 3（已实现，待验收） | `search_articles` 已实现；下一步由 GPT / 用户验收，不自行标记 Completed |
+| P1 | 阶段 5 Task 4-5 | 保持 Planned；Task 3 验收收口后再依次完成单 Agent Tool Loop 和 `AgentStep` 记录 |
 | P2 | Context 管理增强 | 阶段 5 稳定后再加入页面数据、关键词、工具 Observation 和预算规则 |
 
 ## 现在暂不做

--- a/docs/tasks/README.md
+++ b/docs/tasks/README.md
@@ -6,7 +6,7 @@
 
 | 区域 | 状态 | 文档 | 说明 |
 | --- | --- | --- | --- |
-| 阶段 5 最小 Tool Calling | In Progress | [phase-05-tool-calling/README.md](./phase-05-tool-calling/README.md) | Task 0-2 已完成；Task 3 保持 Planned，尚未开始 |
+| 阶段 5 最小 Tool Calling | In Progress | [phase-05-tool-calling/README.md](./phase-05-tool-calling/README.md) | Task 0-2 已完成；Task 3 已实现、待验收，尚未标记 Completed；Task 4 保持 Planned |
 | 阶段 4 Agent Runtime | Completed | [completed/phase-04-agent-runtime.md](./completed/phase-04-agent-runtime.md) | 已归档为可观测 Agent Run 的基础阶段 |
 | 阶段 3 收口 | Completed | [completed/phase-03-streaming-closeout.md](./completed/phase-03-streaming-closeout.md) | 已收口 `done/error/aborted` 最终态一致性 |
 | 阶段 2 | Completed | [completed/phase-02-agent-chat-session.md](./completed/phase-02-agent-chat-session.md) | 多会话和消息持久化已完成 |

--- a/docs/tasks/phase-05-tool-calling/README.md
+++ b/docs/tasks/phase-05-tool-calling/README.md
@@ -1,6 +1,6 @@
 # 阶段 5：最小 Tool Calling
 
-状态：进行中。Task 2 已完成并通过验收，Task 3 尚未开始。
+状态：进行中。Task 2 已完成并通过验收；Task 3 已实现、待验收，尚未标记 Completed。
 
 ## 阶段目标
 
@@ -41,7 +41,7 @@
 | Task 0 | Completed | 新增 `Article` 表并导入文章 Demo 数据，为只读工具提供稳定数据源 |
 | Task 1 | Completed | 将纯文本模型流升级为 provider-neutral `ModelStreamEvent`，让 Runtime 能识别文本、Tool Call 和本次 sampling 的结束原因 |
 | Task 2 | Completed | 定义最小 `ToolDefinition`、`ToolRegistry`、参数验证、执行与结果边界 |
-| Task 3 | Planned | 实现第一只只读工具 `search_articles`，查询并返回精简文章信息 |
+| Task 3 | 已实现，待验收 | 实现第一只只读工具 `search_articles`，查询并返回精简文章信息 |
 | Task 4 | Planned | 实现单 Agent Tool Loop：模型请求工具、后端执行、Observation 回填、模型继续生成最终回答 |
 | Task 5 | Planned | 将模型调用、工具执行和工具结果记录到 `AgentStep`，保持当前前端 stream 协议稳定 |
 
@@ -64,7 +64,16 @@
 - 新增 provider-neutral `ModelToolSpec` 与纯映射，只暴露名称、描述和输入 Schema。
 - 使用无网络、无副作用的测试专用 `echo` 工具覆盖 13 个 Registry、Invocation、Mapper 和 NestJS 模块回归用例；未接入 Runtime Tool Loop，也未实现正式业务工具。
 - `timeoutMs` 当前只保留为 server-owned metadata；工具超时执行逻辑按 Issue #1 明确留待后续任务，不阻塞 Task 2 验收。
-- 实施状态：已实现；验收状态：已通过；任务状态：Completed。Task 3 保持 Planned，尚未开始。
+- 实施状态：已实现；验收状态：已通过；任务状态：Completed。
+
+## Task 3 实现结果
+
+- 新增低风险、只读、无外部网络且无需审批的 `search_articles`，通过现有输入契约校验 `query`、`languageCode` 和 `limit`。
+- 工具查询 `Article` 表并稳定返回匹配总数与最多 10 条精简结果；单条结果只包含 `sourceId`、`slug`、`languageCode`、`title`、`seoTitle`、`seoDescription` 和截断后的 `excerpt`，不返回完整 `content`。
+- `ToolsModule` 显式注册工具并引入 `PrismaModule`；合法调用继续通过 `ToolRegistryService`、`ToolInvocationService` 和 `ToolExecutor` 边界执行。
+- `modelContent` 提供有结果或无结果的受控查询说明，可供后续 Task 4 作为 Observation 使用；本任务未接入 Runtime Tool Loop、Observation 回填或第二轮 sampling。
+- `test:tools` 覆盖 Registry、模型 spec、参数校验、查询参数、精简输出、无结果和风险边界；既有模型流回归、API typecheck/lint 与 workspace typecheck 通过。
+- 实施状态：已实现；验收状态：待验收。Task 3 未标记 Completed，Task 4 保持 Planned。
 
 ## 关键边界
 

--- a/docs/work-log.md
+++ b/docs/work-log.md
@@ -6,7 +6,7 @@
 
 | 类型 | 当前记录 | 下一步 |
 | --- | --- | --- |
-| 当前阶段 | 阶段 4 Agent Runtime 基础已归档；阶段 5 进行中，Task 0-2 已完成，Task 2 已通过验收 | Task 3 保持 Planned，尚未开始 |
+| 当前阶段 | 阶段 4 Agent Runtime 基础已归档；阶段 5 进行中，Task 0-2 已完成；Task 3 已实现、待验收，尚未标记 Completed | 下一步由 GPT / 用户验收 Task 3；Task 4 保持 Planned |
 | 文档结构 | docs 已重组为 `roadmap`、`tasks`、`research`、`work-log` 四类入口；当前任务以 `docs/tasks/README.md` 为准 | 后续 commit 按 task docs 和 work-log 分工更新 |
 | 任务规范 | 新任务使用 TDD 风格模板；已完成阶段保留在 `docs/tasks/completed/`，当前任务目录只保留可执行阶段入口 | 后续任务继续按 Red / Green / Refactor 推进 |
 | Codex 研究 | 已基于本地 Codex fork 与当前 Agent 源码重建 `docs/research/`：形成架构报告、学习清单、云端映射和 14 个分阶段学习目录 | 作为阶段 5 及后续任务的研究依据；真实执行状态仍以 `docs/tasks/` 为准 |
@@ -16,6 +16,7 @@
 
 | 日期 | 提交 | 类型 | 核心完成 | 关键文件 | 验证结果 |
 | --- | --- | --- | --- | --- | --- |
+| 2026-07-15 | Issue #9 实现 | feat / Tool Calling | 新增第一只只读业务工具 `search_articles`：校验关键词、语言和条数后查询 `Article`，返回总数、受控文章字段、截断 excerpt 与可供后续 Observation 使用的 `modelContent`；显式注册到 `ToolsModule`，未接 Runtime Tool Loop；Task 3 只记录已实现、待验收 | `apps/api/src/tools/search-articles.tool.ts`、对应测试、`apps/api/src/tools/tools.module.ts`、阶段 5 状态文档 | 17 个 tools 测试、12 个 model stream 回归、API typecheck/lint、workspace typecheck、`git diff --check` 通过 |
 | 2026-07-12 | PR #2 验收收口 | docs / Tool Calling | GPT 与用户确认 Issue #1 验收通过；Task 2 标记为 Completed，阶段 5 保持 In Progress，Task 3 保持 Planned；记录 Abort 前后检查、低风险 fail-closed 修复，以及 `timeoutMs` 仅保留 metadata、超时执行逻辑留待后续的范围裁定 | `docs/tasks/phase-05-tool-calling/README.md`、`docs/tasks/README.md`、`docs/roadmap.md`、`docs/work-log.md` | docs 结构与状态一致性检查、`git diff --check` 通过 |
 | 2026-07-12 | 9825394、a6bc873 / Draft PR #2 | feat / Tool Calling | 完成 Issue #1 的最小 Tool Contract、Registry、参数验证、统一执行结果和 provider-neutral `ModelToolSpec` 映射；Review 后补齐 Abort 前后检查与低风险 fail-closed；实施状态已实现，验收状态已通过 | `apps/api/src/tools/**`、`apps/api/src/llm/model-tool-spec.types.ts`、`apps/api/src/app.module.ts`、`apps/api/package.json`、`docs/tasks/phase-05-tool-calling/README.md` | 13 个 tools 测试、12 个 model stream 回归、API typecheck/lint、workspace typecheck、`git diff --check` 通过；全仓 lint 仍被既有 research Markdown 的 97 个错误阻断 |
 | 2026-07-11 | feat: 实现结构化模型流事件 | feat / Tool Calling | 完成阶段 5 Task 1：新增 provider-neutral `ModelStreamEvent`、OpenAI-compatible stream adapter 与 Tool Call 分片累积器；LLM stream 支持 text/tool/usage/completed，Runtime 对 Tool Call 临时 fail-fast，前端协议保持不变；补充 Node 原生最小回归测试 | `apps/api/src/llm/model-stream.types.ts`、`apps/api/src/llm/clients/openai-compatible-*.ts`、`apps/api/src/agent-runtime/agent-runtime.{errors,service}.ts`、对应测试文件、`apps/api/package.json` | 12 个模型流与 Runtime 测试通过；API lint、workspace typecheck、`git diff --check` 通过；全仓 lint 被既有 research Markdown 的 97 个错误阻断 |


### PR DESCRIPTION
Closes #9

## 改动摘要

- 新增正式只读工具 `search_articles`，复用现有 `ToolDefinition`、`ToolInputContract`、`ToolRegistryService`、`ToolInvocationService`、`ToolExecutor` 与 `ToolResult` 边界。
- 校验并规范化 `query`、`languageCode`、`limit`；`limit` 默认 5，范围 1-10。
- 只读查询 `Article`，返回 `total` 与稳定排序的精简结果；文章字段仅包含 `sourceId`、`slug`、`languageCode`、`title`、`seoTitle`、`seoDescription`、截断后的 `excerpt`，不返回完整 `content`。
- 为有结果和无结果场景生成可供后续 Observation 使用的受控 `modelContent`。
- `ToolsModule` 引入 `PrismaModule` 并显式注册 `search_articles`。
- `test:tools` 新增 Registry、模型 spec、参数校验、查询参数、精简输出、无结果和风险边界覆盖。

## 明确未做

- 未接入 `AgentRuntimeService` Tool Loop。
- 未实现 Observation 回填，未发起第二轮 sampling。
- 未记录 tool call / tool result 到 `AgentStep`。
- 未修改前端 `ChatStreamEvent` 协议。
- 未新增 `list_articles`、`count_articles`、`get_article_detail`。
- 未实现 RAG、embedding、向量数据库、MCP、多 Agent 或 Human-in-the-loop。
- 未推进 Task 4，未归档阶段 5。

## 验证结果

以下命令均通过：

- `pnpm --filter @agent/api test:tools`：17/17 通过。
- `pnpm --filter @agent/api test:model-stream`：12/12 通过。
- `pnpm --filter @agent/api typecheck`：通过。
- `pnpm --filter @agent/api lint`：通过。
- `pnpm typecheck`：通过。
- `git diff --check`：通过。

## 文档状态

Task 3 仅记录为：

- 实施状态：已实现
- 验收状态：待验收

Task 3 未标记 Completed；Task 4 保持 Planned。

## 建议阅读顺序与调用链

1. `apps/api/src/tools/search-articles.tool.ts`
2. `apps/api/src/tools/tools.module.ts`
3. `apps/api/src/tools/search-articles.tool.test.ts`
4. `docs/tasks/phase-05-tool-calling/README.md`

调用链：`ToolRegistryService` 查找定义 -> `ToolInvocationService` 解析并校验参数 -> `SearchArticlesTool` 只读查询 Prisma -> 返回受控 `ToolResult.data` 与 `modelContent`。

## 下一步

交由 GPT / 用户进行代码与学习验收；本 PR 不自行标记 Completed，不自行合并。