### PR TITLE
docs: 收口阶段 5 Task 5 验收状态

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -4,7 +4,7 @@
 
 ## 当前判断
 
-项目已经完成从固定字段 SEO 生成器到 Session Chat 的迁移，并完成流式输出最终态一致性收口。阶段 4 Agent Runtime 基础已归档；阶段 5 继续进行，Task 0-4 已完成并通过验收，Task 5 的 Tool Calling 可靠性与 `AgentStep` 运行记录已实现、待验收。当前不推进阶段 5 Completed、Issue #14、RAG 或多 Agent。
+项目已经完成从固定字段 SEO 生成器到 Session Chat 的迁移，并完成流式输出最终态一致性收口。阶段 4 Agent Runtime 基础已归档；阶段 5 的 Task 0-5 已完成并通过验收，Tool Calling 可靠性与 `AgentStep` 运行记录已随 PR #15 合并到 `master`。阶段 5 暂不归档，下一步先完成 Issue #14，统一同步与流式 SEO Chat 的 Agent Runtime 路径；当前不推进 RAG 或多 Agent。
 
 ## 阶段路线
 
@@ -23,7 +23,7 @@
 
 | 优先级 | 任务 | 说明 |
 | --- | --- | --- |
-| P0 | 阶段 5 Task 5（已实现、待验收） | 验收动态 Step、sampling / tool 安全摘要、timeout / abort 与现有前端 stream 协议兼容性；验收前不标记 Completed |
+| P0 | Issue #14：统一同步与流式 SEO Chat Runtime | 移除同步 `/seo/chat` 绕过 Agent Runtime 的旁路，让两个入口共享 Message、Run、Step 和 Tool Loop 语义；通过验收后归档阶段 5 |
 | P1 | Context 管理增强 | 阶段 5 稳定后再加入页面数据、关键词、工具 Observation 和预算规则 |
 | P2 | 阶段 6 Human-in-the-loop | 有中风险或写操作工具前，再实现用户确认与审批接口 |
 
@@ -31,10 +31,10 @@
 
 | 暂不做 | 原因 |
 | --- | --- |
-| 复杂 Tool Calling | 阶段 5 先做最小只读工具闭环 |
+| 复杂 Tool Calling | 阶段 5 仍以最小只读工具闭环和执行路径统一为收口范围 |
 | RAG / 向量数据库 | 当前主线是 Agent Runtime，不是知识库问答 |
-| Multi-agent | 单 Agent run/step/tool loop 还没稳定 |
-| MCP / 插件系统 | 先把内置工具闭环跑通 |
+| Multi-agent | 单 Agent baseline 刚完成可靠性收口，尚无产品必要性 |
+| MCP / 插件系统 | 先把内置工具与统一 Runtime 路径稳定下来 |
 | OS sandbox | 当前不执行 shell，不需要 Codex 级 sandbox |
 | Workflow engine | 目前用 TypeScript service 编排更适合学习 |
 | WebSocket 多路复用 | NDJSON 已能满足当前流式任务 |

--- a/docs/tasks/README.md
+++ b/docs/tasks/README.md
@@ -6,7 +6,7 @@
 
 | 区域 | 状态 | 文档 | 说明 |
 | --- | --- | --- | --- |
-| 阶段 5 最小 Tool Calling | In Progress | [phase-05-tool-calling/README.md](./phase-05-tool-calling/README.md) | Task 0-4 已完成并通过验收；Task 5 已实现、待验收，未标记为 Completed |
+| 阶段 5 最小 Tool Calling | In Progress | [phase-05-tool-calling/README.md](./phase-05-tool-calling/README.md) | Task 0-5 已完成并通过验收；PR #15 已合并，下一步处理 Issue #14，阶段尚未归档 |
 | 阶段 4 Agent Runtime | Completed | [completed/phase-04-agent-runtime.md](./completed/phase-04-agent-runtime.md) | 已归档为可观测 Agent Run 的基础阶段 |
 | 阶段 3 收口 | Completed | [completed/phase-03-streaming-closeout.md](./completed/phase-03-streaming-closeout.md) | 已收口 `done/error/aborted` 最终态一致性 |
 | 阶段 2 | Completed | [completed/phase-02-agent-chat-session.md](./completed/phase-02-agent-chat-session.md) | 多会话和消息持久化已完成 |

