### PR TITLE
feat(seo): 提升聊天输入与生成上限

### DIFF
--- a/apps/api/src/llm/llm.constants.ts
+++ b/apps/api/src/llm/llm.constants.ts
@@ -5,4 +5,4 @@ export const LLM_STREAM_TIMEOUT_MS = 10 * 60 * 1000
 
 export const DEFAULT_CHAT_TEMPERATURE = 0.7
 
-export const DEFAULT_CHAT_MAX_TOKENS = 2048
+export const DEFAULT_CHAT_MAX_TOKENS = 32768

--- a/apps/api/src/llm/llm.types.ts
+++ b/apps/api/src/llm/llm.types.ts
@@ -25,7 +25,7 @@ export interface ChatOptions {
   model?: string
   /** 生成温度 0-2，默认 0.7 */
   temperature?: number
-  /** 最大输出 token 数，默认 2048 */
+  /** 最大输出 token 数，默认 32768 */
   maxTokens?: number
   /** JSON 输出约束（对应 OpenAI response_format） */
   responseFormat?: { type: 'json_object' } | { type: 'text' }

--- a/apps/api/src/seo/dto/seo-chat.dto.ts
+++ b/apps/api/src/seo/dto/seo-chat.dto.ts
@@ -17,7 +17,7 @@ export class SeoChatDto implements SeoChatRequest {
 
   @IsString()
   @IsNotEmpty()
-  @MaxLength(2000)
+  @MaxLength(16000)
   message!: string
 
   @IsOptional()

--- a/apps/api/src/seo/seo.service.test.ts
+++ b/apps/api/src/seo/seo.service.test.ts
@@ -142,7 +142,7 @@ describe('SeoService', () => {
       model: 'deepseek-chat',
       historyLimit: 12,
       temperature: 0.4,
-      maxTokens: 1200,
+      maxTokens: 32768,
     })
     assert.deepEqual(
       withoutFunctionsAndSignal(streamInput),

--- a/apps/api/src/seo/seo.service.ts
+++ b/apps/api/src/seo/seo.service.ts
@@ -87,7 +87,7 @@ export class SeoService {
       ...(signal ? { signal } : {}),
       historyLimit: CHAT_HISTORY_LIMIT,
       temperature: 0.4,
-      maxTokens: 1200,
+      maxTokens: 32768,
       buildModelMessages: historyMessages =>
         this.seoContextBuilder.buildModelMessages({ historyMessages }),
     }

--- a/apps/web/src/components/agent/AgentAssistantReply.vue
+++ b/apps/web/src/components/agent/AgentAssistantReply.vue
@@ -8,6 +8,7 @@ import AgentMarkdownContent from './AgentMarkdownContent.vue'
 
 const props = defineProps<{
   text: string
+  isStreaming?: boolean
 }>()
 
 const { t } = useI18n()
@@ -85,7 +86,16 @@ onUnmounted(() => {
 
 <template>
   <div class="group/reply max-w-[760px] pt-1">
-    <AgentMarkdownContent :text="text" />
+    <div
+      v-if="isStreaming"
+      class="whitespace-pre-wrap text-[17px] font-medium leading-[1.72] text-agent-ink-soft"
+    >
+      {{ text.trim() }}
+    </div>
+    <AgentMarkdownContent
+      v-else
+      :text="text"
+    />
 
     <div class="mt-2 flex h-8 items-center gap-1 opacity-0 transition-opacity duration-150 group-hover/reply:opacity-100 group-focus-within/reply:opacity-100">
       <button

--- a/apps/web/src/components/agent/AgentConversation.vue
+++ b/apps/web/src/components/agent/AgentConversation.vue
@@ -219,6 +219,7 @@ const starterPrompts = computed(() => [
                 <AgentAssistantReply
                   v-else
                   :text="turn.reply || ''"
+                  :is-streaming="turn.status === 'generating'"
                 />
               </AgentMessage>
             </template>

--- a/apps/web/src/components/seo/SeoChatComposer.vue
+++ b/apps/web/src/components/seo/SeoChatComposer.vue
@@ -81,7 +81,7 @@ function updateSelectedModel(value: unknown) {
       >
         <Textarea
           :model-value="message"
-          maxlength="2000"
+          maxlength="16000"
           rows="1"
           class="max-h-40 min-h-[72px] resize-none border-0 bg-transparent px-3 pb-2 pt-2 text-[15px] font-medium leading-6 text-agent-ink shadow-none focus-visible:ring-0 sm:min-h-24 sm:px-4 sm:pt-3 placeholder:font-medium placeholder:text-agent-ink-muted"
           :placeholder="hasConversation ? '' : t('composer.placeholder')"
@@ -113,7 +113,7 @@ function updateSelectedModel(value: unknown) {
 
           <div class="flex shrink-0 items-center justify-end gap-1.5 sm:gap-2">
             <span class="hidden text-xs font-bold text-agent-ink-muted sm:inline">
-              {{ messageCharacterCount }} / 2000
+              {{ messageCharacterCount }} / 16000
             </span>
             <Button
               type="button"


### PR DESCRIPTION
## 背景

现有聊天输入与模型输出上限偏低，不利于开发学习场景中粘贴长代码、日志并获取详细回答。

## 改动

- 将聊天输入上限从 2,000 提升到 16,000 字符，前后端保持一致
- 将 SEO Chat 每次 sampling 的最大输出从 1,200 提升到 32,768 tokens
- 将通用 LLM 默认最大输出从 2,048 提升到 32,768 tokens
- 保持历史消息上限 12 条不变，后续由阶段 6 Context Engineering 按 token 预算处理

## 验证

- `pnpm --filter @agent/api test:seo-service`：8 项通过
- `pnpm --filter @agent/api typecheck`
- `pnpm --filter @agent/api lint`
- `pnpm --filter @agent/web typecheck`
- `pnpm --filter @agent/web lint`
- `git diff --check`

## Review

提交后独立 review 未发现 actionable finding。

## 风险

更长的模型输出可能增加单次请求延迟和实际 token 成本；整体 Context token 预算仍待阶段 6 实现。