### PR TITLE
[Phase 5 Closeout Fix] 统一同步与流式 SEO Chat Runtime

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -11,6 +11,7 @@
     "start": "node dist/main.js",
     "test:agent-recorder": "tsx --test src/agent-runtime/agent-run-recorder.service.test.ts",
     "test:model-stream": "tsx --test src/llm/clients/openai-compatible-stream.adapter.test.ts src/agent-runtime/agent-runtime.service.test.ts src/agent-runtime/model-sampling-decision.test.ts",
+    "test:seo-service": "tsx --test src/seo/seo.service.test.ts",
     "test:tool-loop": "tsx --test src/agent-runtime/agent-runtime.service.test.ts",
     "test:tools": "tsx --test src/tools/**/*.test.ts",
     "pretypecheck": "pnpm --workspace-root prisma:generate",

--- a/apps/api/src/agent-runtime/agent-runtime.service.test.ts
+++ b/apps/api/src/agent-runtime/agent-runtime.service.test.ts
@@ -94,6 +94,24 @@ describe('AgentRuntimeService model stream', () => {
     assertNoUnfinishedSteps(harness)
   })
 
+  it('会话不存在时产出稳定失败分类且不创建 Message 或 Run', async () => {
+    const harness = createHarness(() => toModelStream([]))
+
+    harness.prisma.conversationExists = false
+
+    const events = await collectEvents(harness.run())
+
+    assert.deepEqual(events, [{
+      type: 'run_failed',
+      conversationId: 'conversation-1',
+      failureReason: 'conversation_not_found',
+      message: '会话不存在或已被删除',
+    }])
+    assert.equal(harness.prisma.messages.length, 0)
+    assert.equal(harness.recorder.steps.length, 0)
+    assert.equal(harness.llmCalls.length, 0)
+  })
+
   it('在 response_completed 前实时产出普通回答 delta', async () => {
     const completionGate = createDeferred()
     const harness = createHarness(() => delayedCompletionModelStream(
@@ -825,6 +843,7 @@ function createHarness(
 
   return {
     llmCalls,
+    prisma,
     recorder,
     toolInvocations: toolInvocationService.invocations,
     toolExecutionContexts: toolInvocationService.contexts,
@@ -867,9 +886,12 @@ class FakeToolInvocationService {
 
 class FakePrismaService {
   readonly messages: Message[] = []
+  conversationExists = true
 
   readonly conversation = {
-    findUnique: async () => ({ id: 'conversation-1' }),
+    findUnique: async () => this.conversationExists
+      ? { id: 'conversation-1' }
+      : null,
     update: async () => ({ id: 'conversation-1' }),
   }
 

--- a/apps/api/src/agent-runtime/agent-runtime.service.ts
+++ b/apps/api/src/agent-runtime/agent-runtime.service.ts
@@ -414,6 +414,9 @@ export class AgentRuntimeService {
         ...(agentRunId ? { runId: agentRunId } : {}),
         conversationId: input.conversationId,
         ...(assistantMessage ? { assistantMessageId: assistantMessage.id } : {}),
+        ...(error instanceof NotFoundException
+          ? { failureReason: 'conversation_not_found' as const }
+          : {}),
         message: errorMessage,
       }
     }

--- a/apps/api/src/agent-runtime/agent-runtime.types.ts
+++ b/apps/api/src/agent-runtime/agent-runtime.types.ts
@@ -37,6 +37,7 @@ export interface AgentRuntimeRunFailedEvent {
   runId?: string
   conversationId: string
   assistantMessageId?: string
+  failureReason?: 'conversation_not_found'
   message: string
 }
 

--- a/apps/api/src/seo/seo.module.ts
+++ b/apps/api/src/seo/seo.module.ts
@@ -1,13 +1,12 @@
 import { Module } from '@nestjs/common'
 
 import { AgentRuntimeModule } from '../agent-runtime/agent-runtime.module.js'
-import { PrismaModule } from '../prisma/prisma.module.js'
 import { SeoContextBuilder } from './seo-context-builder.service.js'
 import { SeoController } from './seo.controller.js'
 import { SeoService } from './seo.service.js'
 
 @Module({
-  imports: [AgentRuntimeModule, PrismaModule],
+  imports: [AgentRuntimeModule],
   controllers: [SeoController],
   providers: [SeoContextBuilder, SeoService],
 })

--- a/apps/api/src/seo/seo.service.test.ts
+++ b/apps/api/src/seo/seo.service.test.ts
@@ -1,6 +1,7 @@
 import type { AgentRuntimeService } from '../agent-runtime/agent-runtime.service.js'
 import type {
   AgentRuntimeEvent,
+  AgentRuntimeRunFailedEvent,
   RunTurnStreamInput,
 } from '../agent-runtime/agent-runtime.types.js'
 import type { ChatMessage } from '../llm/llm.types.js'
@@ -12,6 +13,7 @@ import { describe, it } from 'node:test'
 import {
   HttpStatus,
   InternalServerErrorException,
+  NotFoundException,
   RequestTimeoutException,
   ServiceUnavailableException,
 } from '@nestjs/common'
@@ -60,6 +62,23 @@ describe('SeoService', () => {
         assert.ok(error instanceof ServiceUnavailableException)
         assert.equal(error.getStatus(), HttpStatus.SERVICE_UNAVAILABLE)
         assert.equal(error.message, '模型服务暂时没有返回结果，请稍后重试。')
+        assert.doesNotMatch(JSON.stringify(error.getResponse()), /provider|password|secret/)
+        return true
+      },
+    )
+  })
+
+  it('conversation_not_found 映射为固定 404，不伪装成模型故障', async () => {
+    const harness = createHarness([
+      runFailedEvent('provider password=secret', 'conversation_not_found'),
+    ])
+
+    await assert.rejects(
+      harness.service.chat(createInput()),
+      (error: unknown) => {
+        assert.ok(error instanceof NotFoundException)
+        assert.equal(error.getStatus(), HttpStatus.NOT_FOUND)
+        assert.equal(error.message, '会话不存在或已被删除')
         assert.doesNotMatch(JSON.stringify(error.getResponse()), /provider|password|secret/)
         return true
       },
@@ -149,7 +168,7 @@ describe('SeoService', () => {
       runStartedEvent(),
       assistantDeltaEvent('增量'),
       runCompletedEvent('最终回答'),
-      runFailedEvent('安全错误'),
+      runFailedEvent('安全错误', 'conversation_not_found'),
       runAbortedEvent('部分回答'),
     ])
 
@@ -190,7 +209,7 @@ describe('SeoService', () => {
     ])
     assert.doesNotMatch(
       JSON.stringify(events),
-      /runId|AgentStep|ToolResult|rawArgumentsJson/,
+      /runId|failureReason|conversation_not_found|AgentStep|ToolResult|rawArgumentsJson/,
     )
   })
 })
@@ -294,12 +313,16 @@ function runCompletedEvent(content: string): AgentRuntimeEvent {
   }
 }
 
-function runFailedEvent(message: string): AgentRuntimeEvent {
+function runFailedEvent(
+  message: string,
+  failureReason?: AgentRuntimeRunFailedEvent['failureReason'],
+): AgentRuntimeRunFailedEvent {
   return {
     type: 'run_failed',
     runId: 'run-1',
     conversationId: 'conversation-1',
     assistantMessageId: 'assistant-message-1',
+    ...(failureReason ? { failureReason } : {}),
     message,
   }
 }

--- a/apps/api/src/seo/seo.service.test.ts
+++ b/apps/api/src/seo/seo.service.test.ts
@@ -1,0 +1,315 @@
+import type { AgentRuntimeService } from '../agent-runtime/agent-runtime.service.js'
+import type {
+  AgentRuntimeEvent,
+  RunTurnStreamInput,
+} from '../agent-runtime/agent-runtime.types.js'
+import type { ChatMessage } from '../llm/llm.types.js'
+import type { SeoContextBuilder } from './seo-context-builder.service.js'
+import assert from 'node:assert/strict'
+// 项目使用 Node 原生测试运行器，不引入新测试框架。
+// eslint-disable-next-line test/no-import-node-test
+import { describe, it } from 'node:test'
+import {
+  HttpStatus,
+  InternalServerErrorException,
+  RequestTimeoutException,
+  ServiceUnavailableException,
+} from '@nestjs/common'
+
+import { SeoService } from './seo.service.js'
+
+const GENERATED_AT = '2026-07-18T08:00:00.000Z'
+
+describe('SeoService', () => {
+  it('非流式入口忽略过程事件，只投影 run_completed 终态', async () => {
+    const harness = createHarness([
+      runStartedEvent(),
+      assistantDeltaEvent('不应作为最终答案'),
+      runCompletedEvent('最终回答'),
+    ])
+
+    const result = await harness.service.chat(createInput())
+
+    assert.deepEqual(result, {
+      reply: '最终回答',
+      generatedAt: GENERATED_AT,
+    })
+    assert.equal(harness.runtime.inputs.length, 1)
+  })
+
+  it('非流式 Tool Loop 只使用 Runtime 的最终回答，不拼接 delta 或工具数据', async () => {
+    const harness = createHarness([
+      runStartedEvent(),
+      assistantDeltaEvent('{"rawArgumentsJson":"secret"}'),
+      assistantDeltaEvent('{"ToolResult":{"data":"article-json"}}'),
+      runCompletedEvent('找到 1 篇相关文章。'),
+    ])
+
+    const result = await harness.service.chat(createInput())
+
+    assert.equal(result.reply, '找到 1 篇相关文章。')
+    assert.doesNotMatch(result.reply, /rawArgumentsJson|ToolResult|article-json|secret/)
+  })
+
+  it('run_failed 映射为稳定的安全 HTTP 异常', async () => {
+    const harness = createHarness([runFailedEvent('provider password=secret')])
+
+    await assert.rejects(
+      harness.service.chat(createInput()),
+      (error: unknown) => {
+        assert.ok(error instanceof ServiceUnavailableException)
+        assert.equal(error.getStatus(), HttpStatus.SERVICE_UNAVAILABLE)
+        assert.equal(error.message, '模型服务暂时没有返回结果，请稍后重试。')
+        assert.doesNotMatch(JSON.stringify(error.getResponse()), /provider|password|secret/)
+        return true
+      },
+    )
+  })
+
+  it('run_aborted 映射为失败，不返回 SeoChatResponse 伪成功', async () => {
+    const harness = createHarness([runAbortedEvent('部分回答')])
+
+    await assert.rejects(
+      harness.service.chat(createInput()),
+      (error: unknown) => {
+        assert.ok(error instanceof RequestTimeoutException)
+        assert.equal(error.getStatus(), HttpStatus.REQUEST_TIMEOUT)
+        assert.equal(error.message, '请求已中止，请重新发起。')
+        assert.doesNotMatch(JSON.stringify(error.getResponse()), /部分回答/)
+        return true
+      },
+    )
+  })
+
+  it('Runtime generator 无 terminal 时明确失败', async () => {
+    const harness = createHarness([
+      runStartedEvent(),
+      assistantDeltaEvent('未完成'),
+    ])
+
+    await assert.rejects(
+      harness.service.chat(createInput()),
+      (error: unknown) => {
+        assert.ok(error instanceof InternalServerErrorException)
+        assert.equal(error.getStatus(), HttpStatus.INTERNAL_SERVER_ERROR)
+        assert.equal(error.message, '请求未能完成，请稍后重试。')
+        assert.doesNotMatch(JSON.stringify(error.getResponse()), /未完成/)
+        return true
+      },
+    )
+  })
+
+  it('同步与流式入口共享同一 RunTurnStreamInput 配置，只有流式透传 signal', async () => {
+    const abortController = new AbortController()
+    const harness = createHarness(
+      [runCompletedEvent('同步回答')],
+      [runCompletedEvent('流式回答')],
+    )
+    const input = createInput('deepseek-chat')
+
+    await harness.service.chat(input)
+    await collectEvents(harness.service.chatStream(input, {
+      signal: abortController.signal,
+    }))
+
+    assert.equal(harness.runtime.inputs.length, 2)
+    const [chatInput, streamInput] = harness.runtime.inputs
+
+    assert.ok(chatInput)
+    assert.ok(streamInput)
+    assert.deepEqual(withoutFunctionsAndSignal(chatInput), {
+      conversationId: 'conversation-1',
+      userContent: '用户问题',
+      model: 'deepseek-chat',
+      historyLimit: 12,
+      temperature: 0.4,
+      maxTokens: 1200,
+    })
+    assert.deepEqual(
+      withoutFunctionsAndSignal(streamInput),
+      withoutFunctionsAndSignal(chatInput),
+    )
+    assert.equal(Object.hasOwn(chatInput, 'signal'), false)
+    assert.equal(streamInput.signal, abortController.signal)
+
+    const historyMessages: ChatMessage[] = [{ role: 'user', content: '历史消息' }]
+
+    assert.deepEqual(
+      chatInput.buildModelMessages(historyMessages),
+      streamInput.buildModelMessages(historyMessages),
+    )
+    assert.deepEqual(harness.contextBuilder.historyCalls, [
+      historyMessages,
+      historyMessages,
+    ])
+  })
+
+  it('流式入口保持既有五类 ChatStreamEvent 且不暴露 Runtime 字段', async () => {
+    const harness = createHarness([
+      runStartedEvent(),
+      assistantDeltaEvent('增量'),
+      runCompletedEvent('最终回答'),
+      runFailedEvent('安全错误'),
+      runAbortedEvent('部分回答'),
+    ])
+
+    const events = await collectEvents(harness.service.chatStream(createInput()))
+
+    assert.deepEqual(events, [
+      {
+        type: 'start',
+        conversationId: 'conversation-1',
+        userMessageId: 'user-message-1',
+        assistantMessageId: 'assistant-message-1',
+      },
+      {
+        type: 'delta',
+        conversationId: 'conversation-1',
+        assistantMessageId: 'assistant-message-1',
+        contentDelta: '增量',
+      },
+      {
+        type: 'done',
+        conversationId: 'conversation-1',
+        assistantMessageId: 'assistant-message-1',
+        content: '最终回答',
+        generatedAt: GENERATED_AT,
+      },
+      {
+        type: 'error',
+        conversationId: 'conversation-1',
+        assistantMessageId: 'assistant-message-1',
+        message: '安全错误',
+      },
+      {
+        type: 'aborted',
+        conversationId: 'conversation-1',
+        assistantMessageId: 'assistant-message-1',
+        content: '部分回答',
+      },
+    ])
+    assert.doesNotMatch(
+      JSON.stringify(events),
+      /runId|AgentStep|ToolResult|rawArgumentsJson/,
+    )
+  })
+})
+
+class FakeAgentRuntimeService {
+  readonly inputs: RunTurnStreamInput[] = []
+  private readonly eventSequences: AgentRuntimeEvent[][]
+
+  constructor(...eventSequences: AgentRuntimeEvent[][]) {
+    this.eventSequences = eventSequences
+  }
+
+  async* runTurnStream(input: RunTurnStreamInput): AsyncGenerator<AgentRuntimeEvent> {
+    this.inputs.push(input)
+
+    for (const event of this.eventSequences.shift() ?? [])
+      yield event
+  }
+}
+
+class FakeSeoContextBuilder {
+  readonly historyCalls: ChatMessage[][] = []
+
+  buildModelMessages(input: { historyMessages: ChatMessage[] }): ChatMessage[] {
+    this.historyCalls.push(input.historyMessages)
+
+    return [
+      { role: 'system', content: 'SEO Agent' },
+      ...input.historyMessages,
+    ]
+  }
+}
+
+function createHarness(...eventSequences: AgentRuntimeEvent[][]) {
+  const runtime = new FakeAgentRuntimeService(...eventSequences)
+  const contextBuilder = new FakeSeoContextBuilder()
+  const service = new SeoService(
+    runtime as unknown as AgentRuntimeService,
+    contextBuilder as unknown as SeoContextBuilder,
+  )
+
+  return { contextBuilder, runtime, service }
+}
+
+function createInput(model?: string) {
+  return {
+    conversationId: 'conversation-1',
+    message: '用户问题',
+    ...(model ? { model } : {}),
+  }
+}
+
+function withoutFunctionsAndSignal(input: RunTurnStreamInput) {
+  return {
+    conversationId: input.conversationId,
+    userContent: input.userContent,
+    ...(input.model ? { model: input.model } : {}),
+    historyLimit: input.historyLimit,
+    temperature: input.temperature,
+    maxTokens: input.maxTokens,
+  }
+}
+
+async function collectEvents<T>(events: AsyncGenerator<T>): Promise<T[]> {
+  const collectedEvents: T[] = []
+
+  for await (const event of events)
+    collectedEvents.push(event)
+
+  return collectedEvents
+}
+
+function runStartedEvent(): AgentRuntimeEvent {
+  return {
+    type: 'run_started',
+    runId: 'run-1',
+    conversationId: 'conversation-1',
+    userMessageId: 'user-message-1',
+    assistantMessageId: 'assistant-message-1',
+  }
+}
+
+function assistantDeltaEvent(contentDelta: string): AgentRuntimeEvent {
+  return {
+    type: 'assistant_delta',
+    runId: 'run-1',
+    conversationId: 'conversation-1',
+    assistantMessageId: 'assistant-message-1',
+    contentDelta,
+  }
+}
+
+function runCompletedEvent(content: string): AgentRuntimeEvent {
+  return {
+    type: 'run_completed',
+    runId: 'run-1',
+    conversationId: 'conversation-1',
+    assistantMessageId: 'assistant-message-1',
+    content,
+    generatedAt: GENERATED_AT,
+  }
+}
+
+function runFailedEvent(message: string): AgentRuntimeEvent {
+  return {
+    type: 'run_failed',
+    runId: 'run-1',
+    conversationId: 'conversation-1',
+    assistantMessageId: 'assistant-message-1',
+    message,
+  }
+}
+
+function runAbortedEvent(content: string): AgentRuntimeEvent {
+  return {
+    type: 'run_aborted',
+    runId: 'run-1',
+    conversationId: 'conversation-1',
+    assistantMessageId: 'assistant-message-1',
+    content,
+  }
+}

--- a/apps/api/src/seo/seo.service.ts
+++ b/apps/api/src/seo/seo.service.ts
@@ -1,17 +1,15 @@
 import type { ChatStreamEvent, SeoChatResponse } from '@agent/contracts'
-import type {
-  Message,
-  MessageRole as PrismaMessageRole,
-  MessageStatus as PrismaMessageStatus,
-} from '../generated/prisma/client.js'
-import type { ChatMessage } from '../llm/llm.types.js'
+import type { RunTurnStreamInput } from '../agent-runtime/agent-runtime.types.js'
 import type { SeoChatDto } from './dto/seo-chat.dto.js'
-import { Inject, Injectable, NotFoundException } from '@nestjs/common'
+import {
+  Inject,
+  Injectable,
+  InternalServerErrorException,
+  RequestTimeoutException,
+  ServiceUnavailableException,
+} from '@nestjs/common'
 
 import { AgentRuntimeService } from '../agent-runtime/agent-runtime.service.js'
-import { MessageRole, MessageStatus } from '../generated/prisma/client.js'
-import { LLMService } from '../llm/llm.service.js'
-import { PrismaService } from '../prisma/prisma.service.js'
 import { toChatStreamEvent } from './seo-chat-stream-event.mapper.js'
 import { SeoContextBuilder } from './seo-context-builder.service.js'
 
@@ -24,12 +22,6 @@ interface SeoChatStreamOptions {
 @Injectable()
 export class SeoService {
   constructor(
-    @Inject(LLMService)
-    private readonly llmService: LLMService,
-
-    @Inject(PrismaService)
-    private readonly prismaService: PrismaService,
-
     @Inject(AgentRuntimeService)
     private readonly agentRuntimeService: AgentRuntimeService,
 
@@ -38,143 +30,61 @@ export class SeoService {
   ) {}
 
   async chat(input: SeoChatDto): Promise<SeoChatResponse> {
-    await this.assertConversationExists(input.conversationId)
-
-    await this.createMessageAndTouchConversation(
-      input.conversationId,
-      MessageRole.USER,
-      input.message.trim(),
+    const runtimeEvents = this.agentRuntimeService.runTurnStream(
+      this.buildRunTurnInput(input),
     )
 
-    const historyMessages = await this.listRecentChatMessages(input.conversationId)
-    const llmMessages = this.seoContextBuilder.buildModelMessages({
-      historyMessages: historyMessages.map(message => this.toLlmMessage(message)),
-    })
+    for await (const event of runtimeEvents) {
+      switch (event.type) {
+        case 'run_completed':
+          return {
+            reply: event.content,
+            generatedAt: event.generatedAt,
+          }
 
-    let reply: string
+        case 'run_failed':
+          throw new ServiceUnavailableException(
+            '模型服务暂时没有返回结果，请稍后重试。',
+          )
 
-    try {
-      reply = await this.llmService.chat(llmMessages, {
-        ...(input.model ? { model: input.model } : {}),
-        temperature: 0.4,
-        maxTokens: 1200,
-      })
-    }
-    catch (error) {
-      await this.createMessageAndTouchConversation(
-        input.conversationId,
-        MessageRole.ASSISTANT,
-        '模型服务暂时没有返回结果，请稍后重试。',
-        MessageStatus.FAILED,
-      )
+        case 'run_aborted':
+          throw new RequestTimeoutException('请求已中止，请重新发起。')
 
-      throw error
+        case 'run_started':
+        case 'assistant_delta':
+          break
+      }
     }
 
-    const assistantMessage = await this.createMessageAndTouchConversation(
-      input.conversationId,
-      MessageRole.ASSISTANT,
-      reply,
-    )
-
-    return {
-      reply,
-      generatedAt: assistantMessage.createdAt.toISOString(),
-    }
+    throw new InternalServerErrorException('请求未能完成，请稍后重试。')
   }
 
   async* chatStream(
     input: SeoChatDto,
     options: SeoChatStreamOptions = {},
   ): AsyncGenerator<ChatStreamEvent> {
-    const runtimeEvents = this.agentRuntimeService.runTurnStream({
+    const runtimeEvents = this.agentRuntimeService.runTurnStream(
+      this.buildRunTurnInput(input, options.signal),
+    )
+
+    for await (const event of runtimeEvents)
+      yield toChatStreamEvent(event)
+  }
+
+  private buildRunTurnInput(
+    input: SeoChatDto,
+    signal?: AbortSignal,
+  ): RunTurnStreamInput {
+    return {
       conversationId: input.conversationId,
       userContent: input.message,
       ...(input.model ? { model: input.model } : {}),
-      ...(options.signal ? { signal: options.signal } : {}),
+      ...(signal ? { signal } : {}),
       historyLimit: CHAT_HISTORY_LIMIT,
       temperature: 0.4,
       maxTokens: 1200,
       buildModelMessages: historyMessages =>
         this.seoContextBuilder.buildModelMessages({ historyMessages }),
-    })
-
-    for await (const event of runtimeEvents) {
-      yield toChatStreamEvent(event)
-    }
-  }
-
-  private async listRecentChatMessages(conversationId: string): Promise<Message[]> {
-    const messages = await this.prismaService.message.findMany({
-      where: {
-        conversationId,
-      },
-      orderBy: {
-        createdAt: 'desc',
-      },
-      take: CHAT_HISTORY_LIMIT,
-    })
-
-    return messages.reverse()
-  }
-
-  private async createMessageAndTouchConversation(
-    conversationId: string,
-    role: PrismaMessageRole,
-    content: string,
-    status: PrismaMessageStatus = MessageStatus.COMPLETED,
-  ): Promise<Message> {
-    return this.prismaService.$transaction(async (prisma) => {
-      const message = await prisma.message.create({
-        data: {
-          conversationId,
-          role,
-          content,
-          status,
-        },
-      })
-
-      await prisma.conversation.update({
-        where: {
-          id: conversationId,
-        },
-        data: {
-          updatedAt: new Date(),
-        },
-      })
-
-      return message
-    })
-  }
-
-  private toLlmMessage(message: Message): ChatMessage {
-    return {
-      role: this.toLlmRole(message.role),
-      content: message.content,
-    }
-  }
-
-  private toLlmRole(role: PrismaMessageRole): ChatMessage['role'] {
-    switch (role) {
-      case MessageRole.USER:
-        return 'user'
-      case MessageRole.ASSISTANT:
-        return 'assistant'
-    }
-  }
-
-  private async assertConversationExists(conversationId: string): Promise<void> {
-    const conversation = await this.prismaService.conversation.findUnique({
-      where: {
-        id: conversationId,
-      },
-      select: {
-        id: true,
-      },
-    })
-
-    if (!conversation) {
-      throw new NotFoundException('会话不存在或已被删除')
     }
   }
 }

--- a/apps/api/src/seo/seo.service.ts
+++ b/apps/api/src/seo/seo.service.ts
@@ -5,6 +5,7 @@ import {
   Inject,
   Injectable,
   InternalServerErrorException,
+  NotFoundException,
   RequestTimeoutException,
   ServiceUnavailableException,
 } from '@nestjs/common'
@@ -43,6 +44,10 @@ export class SeoService {
           }
 
         case 'run_failed':
+          if (event.failureReason === 'conversation_not_found') {
+            throw new NotFoundException('会话不存在或已被删除')
+          }
+
           throw new ServiceUnavailableException(
             '模型服务暂时没有返回结果，请稍后重试。',
           )

--- a/apps/web/src/api/seo.ts
+++ b/apps/web/src/api/seo.ts
@@ -2,19 +2,10 @@ import type {
   ApiErrorResponse,
   ChatStreamEvent,
   SeoChatRequest,
-  SeoChatResponse,
 } from '@agent/contracts'
-
-import { http } from './http'
 
 interface StreamChatWithSeoAgentOptions {
   signal?: AbortSignal
-}
-
-export async function chatWithSeoAgent(payload: SeoChatRequest): Promise<SeoChatResponse> {
-  const response = await http.post<SeoChatResponse>('/api/seo/chat', payload)
-
-  return response.data
 }
 
 export async function* streamChatWithSeoAgent(

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -4,7 +4,7 @@
 
 ## 当前判断
 
-项目已经完成从固定字段 SEO 生成器到 Session Chat 的迁移，并完成流式输出最终态一致性收口。阶段 4 Agent Runtime 基础已归档；阶段 5 的 Task 0-5 已完成并通过验收，Tool Calling 可靠性与 `AgentStep` 运行记录已随 PR #15 合并到 `master`。阶段 5 暂不归档，下一步先完成 Issue #14，统一同步与流式 SEO Chat 的 Agent Runtime 路径；当前不推进 RAG 或多 Agent。
+项目已经完成从固定字段 SEO 生成器到 Session Chat 的迁移，并完成流式输出最终态一致性收口。阶段 4 Agent Runtime 基础已归档；阶段 5 的 Task 0-5 已完成并通过验收，Tool Calling 可靠性与 `AgentStep` 运行记录已随 PR #15 合并到 `master`。Issue #14 已实现、待验收：同步与流式 SEO Chat 已共享唯一 Agent Runtime 路径。阶段 5 暂不归档，当前不推进阶段 6、RAG 或多 Agent。
 
 ## 阶段路线
 
@@ -23,7 +23,7 @@
 
 | 优先级 | 任务 | 说明 |
 | --- | --- | --- |
-| P0 | Issue #14：统一同步与流式 SEO Chat Runtime | 移除同步 `/seo/chat` 绕过 Agent Runtime 的旁路，让两个入口共享 Message、Run、Step 和 Tool Loop 语义；通过验收后归档阶段 5 |
+| P0 | 验收 Issue #14：统一同步与流式 SEO Chat Runtime | 实现已完成；下一步由 GPT / 用户验证两个入口共享 Message、Run、Step 和 Tool Loop 语义，验收并明确确认后再归档阶段 5 |
 | P1 | Context 管理增强 | 阶段 5 稳定后再加入页面数据、关键词、工具 Observation 和预算规则 |
 | P2 | 阶段 6 Human-in-the-loop | 有中风险或写操作工具前，再实现用户确认与审批接口 |
 

--- a/docs/tasks/README.md
+++ b/docs/tasks/README.md
@@ -6,7 +6,7 @@
 
 | 区域 | 状态 | 文档 | 说明 |
 | --- | --- | --- | --- |
-| 阶段 5 最小 Tool Calling | In Progress | [phase-05-tool-calling/README.md](./phase-05-tool-calling/README.md) | Task 0-5 已完成并通过验收；PR #15 已合并，下一步处理 Issue #14，阶段尚未归档 |
+| 阶段 5 最小 Tool Calling | In Progress | [phase-05-tool-calling/README.md](./phase-05-tool-calling/README.md) | Task 0-5 已完成并通过验收；Issue #14 已实现、待验收，阶段尚未归档 |
 | 阶段 4 Agent Runtime | Completed | [completed/phase-04-agent-runtime.md](./completed/phase-04-agent-runtime.md) | 已归档为可观测 Agent Run 的基础阶段 |
 | 阶段 3 收口 | Completed | [completed/phase-03-streaming-closeout.md](./completed/phase-03-streaming-closeout.md) | 已收口 `done/error/aborted` 最终态一致性 |
 | 阶段 2 | Completed | [completed/phase-02-agent-chat-session.md](./completed/phase-02-agent-chat-session.md) | 多会话和消息持久化已完成 |

--- a/docs/tasks/phase-05-tool-calling/README.md
+++ b/docs/tasks/phase-05-tool-calling/README.md
@@ -1,6 +1,6 @@
 # 阶段 5：最小 Tool Calling
 
-状态：进行中。Task 0-5 已完成并通过验收；PR #15 已合并到 `master`，阶段 5 尚未归档，下一步处理 Issue #14 的同步 / 流式 Runtime 路径统一。
+状态：进行中。Task 0-5 已完成并通过验收；Issue #14 已实现、待验收，阶段 5 尚未归档。
 
 ## 阶段目标
 
@@ -105,7 +105,19 @@
 - `ChatStreamEvent` 继续只有 `start / delta / done / error / aborted`；未新增前端时间线，未暴露 Tool Call、Tool Result、raw arguments 或 `AgentStep`，用户可见 Message 仍只保存最终回答。
 - Red 阶段分别复现 Recorder、sampling、timeout / abort、Runtime 记录与迟到 terminal CAS 缺口；Green / Refactor 后 Recorder 9 个、Tool Loop 19 个、Model Stream 34 个、Tools 24 个自动化用例均通过。真实普通回答、正常 Tool Loop、零结果和停止生成场景已验证，临时会话数据已清理；工具 timeout 使用测试专用永不结束 Executor 验证。
 - GPT 结合 Issue #13、PR #15 diff、Codex Review、自动化测试和真实模型 / 数据库验证证据完成验收；用户明确确认后，PR #15 已合并到 `master`，merge commit `f6985627`，Issue #13 已关闭。
-- 实施状态：已实现；验收状态：已通过；任务状态：Completed。阶段 5 保持进行中，下一步处理 Issue #14，尚未归档。
+- 实施状态：已实现；验收状态：已通过；任务状态：Completed。阶段 5 保持进行中，尚未归档。
+
+## Issue #14 实现结果
+
+- 后端继续保留 `POST /seo/chat` 与 `POST /seo/chat/stream`；两者通过同一个 `buildRunTurnInput()` 构造配置，并且只调用 `AgentRuntimeService.runTurnStream()` 这一套 Runtime。
+- `POST /seo/chat` 已收敛为终态聚合适配器：忽略 `run_started` 与 `assistant_delta`，以 `run_completed.content` 返回最终 `SeoChatResponse`；`run_failed`、`run_aborted` 和 generator 缺少 terminal 分别映射为稳定、脱敏的确定性异常，不返回伪成功。
+- `SeoService` 已删除对 `LLMService`、`PrismaService` 的直接依赖，以及旧同步路径的会话检查、history 查询、Message 持久化和角色转换 helper；Message、AgentRun、AgentStep、Tool Loop 与错误持久化继续只由 Runtime 负责。
+- 流式入口仍只投影既有 `start / delta / done / error / aborted`，未改变 `ChatStreamEvent` 字段，也未暴露 run id、AgentStep、Tool raw arguments 或 Tool Result。
+- Vue 工作台继续只调用 `streamChatWithSeoAgent()`；Web 端未使用的 `chatWithSeoAgent()` 已删除，后端仍保留非流式能力，共享 `SeoChatResponse` contract 保持不变。
+- Red 阶段用 7 个 `SeoService` 测试复现旧同步旁路；Green / Refactor 后 7 个 SEO Service、9 个 Recorder、19 个 Tool Loop、34 个 Model Stream、24 个 Tools 测试通过。API / Web typecheck 与 lint、Web build、workspace typecheck、`git diff --check` 通过。
+- 非流式普通回答与 Tool Loop、流式普通回答与 Tool Loop、停止生成均已完成真实 HTTP / 页面 Smoke；数据库确认两种响应形式使用相同 Step 顺序、Tool execution attempt 为 1、没有重复 Message、没有非终态 Step。Computer Use 当前无法取得 Chrome 窗口，页面 Smoke 改用内置浏览器完成。
+- 本轮 13 个临时验收会话已按精确 ID 删除。全仓 `pnpm lint` 已实际运行，仍仅被既有 `docs/research/**` Markdown baseline 阻断：127 errors、0 warnings；本 Issue 未扩大范围修复。
+- Issue #14 实施状态：已实现；Issue #14 验收状态：待验收。下一步由 GPT / 用户验收 Issue #14，阶段 5 继续保持 In Progress。
 
 ### Task 4 手工验收问题
 
@@ -159,4 +171,4 @@
 
 ## 后续阶段
 
-先完成 Issue #14，统一同步与流式 SEO Chat 的 Agent Runtime 路径；该收口通过验收后，再归档阶段 5 并进入阶段 6：Human-in-the-loop。
+先由 GPT / 用户验收 Issue #14；验收通过且用户明确确认后，再归档阶段 5。当前不推进阶段 6：Human-in-the-loop。

--- a/docs/work-log.md
+++ b/docs/work-log.md
@@ -6,7 +6,7 @@
 
 | 类型 | 当前记录 | 下一步 |
 | --- | --- | --- |
-| 当前阶段 | 阶段 4 Agent Runtime 基础已归档；阶段 5 进行中，Task 0-5 已完成并通过验收；PR #15 已合并到 `master` | 下一步处理 Issue #14，统一同步与流式 SEO Chat 的 Agent Runtime 路径；通过验收后再归档阶段 5 |
+| 当前阶段 | 阶段 4 Agent Runtime 基础已归档；阶段 5 进行中，Task 0-5 已完成并通过验收；Issue #14 已实现、待验收 | 下一步由 GPT / 用户验收 Issue #14；明确确认后再归档阶段 5，当前不推进阶段 6 |
 | 文档结构 | docs 已重组为 `roadmap`、`tasks`、`research`、`work-log` 四类入口；当前任务以 `docs/tasks/README.md` 为准 | 后续 commit 按 task docs 和 work-log 分工更新 |
 | 任务规范 | 新任务使用 TDD 风格模板；已完成阶段保留在 `docs/tasks/completed/`，当前任务目录只保留可执行阶段入口 | 后续任务继续按 Red / Green / Refactor 推进 |
 | Codex 研究 | 已基于本地 Codex fork 与当前 Agent 源码重建 `docs/research/`：形成架构报告、学习清单、云端映射和 14 个分阶段学习目录 | 作为阶段 5 及后续任务的研究依据；真实执行状态仍以 `docs/tasks/` 为准 |
@@ -16,6 +16,7 @@
 
 | 日期 | 提交 | 类型 | 核心完成 | 关键文件 | 验证结果 |
 | --- | --- | --- | --- | --- | --- |
+| 2026-07-18 | Issue #14 实现 | refactor / Agent Runtime | 保留同步与流式两个后端入口，但统一为唯一 `AgentRuntimeService.runTurnStream()`；同步入口只做安全终态聚合，删除直接 LLM / Prisma / history / Message 旁路；删除 Web 未使用的非流式 helper，Vue 主路径与 stream contract 不变；Issue #14 已实现、待验收，阶段 5 保持 In Progress | `apps/api/src/seo/seo.service.ts`、`seo.service.test.ts`、`seo.module.ts`、`apps/web/src/api/seo.ts`、阶段 5 状态文档 | 7 个 SEO Service、9 个 Recorder、19 个 Tool Loop、34 个 Model Stream、24 个 Tools 测试通过；API / Web typecheck 与 lint、Web build、workspace typecheck、`git diff --check` 通过；非流式 / 流式普通回答、Tool Loop 与 abort 的 HTTP、页面和数据库验证通过，13 个临时会话已精确清理；全仓 lint 仅被既有 research Markdown 127 errors baseline 阻断 |
 | 2026-07-17 | PR #15 验收合并收口 | docs / Tool Calling | GPT 验收 Issue #13 / PR #15 通过，用户明确确认后合并到 `master`；Task 5 标记为 Completed，动态 AgentStep、两轮 sampling 记录、工具安全摘要、真实 timeout 和 Observation 上限进入主分支；阶段 5 保持 In Progress，下一步处理 Issue #14 | `docs/tasks/phase-05-tool-calling/README.md`、`docs/tasks/README.md`、`docs/roadmap.md`、`docs/work-log.md` | 基于 PR #15 验证结果：9 个 Recorder、19 个 Tool Loop、34 个 Model Stream、24 个 Tools 测试通过；Prisma migration、API typecheck/lint、Web typecheck/build、workspace typecheck、`git diff --check` 通过；Codex Review 无 major issues；merge commit `f6985627` |
 | 2026-07-17 | Issue #13 实现 | feat / Agent Runtime / Tool Calling | 为 `AgentStep` 增加稳定 sequence migration；Recorder 改为动态 step-id 状态机；分别记录两轮 sampling 的 usage / finish reason 和工具 allowlist 摘要；实现真实 tool deadline、user abort 优先级、8,000 字符 Observation 上限及迟到结果隔离；保持前端五类 stream 事件不变；Task 5 仅更新为已实现、待验收 | `prisma/schema.prisma`、`prisma/migrations/20260717160000_add_agent_step_sequence/`、`packages/contracts/src/agent-run.ts`、`apps/api/src/agent-runtime/**`、`apps/api/src/tools/**`、阶段 5 状态文档 | Prisma generate / validate / migrate deploy / status 通过；9 个 Recorder、19 个 Tool Loop、34 个 Model Stream、24 个 Tools 测试通过；API typecheck/lint、Web typecheck/build、workspace typecheck、`git diff --check` 通过；真实普通回答、Tool Loop、零结果与 abort 场景通过，timeout 使用永不结束 fake Executor 验证 |
 | 2026-07-16 | PR #12 验收合并收口 | docs / Tool Calling | GPT 验收 Issue #11 / PR #12 通过，用户授权后合并到 `master`；Task 4 标记为 Completed，阶段 5 保持 In Progress，Task 5 保持 Planned；单 Agent Tool Loop 已进入主分支 | `docs/tasks/phase-05-tool-calling/README.md`、`docs/tasks/README.md`、`docs/roadmap.md`、`docs/work-log.md` | 基于 PR #12 验证结果：14 个 tool loop、22 个 model stream、17 个 tools 测试通过；API typecheck/lint、workspace typecheck、`git diff --check` 通过；Codex Review 复审无 major issues；merge commit `390d8497` |


### PR DESCRIPTION
Closes #14

## 当前双路径问题

- `POST /seo/chat` 原先自行校验会话、写 Message、查询 history 并直接调用 `LLMService.chat()`，没有 AgentRun / AgentStep，也无法进入 Tool Loop。
- `POST /seo/chat/stream` 已通过 `AgentRuntimeService.runTurnStream()` 统一处理 Message、Run、Step、模型采样、Tool Loop 与终态。
- 问题不在于同时提供 JSON 与 NDJSON，而在于两种响应形式背后存在两套业务状态机。

## 为什么保留后端 `/seo/chat`

`POST /seo/chat` 继续提供一次性 JSON 响应，供未来 CLI、内部服务、脚本、自动评估或不支持流式读取的客户端使用。它现在只是 Runtime 的终态聚合适配器，不再拥有独立业务状态机。

## 为什么删除 Web `chatWithSeoAgent()`

Vue 工作台的真实主路径一直只有 `streamChatWithSeoAgent()`。删除未使用 helper 可以消除错误暗示，但不影响后端非流式 API；共享 `SeoChatResponse` contract 继续保留并由后端使用。

## 唯一 Runtime 调用链

```text
POST /seo/chat
  -> SeoService.chat()
  -> buildRunTurnInput()
  -> AgentRuntimeService.runTurnStream()
  -> terminal event -> SeoChatResponse / safe HTTP error

POST /seo/chat/stream
  -> SeoService.chatStream()
  -> buildRunTurnInput(signal)
  -> AgentRuntimeService.runTurnStream()
  -> toChatStreamEvent() -> NDJSON
```

## 共享 `RunTurnStreamInput` builder

- 两个入口共享 `conversationId`、`userContent`、可选 `model`、`historyLimit=12`、`temperature=0.4`、`maxTokens=1200` 与同一 `SeoContextBuilder`。
- 只有流式入口透传 HTTP client disconnect 对应的 `AbortSignal`；非流式入口不伪造 signal。

## 非流式 terminal 聚合与错误映射

- `run_started` / `assistant_delta`：忽略，不自行拼接答案。
- `run_completed`：只使用 `event.content` 与 `event.generatedAt` 返回 `SeoChatResponse`。
- `run_failed`：缺失会话分类映射为固定脱敏 404，其余失败映射为固定脱敏 503；均不透传 provider、数据库、工具或 secret 信息。
- `run_aborted`：映射为固定脱敏 408，不返回部分内容伪成功。
- generator 无 terminal：映射为固定脱敏 500，不返回空 reply。
- 聚合器不修改 Message、AgentRun、AgentStep，也不再次实现 Tool Loop。

## 删除的重复持久化与旁路代码

- 删除 `SeoService` 对 `LLMService`、`PrismaService` 的直接依赖。
- 删除会话存在性校验、history 查询、Message 写入、角色映射及旧同步失败 Message 写入 helper。
- `SeoModule` 删除无直接用途的 `PrismaModule` import；Runtime 模块继续拥有所需持久化依赖。

## 保持不变的协议与边界

- Controller 继续保留 `POST /seo/chat` 与 `POST /seo/chat/stream`，request shape 与 stream Content-Type 未改。
- `ChatStreamEvent` 仍只有 `start / delta / done / error / aborted`，没有新增字段。
- run id、AgentStep、Tool raw arguments、ToolResult.data 不向 Web 暴露。
- `LLMService.chat()`、`SeoChatResponse`、`SeoChatRequest` 与 `ChatStreamEvent` contract 均保留。
- Vue 页面继续只走流式接口。

## TDD：Red / Green / Refactor

- Red：新增 7 个 `SeoService` 用例，旧实现首次运行 7/7 失败，直接暴露 Prisma / LLM 旁路与缺失 Runtime terminal 聚合。
- Green：共享 input builder、同步终态聚合、依赖清理与 Web helper 清理后 7/7 通过。
- Refactor：`SeoService` 最终只负责 SEO context/config 注入与 HTTP/stream 投影；Runtime、Tool Loop 和 Prisma schema 未改。

## Review 修复

- commit `d581683`：Runtime 的 `run_failed` 新增仅内部使用的 `failureReason=conversation_not_found`，同步适配器据此恢复固定、脱敏的 404；其他失败仍为固定 503。
- 缺失会话在创建 Message / AgentRun 之前失败；回归测试确认不会写入 Message、Step，也不会调用 LLM。
- `toChatStreamEvent()` 忽略内部失败分类，公开 `ChatStreamEvent` shape 保持不变。
- work-log 的 `2026-07-18` 已按 commit 原始 `+08:00` 时间核对无误；GitHub 显示的 7 月 17 日是同一时刻的 UTC，因此未改成错误的本地日期。

## 自动化验证

- `pnpm --filter @agent/api test:seo-service`：PASS，8/8。
- `pnpm --filter @agent/api test:agent-recorder`：PASS，9/9。
- `pnpm --filter @agent/api test:tool-loop`：PASS，20/20。
- `pnpm --filter @agent/api test:model-stream`：PASS，35/35。
- `pnpm --filter @agent/api test:tools`：PASS，24/24。
- `pnpm --filter @agent/api typecheck`：PASS。
- `pnpm --filter @agent/api lint`：PASS。
- `pnpm --filter @agent/web typecheck`：PASS。
- `pnpm --filter @agent/web lint`：PASS。
- `pnpm --filter @agent/web build`：PASS；仅有 `@vueuse/core` 既有 PURE annotation 警告。
- `pnpm typecheck`：PASS。
- `git diff --check`：PASS。
- 四个本次 docs 文件定向 ESLint：PASS。
- `pnpm lint`：已实际运行，FAIL；仅为既有 `docs/research/**` Markdown baseline，127 errors、0 warnings。本 Issue 未顺手修复。

## HTTP 手工验收

- 缺失会话：`POST /api/seo/chat` 已真实验证返回 HTTP 404 与固定文案 `会话不存在或已被删除`，没有伪装成模型故障。
- 非流式普通回答：`POST /api/seo/chat` 返回 HTTP 201 普通 JSON，包含最终 `reply` / `generatedAt`。
- 非流式 Tool Loop：SP Himeko 查询实际执行一次 `search_articles`，返回第二轮自然语言最终回答，没有暴露内部工具 JSON。
- 流式普通回答：NDJSON 实时产生 delta 后 done。
- 流式 Tool Loop：第一轮 Tool Call 后，第二轮回答仍实时产生 delta 后 done。
- 停止生成：客户端断开与页面点击停止均收口为 ABORTED，刷新后部分内容和状态稳定，无迟到覆盖。
- Vue 页面定向 Smoke 已覆盖页面打开、普通渐进输出、Tool Loop 第二轮渐进输出、停止与刷新持久化；浏览器 Console 无错误/警告。
- Computer Use 当前无法取得 Chrome 窗口（`cgWindowNotFound`），因此页面 Smoke 使用内置浏览器完成；未重复 Issue #13 全套取证。

## 数据库 Step 对比

- 普通回答（同步与流式）：`receive_user_message -> load_conversation_history -> model_sampling(stop) -> assistant_output`。
- Tool Loop（同步与流式）：`receive_user_message -> load_conversation_history -> model_sampling#1(tool_calls) -> tool_execution -> model_sampling#2(stop) -> assistant_output`。
- `tool_execution.input.executionAttempt=1`；没有自动重试。
- 每个场景只有 1 条 USER + 1 条 ASSISTANT Message，没有同步旁路重复 Message。
- 所有 Run 的 Step sequence 唯一；PENDING / RUNNING Step 数为 0。
- durable tool Step 仍只保存 allowlist safe summary，不保存 raw arguments 或 ToolResult.data。
- 本轮 13 个临时验收会话已按精确 ID 删除，删除后精确查询为 0。

## 已知风险

- `run_failed` 目前只为缺失会话提供稳定内部分类；未来若增加其他需区分的失败语义，应继续扩展 Runtime 的受控分类，而不是透传原始异常或重新引入旁路。
- 本轮页面验收是针对性浏览器 Smoke，不替代后续 GPT / 用户学习验收。
- 全仓 lint 的既有 research Markdown baseline 仍存在，但 API / Web 与本次 docs 定向 lint 均通过。

## 未做事项

- 未删除后端 `/seo/chat`、`SeoChatResponse` 或通用 `LLMService.chat()`。
- 未修改 Prisma schema、`runTurnStream()` 调用方式或状态机、Tool、AgentStep 类型及公开 `ChatStreamEvent`。
- 未增加非流式/流式切换 UI、Tool Timeline、Run 查询页或自动重试。
- 未实现 HITL、Context、RAG、MCP、Multi-agent。
- 未归档阶段 5，未推进阶段 6，未获得合并授权。

## 文档状态

- Issue #14 实施状态：已实现。
- Issue #14 验收状态：待验收。
- 阶段 5：In Progress。
- 下一步：GPT / 用户验收 Issue #14。
- PR 保持 Draft，不自行转 Ready。