--- a/docs/tasks/phase-05-tool-calling/README.md
+++ b/docs/tasks/phase-05-tool-calling/README.md
@@ -1,6 +1,6 @@
 # 阶段 5：最小 Tool Calling
 
-状态：进行中。Task 0-4 已完成并通过验收；Task 5 已实现、待验收，阶段 5 尚未完成或归档。
+状态：进行中。Task 0-5 已完成并通过验收；PR #15 已合并到 `master`，阶段 5 尚未归档，下一步处理 Issue #14 的同步 / 流式 Runtime 路径统一。
 
 ## 阶段目标
 
@@ -43,7 +43,7 @@
 | Task 2 | Completed | 定义最小 `ToolDefinition`、`ToolRegistry`、参数验证、执行与结果边界 |
 | Task 3 | Completed | 实现第一只只读工具 `search_articles`，查询并返回精简文章信息 |
 | Task 4 | Completed | 实现单 Agent Tool Loop：模型请求工具、后端执行、Observation 回填、模型继续生成最终回答 |
-| Task 5 | 已实现 / 待验收 | 将模型调用、工具执行和工具结果记录到 `AgentStep`，保持当前前端 stream 协议稳定 |
+| Task 5 | Completed | 将模型调用、工具执行和工具结果记录到 `AgentStep`，保持当前前端 stream 协议稳定 |
 
 ## Task 1 完成结果
 
@@ -92,7 +92,7 @@
 - GPT 结合 Issue #11、PR #12 diff、Codex Review、测试结果和前端手工反馈完成验收；用户授权后 PR #12 已合并到 `master`，merge commit `390d8497`。
 - 实施状态：已实现；验收状态：已通过；任务状态：Completed。Task 5 保持 Planned。
 
-## Task 5 实现结果
+## Task 5 完成结果
 
 - `AgentStep` 新增同一 Run 内从 1 开始的 `sequence`，migration 先按 `runId` 分组、按 `createdAt` 和 `id` 稳定回填旧数据，再设置 `NOT NULL` 与唯一约束。
 - `AgentRunRecorderService` 改为在真实执行时动态创建 `RUNNING` Step，并通过真实 `stepId` 和带非终态条件的更新完成 terminal transition；重复收口或迟到更新会抛出 invariant error。
@@ -104,7 +104,8 @@
 - Runtime 已按真实顺序形成普通回答的 `receive -> history -> sampling#1 -> assistant`，以及 Tool Loop 的 `receive -> history -> sampling#1 -> tool -> sampling#2 -> assistant`；工具安全失败 Step 可为 `FAILED`，Run 仍可经第二轮解释后 `COMPLETED`。
 - `ChatStreamEvent` 继续只有 `start / delta / done / error / aborted`；未新增前端时间线，未暴露 Tool Call、Tool Result、raw arguments 或 `AgentStep`，用户可见 Message 仍只保存最终回答。
 - Red 阶段分别复现 Recorder、sampling、timeout / abort、Runtime 记录与迟到 terminal CAS 缺口；Green / Refactor 后 Recorder 9 个、Tool Loop 19 个、Model Stream 34 个、Tools 24 个自动化用例均通过。真实普通回答、正常 Tool Loop、零结果和停止生成场景已验证，临时会话数据已清理；工具 timeout 使用测试专用永不结束 Executor 验证。
-- 实施状态：已实现；验收状态：待验收。Task 5 未标记为 Completed，阶段 5 保持进行中，未处理 Issue #14。
+- GPT 结合 Issue #13、PR #15 diff、Codex Review、自动化测试和真实模型 / 数据库验证证据完成验收；用户明确确认后，PR #15 已合并到 `master`，merge commit `f6985627`，Issue #13 已关闭。
+- 实施状态：已实现；验收状态：已通过；任务状态：Completed。阶段 5 保持进行中，下一步处理 Issue #14，尚未归档。
 
 ### Task 4 手工验收问题
 
@@ -134,7 +135,7 @@
 
 ## 本阶段不做
 
-- 不建设完整自动化测试体系；Task 1 只保留关键模型流和 Runtime 回归测试，其余使用固定场景手工验证。
+- 不建设全仓端到端测试或 CI 体系；保留 Agent Runtime、Tool Loop、模型流和 Tool 边界的关键回归测试与固定场景手工验证。
 - 不做写操作工具。
 - 不做用户审批和 Human-in-the-loop。
 - 不做复杂权限策略。
@@ -158,4 +159,4 @@
 
 ## 后续阶段
 
-阶段 5 稳定后，进入阶段 6：Human-in-the-loop。
+先完成 Issue #14，统一同步与流式 SEO Chat 的 Agent Runtime 路径；该收口通过验收后，再归档阶段 5 并进入阶段 6：Human-in-the-loop。

--- a/docs/work-log.md
+++ b/docs/work-log.md
@@ -6,7 +6,7 @@
 
 | 类型 | 当前记录 | 下一步 |
 | --- | --- | --- |
-| 当前阶段 | 阶段 4 Agent Runtime 基础已归档；阶段 5 进行中，Task 0-4 已完成并通过验收；Task 5 已实现、待验收 | 等待 GPT 和用户验收 Issue #13；不提前推进 Task 5 / 阶段 5 Completed 或 Issue #14 |
+| 当前阶段 | 阶段 4 Agent Runtime 基础已归档；阶段 5 进行中，Task 0-5 已完成并通过验收；PR #15 已合并到 `master` | 下一步处理 Issue #14，统一同步与流式 SEO Chat 的 Agent Runtime 路径；通过验收后再归档阶段 5 |
 | 文档结构 | docs 已重组为 `roadmap`、`tasks`、`research`、`work-log` 四类入口；当前任务以 `docs/tasks/README.md` 为准 | 后续 commit 按 task docs 和 work-log 分工更新 |
 | 任务规范 | 新任务使用 TDD 风格模板；已完成阶段保留在 `docs/tasks/completed/`，当前任务目录只保留可执行阶段入口 | 后续任务继续按 Red / Green / Refactor 推进 |
 | Codex 研究 | 已基于本地 Codex fork 与当前 Agent 源码重建 `docs/research/`：形成架构报告、学习清单、云端映射和 14 个分阶段学习目录 | 作为阶段 5 及后续任务的研究依据；真实执行状态仍以 `docs/tasks/` 为准 |
@@ -16,6 +16,7 @@
 
 | 日期 | 提交 | 类型 | 核心完成 | 关键文件 | 验证结果 |
 | --- | --- | --- | --- | --- | --- |
+| 2026-07-17 | PR #15 验收合并收口 | docs / Tool Calling | GPT 验收 Issue #13 / PR #15 通过，用户明确确认后合并到 `master`；Task 5 标记为 Completed，动态 AgentStep、两轮 sampling 记录、工具安全摘要、真实 timeout 和 Observation 上限进入主分支；阶段 5 保持 In Progress，下一步处理 Issue #14 | `docs/tasks/phase-05-tool-calling/README.md`、`docs/tasks/README.md`、`docs/roadmap.md`、`docs/work-log.md` | 基于 PR #15 验证结果：9 个 Recorder、19 个 Tool Loop、34 个 Model Stream、24 个 Tools 测试通过；Prisma migration、API typecheck/lint、Web typecheck/build、workspace typecheck、`git diff --check` 通过；Codex Review 无 major issues；merge commit `f6985627` |
 | 2026-07-17 | Issue #13 实现 | feat / Agent Runtime / Tool Calling | 为 `AgentStep` 增加稳定 sequence migration；Recorder 改为动态 step-id 状态机；分别记录两轮 sampling 的 usage / finish reason 和工具 allowlist 摘要；实现真实 tool deadline、user abort 优先级、8,000 字符 Observation 上限及迟到结果隔离；保持前端五类 stream 事件不变；Task 5 仅更新为已实现、待验收 | `prisma/schema.prisma`、`prisma/migrations/20260717160000_add_agent_step_sequence/`、`packages/contracts/src/agent-run.ts`、`apps/api/src/agent-runtime/**`、`apps/api/src/tools/**`、阶段 5 状态文档 | Prisma generate / validate / migrate deploy / status 通过；9 个 Recorder、19 个 Tool Loop、34 个 Model Stream、24 个 Tools 测试通过；API typecheck/lint、Web typecheck/build、workspace typecheck、`git diff --check` 通过；真实普通回答、Tool Loop、零结果与 abort 场景通过，timeout 使用永不结束 fake Executor 验证 |
 | 2026-07-16 | PR #12 验收合并收口 | docs / Tool Calling | GPT 验收 Issue #11 / PR #12 通过，用户授权后合并到 `master`；Task 4 标记为 Completed，阶段 5 保持 In Progress，Task 5 保持 Planned；单 Agent Tool Loop 已进入主分支 | `docs/tasks/phase-05-tool-calling/README.md`、`docs/tasks/README.md`、`docs/roadmap.md`、`docs/work-log.md` | 基于 PR #12 验证结果：14 个 tool loop、22 个 model stream、17 个 tools 测试通过；API typecheck/lint、workspace typecheck、`git diff --check` 通过；Codex Review 复审无 major issues；merge commit `390d8497` |
 | 2026-07-16 | PR #12 手工验收修复 | fix / Agent Runtime / Tool Calling | 修复普通回答与工具后第二轮回答等待完整 sampling 后回放的问题，改为在 `response_completed` 前实时产出 delta；SEO Agent 增加 `search_articles` 的关键词查询、Observation、能力询问不执行工具和零结果不编造说明；手工验收问题改为基于真实 Article seed | `apps/api/src/agent-runtime/**`、`apps/api/src/seo/prompts/seo-agent.prompt.ts`、阶段 5 任务文档 | Red 测试复现 2 个时序失败和 1 个 prompt 边界失败；Green 阶段 14 个 tool loop、22 个 model stream、17 个 tools 测试通过；API typecheck/lint、workspace typecheck、`git diff --check` 通过；真实 DeepSeek 流验证能力询问无 Tool Call 错误、SP Himeko 返回 1 篇并实时输出 |


### PR DESCRIPTION
## 变更摘要

- 将阶段 5 Task 5 从“已实现、待验收”更新为 `Completed`。
- 记录 GPT 已结合 Issue #13、PR #15 diff、Codex Review、自动化与真实模型 / 数据库验证完成验收。
- 记录用户明确确认后 PR #15 已合并到 `master`，merge commit 为 `f6985627`，Issue #13 已关闭。
- 更新任务看板、路线图和 work-log，将当前 P0 切换到 Issue #14。
- 阶段 5 仍保持 `In Progress`，不提前归档；未推进阶段 6。

## 影响范围

仅修改：

- `docs/tasks/phase-05-tool-calling/README.md`
- `docs/tasks/README.md`
- `docs/roadmap.md`
- `docs/work-log.md`

## 验证

- GitHub compare：相对 `master@f6985627` 仅修改上述 4 个 Markdown 文件。
- 文档状态保持一致：Task 5 Completed；阶段 5 In Progress；下一步 Issue #14。

用户已明确授权将本次状态收口更新到 `master`。