### PR TITLE
fix: 加固 Agent Runtime 数据库 deadline 与终态一致性

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -12,6 +12,7 @@
     "build": "tsc",
     "start": "node dist/main.js",
     "test:agent-recorder": "tsx --test src/agent-runtime/agent-run-recorder.service.test.ts",
+    "test:db-reliability": "tsx --env-file-if-exists=../../.env --test src/prisma/prisma.service.reliability.test.ts",
     "test:model-stream": "tsx --test src/llm/clients/openai-compatible-stream.adapter.test.ts src/agent-runtime/agent-runtime.service.test.ts src/agent-runtime/model-sampling-decision.test.ts",
     "test:llm-config": "tsx --test src/llm/model-profiles.test.ts src/llm/llm-runtime-config.test.ts src/llm/llm.module.test.ts src/llm/clients/openai-compatible.client.test.ts",
     "test:seo-service": "pnpm --filter @agent/contracts build && tsx --test src/seo/seo.service.test.ts src/seo/dto/seo-chat.dto.test.ts",

--- a/apps/api/src/agent-runtime/agent-run-recorder.service.test.ts
+++ b/apps/api/src/agent-runtime/agent-run-recorder.service.test.ts
@@ -1,14 +1,28 @@
-import type { PrismaService } from '../prisma/prisma.service.js'
+import type { Message, MessageRole, Prisma } from '../generated/prisma/client.js'
+import type {
+  DatabaseOperationDeadline,
+  DeadlineTransaction,
+  PrismaService,
+} from '../prisma/prisma.service.js'
 import assert from 'node:assert/strict'
 // 项目使用 Node 原生测试运行器，不为 Recorder 引入额外测试框架。
 // eslint-disable-next-line test/no-import-node-test
 import { describe, it } from 'node:test'
 
-import { AgentRunStatus, AgentStepStatus } from '../generated/prisma/client.js'
+import {
+  AgentRunStatus,
+  AgentStepStatus,
+  MessageStatus,
+} from '../generated/prisma/client.js'
 import {
   AGENT_STEP_TYPES,
   AgentRunRecorderService,
 } from './agent-run-recorder.service.js'
+
+const TEST_DEADLINE: DatabaseOperationDeadline = {
+  deadlineAt: Number.MAX_SAFE_INTEGER,
+  createTimeoutError: () => new Error('测试数据库操作超时'),
+}
 
 describe('AgentRunRecorderService', () => {
   it('同一 Run 可以创建两条独立 model_sampling', async () => {
@@ -18,11 +32,11 @@ describe('AgentRunRecorderService', () => {
     const first = await harness.recorder.startStep({
       runId: run.id,
       type: AGENT_STEP_TYPES.modelSampling,
-    })
+    }, TEST_DEADLINE)
     const second = await harness.recorder.startStep({
       runId: run.id,
       type: AGENT_STEP_TYPES.modelSampling,
-    })
+    }, TEST_DEADLINE)
 
     assert.notEqual(first.id, second.id)
     assert.equal(first.status, AgentStepStatus.RUNNING)
@@ -35,20 +49,20 @@ describe('AgentRunRecorderService', () => {
     const first = await harness.recorder.startStep({
       runId: run.id,
       type: AGENT_STEP_TYPES.modelSampling,
-    })
+    }, TEST_DEADLINE)
     const second = await harness.recorder.startStep({
       runId: run.id,
       type: AGENT_STEP_TYPES.modelSampling,
-    })
+    }, TEST_DEADLINE)
 
-    await harness.recorder.completeStep(first.id, {
+    await harness.recorder.completeStep(first.id, TEST_DEADLINE, {
       output: { finishReason: 'tool_calls' },
     })
 
     assert.equal(harness.step(first.id)?.status, AgentStepStatus.COMPLETED)
     assert.equal(harness.step(second.id)?.status, AgentStepStatus.RUNNING)
 
-    await harness.recorder.completeStep(second.id, {
+    await harness.recorder.completeStep(second.id, TEST_DEADLINE, {
       output: { finishReason: 'stop' },
     })
     assert.equal(harness.step(second.id)?.status, AgentStepStatus.COMPLETED)
@@ -60,105 +74,258 @@ describe('AgentRunRecorderService', () => {
     const completed = await harness.recorder.startStep({
       runId: run.id,
       type: AGENT_STEP_TYPES.modelSampling,
-    })
+    }, TEST_DEADLINE)
     const failed = await harness.recorder.startStep({
       runId: run.id,
       type: AGENT_STEP_TYPES.toolExecution,
-    })
+    }, TEST_DEADLINE)
     const aborted = await harness.recorder.startStep({
       runId: run.id,
       type: AGENT_STEP_TYPES.assistantOutput,
-    })
+    }, TEST_DEADLINE)
 
-    await harness.recorder.completeStep(completed.id)
-    await harness.recorder.failStep(failed.id, { errorMessage: '安全失败' })
-    await harness.recorder.abortStep(aborted.id)
+    await harness.recorder.completeStep(completed.id, TEST_DEADLINE)
+    await harness.recorder.failStep(failed.id, TEST_DEADLINE, { errorMessage: '安全失败' })
+    await harness.recorder.abortStep(aborted.id, TEST_DEADLINE)
 
-    await assertRecorderInvariant(() => harness.recorder.failStep(completed.id, {
+    await assertRecorderInvariant(() => harness.recorder.failStep(completed.id, TEST_DEADLINE, {
       errorMessage: '迟到失败',
     }))
-    await assertRecorderInvariant(() => harness.recorder.abortStep(failed.id))
-    await assertRecorderInvariant(() => harness.recorder.completeStep(aborted.id))
+    await assertRecorderInvariant(() => harness.recorder.abortStep(failed.id, TEST_DEADLINE))
+    await assertRecorderInvariant(() => harness.recorder.completeStep(aborted.id, TEST_DEADLINE))
   })
 
-  it('completeRun 在仍有 RUNNING Step 时失败', async () => {
+  it('completeRun 在一个事务内完成 Message、assistant Step 和 Run', async () => {
     const harness = createHarness()
-    const run = await harness.createRun('run-a')
-    await harness.recorder.startStep({
-      runId: run.id,
-      type: AGENT_STEP_TYPES.modelSampling,
+    const prepared = await harness.prepareAssistantRun('completed')
+    let commitOwned = false
+
+    const message = await harness.recorder.completeRun({
+      ...prepared.completion,
+      content: '最终回答',
+      output: { contentLength: 4 },
+    }, TEST_DEADLINE, () => {
+      assert.equal(harness.message(prepared.message.id)?.status, MessageStatus.COMPLETED)
+      assert.equal(harness.step(prepared.assistantStep.id)?.status, AgentStepStatus.COMPLETED)
+      assert.equal(harness.run(prepared.run.id)?.status, AgentRunStatus.COMPLETED)
+      commitOwned = true
     })
 
-    await assertRecorderInvariant(() => harness.recorder.completeRun(run.id))
-
-    assert.equal(harness.run(run.id)?.status, AgentRunStatus.RUNNING)
-    assert.equal(harness.unfinishedSteps(run.id).length, 1)
+    assert.equal(commitOwned, true)
+    assert.equal(message.status, MessageStatus.COMPLETED)
+    assert.equal(message.content, '最终回答')
+    assert.equal(harness.message(prepared.message.id)?.status, MessageStatus.COMPLETED)
+    assert.equal(harness.step(prepared.assistantStep.id)?.status, AgentStepStatus.COMPLETED)
+    assert.deepEqual(harness.step(prepared.assistantStep.id)?.output, { contentLength: 4 })
+    assert.equal(harness.run(prepared.run.id)?.status, AgentRunStatus.COMPLETED)
+    assert.equal(harness.unfinishedSteps(prepared.run.id).length, 0)
   })
 
-  it('failRun 在事务中收口所有非终态 Step', async () => {
+  it('completeRun 发现其他 RUNNING Step 时整笔回滚', async () => {
     const harness = createHarness()
-    const run = await harness.createRun('run-a')
-    await harness.recorder.startStep({
-      runId: run.id,
+    const prepared = await harness.prepareAssistantRun('unfinished')
+    const unfinished = await harness.recorder.startStep({
+      runId: prepared.run.id,
       type: AGENT_STEP_TYPES.modelSampling,
-    })
-    harness.addPendingStep(run.id)
+    }, TEST_DEADLINE)
 
-    await harness.recorder.failRun(run.id, '安全错误')
+    await assertRecorderInvariant(() => harness.recorder.completeRun({
+      ...prepared.completion,
+      content: '不应提交',
+    }, TEST_DEADLINE))
 
-    assert.equal(harness.run(run.id)?.status, AgentRunStatus.FAILED)
-    assert.equal(harness.unfinishedSteps(run.id).length, 0)
-    for (const step of harness.steps(run.id)) {
+    assert.equal(harness.message(prepared.message.id)?.status, MessageStatus.STREAMING)
+    assert.equal(harness.step(prepared.assistantStep.id)?.status, AgentStepStatus.RUNNING)
+    assert.equal(harness.step(unfinished.id)?.status, AgentStepStatus.RUNNING)
+    assert.equal(harness.run(prepared.run.id)?.status, AgentRunStatus.RUNNING)
+  })
+
+  it('completeRun 在 Run CAS 失败时不留下部分终态', async () => {
+    const harness = createHarness()
+    const prepared = await harness.prepareAssistantRun('completion-failure')
+    let commitOwned = false
+
+    harness.failNextTransactionAt(7)
+    await assert.rejects(() => harness.recorder.completeRun({
+      ...prepared.completion,
+      content: '不应提交',
+    }, TEST_DEADLINE, () => {
+      commitOwned = true
+    }), /injected transaction failure/)
+
+    assert.equal(commitOwned, false)
+    assert.equal(harness.message(prepared.message.id)?.status, MessageStatus.STREAMING)
+    assert.equal(harness.step(prepared.assistantStep.id)?.status, AgentStepStatus.RUNNING)
+    assert.equal(harness.run(prepared.run.id)?.status, AgentRunStatus.RUNNING)
+  })
+
+  it('failRun 在一个事务中收口 Message、Step 和 Run', async () => {
+    const harness = createHarness()
+    const prepared = await harness.prepareAssistantRun('failed')
+    harness.addPendingStep(prepared.run.id)
+    harness.run(prepared.run.id)!.assistantMessageId = null
+
+    await harness.recorder.failRun(
+      prepared.run.id,
+      '安全错误',
+      TEST_DEADLINE,
+      {
+        id: prepared.message.id,
+        conversationId: prepared.run.conversationId,
+        content: '部分回答',
+      },
+    )
+
+    assert.equal(harness.message(prepared.message.id)?.status, MessageStatus.FAILED)
+    assert.equal(harness.message(prepared.message.id)?.content, '部分回答')
+    assert.equal(harness.run(prepared.run.id)?.status, AgentRunStatus.FAILED)
+    assert.equal(harness.run(prepared.run.id)?.assistantMessageId, prepared.message.id)
+    assert.equal(harness.unfinishedSteps(prepared.run.id).length, 0)
+    for (const step of harness.steps(prepared.run.id)) {
       assert.equal(step.status, AgentStepStatus.FAILED)
       assert.equal(step.errorMessage, '安全错误')
       assert.ok(step.endedAt)
     }
   })
 
-  it('abortRun 在事务中收口所有非终态 Step', async () => {
+  it('abortRun 在一个事务中收口 Message、Step 和 Run', async () => {
     const harness = createHarness()
-    const run = await harness.createRun('run-a')
-    await harness.recorder.startStep({
-      runId: run.id,
-      type: AGENT_STEP_TYPES.modelSampling,
-    })
-    harness.addPendingStep(run.id)
+    const prepared = await harness.prepareAssistantRun('aborted')
+    harness.addPendingStep(prepared.run.id)
 
-    await harness.recorder.abortRun(run.id)
+    await harness.recorder.abortRun(
+      prepared.run.id,
+      TEST_DEADLINE,
+      {
+        id: prepared.message.id,
+        conversationId: prepared.run.conversationId,
+        content: '已停止',
+      },
+    )
 
-    assert.equal(harness.run(run.id)?.status, AgentRunStatus.ABORTED)
-    assert.equal(harness.unfinishedSteps(run.id).length, 0)
-    for (const step of harness.steps(run.id)) {
+    assert.equal(harness.message(prepared.message.id)?.status, MessageStatus.ABORTED)
+    assert.equal(harness.message(prepared.message.id)?.content, '已停止')
+    assert.equal(harness.run(prepared.run.id)?.status, AgentRunStatus.ABORTED)
+    assert.equal(harness.unfinishedSteps(prepared.run.id).length, 0)
+    for (const step of harness.steps(prepared.run.id)) {
       assert.equal(step.status, AgentStepStatus.ABORTED)
       assert.ok(step.endedAt)
     }
   })
 
+  it('调用方未取得 Message 结果时仍按 Run 关联收口 late Message', async () => {
+    const harness = createHarness()
+    const prepared = await harness.prepareAssistantRun('late-message-result')
+
+    await harness.recorder.failRun(
+      prepared.run.id,
+      '安全错误',
+      TEST_DEADLINE,
+    )
+
+    assert.equal(harness.message(prepared.message.id)?.status, MessageStatus.FAILED)
+    assert.equal(harness.message(prepared.message.id)?.content, '安全错误')
+    assert.equal(harness.run(prepared.run.id)?.status, AgentRunStatus.FAILED)
+    assert.equal(harness.unfinishedSteps(prepared.run.id).length, 0)
+  })
+
+  it('failedStep 迟到完成时保留既有终态并继续收口 Run', async () => {
+    const harness = createHarness()
+    const prepared = await harness.prepareAssistantRun('late-completed-step')
+    const completedStep = await harness.recorder.startStep({
+      runId: prepared.run.id,
+      type: AGENT_STEP_TYPES.modelSampling,
+    }, TEST_DEADLINE)
+    await harness.recorder.completeStep(completedStep.id, TEST_DEADLINE)
+
+    await harness.recorder.failRun(
+      prepared.run.id,
+      'Run deadline',
+      TEST_DEADLINE,
+      {
+        id: prepared.message.id,
+        conversationId: prepared.run.conversationId,
+        content: '部分回答',
+      },
+      {
+        id: completedStep.id,
+        errorMessage: '迟到 failure detail',
+      },
+    )
+
+    assert.equal(harness.step(completedStep.id)?.status, AgentStepStatus.COMPLETED)
+    assert.equal(harness.step(completedStep.id)?.errorMessage, null)
+    assert.equal(harness.step(prepared.assistantStep.id)?.status, AgentStepStatus.FAILED)
+    assert.equal(harness.message(prepared.message.id)?.status, MessageStatus.FAILED)
+    assert.equal(harness.run(prepared.run.id)?.status, AgentRunStatus.FAILED)
+    assert.equal(harness.unfinishedSteps(prepared.run.id).length, 0)
+  })
+
+  it('terminalization 自身失败时整笔回滚且不伪造已收口', async () => {
+    const harness = createHarness()
+    const prepared = await harness.prepareAssistantRun('cleanup-failure')
+    harness.addPendingStep(prepared.run.id)
+
+    harness.failNextTransactionAt(5)
+    await assert.rejects(() => harness.recorder.failRun(
+      prepared.run.id,
+      '安全错误',
+      TEST_DEADLINE,
+      {
+        id: prepared.message.id,
+        conversationId: prepared.run.conversationId,
+        content: '部分回答',
+      },
+    ), /injected transaction failure/)
+
+    assert.equal(harness.message(prepared.message.id)?.status, MessageStatus.STREAMING)
+    assert.equal(harness.run(prepared.run.id)?.status, AgentRunStatus.RUNNING)
+    assert.equal(harness.unfinishedSteps(prepared.run.id).length, 2)
+  })
+
   it('terminal Run 不能被迟到更新覆盖', async () => {
     const harness = createHarness()
-    const completedRun = await harness.createRun('run-completed')
-    await harness.recorder.completeRun(completedRun.id)
+    const completed = await harness.prepareAssistantRun('terminal-completed')
+    const completionInput = {
+      ...completed.completion,
+      content: '已完成',
+    }
+    await harness.recorder.completeRun(completionInput, TEST_DEADLINE)
 
-    await assertRecorderInvariant(() => harness.recorder.completeRun(completedRun.id))
-    await assertRecorderInvariant(() => harness.recorder.failRun(completedRun.id, '迟到失败'))
-    await assertRecorderInvariant(() => harness.recorder.abortRun(completedRun.id))
-    await assertRecorderInvariant(() => harness.recorder.attachAssistantMessage(
-      completedRun.id,
-      'assistant-late',
+    await assertRecorderInvariant(() => harness.recorder.completeRun(
+      completionInput,
+      TEST_DEADLINE,
+    ))
+    await assertRecorderInvariant(() => harness.recorder.failRun(
+      completed.run.id,
+      '迟到失败',
+      TEST_DEADLINE,
+    ))
+    await assertRecorderInvariant(() => harness.recorder.abortRun(
+      completed.run.id,
+      TEST_DEADLINE,
+    ))
+    await assertRecorderInvariant(() => harness.recorder.createAssistantMessage(
+      completed.run.id,
+      completed.run.conversationId,
+      TEST_DEADLINE,
     ))
     await assertRecorderInvariant(() => harness.recorder.startStep({
-      runId: completedRun.id,
+      runId: completed.run.id,
       type: AGENT_STEP_TYPES.modelSampling,
-    }))
-    assert.equal(harness.run(completedRun.id)?.status, AgentRunStatus.COMPLETED)
+    }, TEST_DEADLINE))
+    assert.equal(harness.run(completed.run.id)?.status, AgentRunStatus.COMPLETED)
 
     const abortedRun = await harness.createRun('run-aborted')
     const activeStep = await harness.recorder.startStep({
       runId: abortedRun.id,
       type: AGENT_STEP_TYPES.toolExecution,
-    })
-    await harness.recorder.abortRun(abortedRun.id)
-    await assertRecorderInvariant(() => harness.recorder.completeStep(activeStep.id))
+    }, TEST_DEADLINE)
+    await harness.recorder.abortRun(abortedRun.id, TEST_DEADLINE)
+    await assertRecorderInvariant(() => harness.recorder.completeStep(
+      activeStep.id,
+      TEST_DEADLINE,
+    ))
     assert.equal(harness.step(activeStep.id)?.status, AgentStepStatus.ABORTED)
   })
 
@@ -172,7 +339,7 @@ describe('AgentRunRecorderService', () => {
       AGENT_STEP_TYPES.loadConversationHistory,
       AGENT_STEP_TYPES.modelSampling,
     ]) {
-      steps.push(await harness.recorder.startStep({ runId: run.id, type }))
+      steps.push(await harness.recorder.startStep({ runId: run.id, type }, TEST_DEADLINE))
     }
 
     assert.deepEqual(steps.map(step => step.sequence), [1, 2, 3])
@@ -187,11 +354,11 @@ describe('AgentRunRecorderService', () => {
     const firstStep = await harness.recorder.startStep({
       runId: firstRun.id,
       type: AGENT_STEP_TYPES.receiveUserMessage,
-    })
+    }, TEST_DEADLINE)
     const secondStep = await harness.recorder.startStep({
       runId: secondRun.id,
       type: AGENT_STEP_TYPES.receiveUserMessage,
-    })
+    }, TEST_DEADLINE)
 
     assert.equal(firstStep.sequence, 1)
     assert.equal(secondStep.sequence, 1)
@@ -215,14 +382,45 @@ function createHarness() {
   const recorder = new AgentRunRecorderService(
     prisma as unknown as PrismaService,
   )
+  const createRun = async (suffix: string) => {
+    const conversationId = `conversation-${suffix}`
+
+    prisma.ensureConversation(conversationId)
+    return await recorder.createRun({
+      conversationId,
+      userMessageId: `message-${suffix}`,
+    })
+  }
 
   return {
     recorder,
-    createRun: async (suffix: string) => await recorder.createRun({
-      conversationId: `conversation-${suffix}`,
-      userMessageId: `message-${suffix}`,
-    }),
+    createRun,
+    prepareAssistantRun: async (suffix: string) => {
+      const run = await createRun(suffix)
+      const message = await recorder.createAssistantMessage(
+        run.id,
+        run.conversationId,
+        TEST_DEADLINE,
+      )
+      const assistantStep = await recorder.startStep({
+        runId: run.id,
+        type: AGENT_STEP_TYPES.assistantOutput,
+      }, TEST_DEADLINE)
+
+      return {
+        run,
+        message,
+        assistantStep,
+        completion: {
+          runId: run.id,
+          conversationId: run.conversationId,
+          assistantMessageId: message.id,
+          assistantOutputStepId: assistantStep.id,
+        },
+      }
+    },
     run: (runId: string) => prisma.runs.find(run => run.id === runId),
+    message: (messageId: string) => prisma.messages.find(message => message.id === messageId),
     step: (stepId: string) => prisma.steps.find(step => step.id === stepId),
     steps: (runId: string) => prisma.steps.filter(step => step.runId === runId),
     unfinishedSteps: (runId: string) => prisma.steps.filter(step => (
@@ -230,7 +428,14 @@ function createHarness() {
       && UNFINISHED_STEP_STATUSES.includes(step.status)
     )),
     addPendingStep: (runId: string) => prisma.addPendingStep(runId),
+    failNextTransactionAt: (statement: number) => prisma.failNextTransactionAt(statement),
   }
+}
+
+interface StoredConversation {
+  id: string
+  title: string
+  updatedAt: Date
 }
 
 interface StoredRun {
@@ -262,11 +467,72 @@ interface StoredStep {
 }
 
 class FakePrismaService {
+  readonly conversations: StoredConversation[] = []
+  readonly messages: Message[] = []
   readonly runs: StoredRun[] = []
   readonly steps: StoredStep[] = []
 
+  private nextMessageId = 1
   private nextRunId = 1
   private nextStepId = 1
+  private transactionFailureAt: number | undefined
+
+  readonly conversation = {
+    update: async ({
+      where,
+      data,
+    }: {
+      where: { id: string }
+      data: { updatedAt: Date }
+    }): Promise<StoredConversation> => {
+      const conversation = this.conversations.find(candidate => candidate.id === where.id)
+
+      if (!conversation)
+        throw new Error(`conversation ${where.id} not found`)
+
+      conversation.updatedAt = data.updatedAt
+      return structuredClone(conversation)
+    },
+  }
+
+  readonly message = {
+    create: async ({ data }: {
+      data: Pick<Message, 'conversationId' | 'role' | 'content' | 'status'>
+    }): Promise<Message> => {
+      const now = new Date()
+      const message: Message = {
+        id: `assistant-${this.nextMessageId++}`,
+        ...data,
+        createdAt: now,
+        updatedAt: now,
+      }
+
+      this.messages.push(message)
+      return structuredClone(message)
+    },
+    findUniqueOrThrow: async ({ where }: { where: { id: string } }): Promise<Message> => {
+      const message = this.messages.find(candidate => candidate.id === where.id)
+
+      if (!message)
+        throw new Error(`message ${where.id} not found`)
+
+      return structuredClone(message)
+    },
+    updateMany: async ({
+      where,
+      data,
+    }: {
+      where: MessageWhere
+      data: Partial<Pick<Message, 'content' | 'status'>>
+    }): Promise<{ count: number }> => {
+      const matches = this.messages.filter(message => matchesMessage(message, where))
+
+      for (const message of matches)
+        Object.assign(message, structuredClone(data), { updatedAt: new Date() })
+
+      return { count: matches.length }
+    },
+  }
 
   readonly agentRun = {
     create: async ({ data }: { data: Partial<StoredRun> }): Promise<StoredRun> => {
@@ -372,11 +638,53 @@ class FakePrismaService {
     const runId = requireString(values[0])
     const run = this.runs.find(candidate => candidate.id === runId)
 
-    return (run ? [{ id: run.id, status: run.status }] : []) as T
+    return (run
+      ? [{
+          id: run.id,
+          status: run.status,
+          conversationId: run.conversationId,
+          assistantMessageId: run.assistantMessageId,
+        }]
+      : []) as T
   }
 
-  async $transaction<T>(operation: (prisma: FakePrismaService) => Promise<T>): Promise<T> {
-    return await operation(this)
+  async withDeadlineTransaction<T>(
+    deadline: DatabaseOperationDeadline,
+    operation: (transaction: DeadlineTransaction) => Promise<T>,
+    onCommitOwned?: () => void,
+  ): Promise<T> {
+    const snapshot = this.snapshot()
+    const failureAt = this.transactionFailureAt
+
+    this.transactionFailureAt = undefined
+
+    try {
+      this.assertDeadline(deadline)
+      const result = await operation(new FakeDeadlineTransaction(this, failureAt))
+
+      this.assertDeadline(deadline)
+      onCommitOwned?.()
+      return result
+    }
+    catch (error) {
+      this.restore(snapshot)
+      throw error
+    }
+  }
+
+  ensureConversation(id: string): void {
+    if (this.conversations.some(conversation => conversation.id === id))
+      return
+
+    this.conversations.push({
+      id,
+      title: id,
+      updatedAt: new Date(),
+    })
+  }
+
+  failNextTransactionAt(statement: number): void {
+    this.transactionFailureAt = statement
   }
 
   addPendingStep(runId: string): void {
@@ -402,12 +710,69 @@ class FakePrismaService {
       updatedAt: now,
     })
   }
+
+  private assertDeadline(deadline: DatabaseOperationDeadline): void {
+    deadline.signal?.throwIfAborted()
+
+    if (Date.now() >= deadline.deadlineAt)
+      throw deadline.createTimeoutError()
+  }
+
+  private snapshot() {
+    return {
+      conversations: structuredClone(this.conversations),
+      messages: structuredClone(this.messages),
+      runs: structuredClone(this.runs),
+      steps: structuredClone(this.steps),
+      nextMessageId: this.nextMessageId,
+      nextRunId: this.nextRunId,
+      nextStepId: this.nextStepId,
+    }
+  }
+
+  private restore(snapshot: ReturnType<FakePrismaService['snapshot']>): void {
+    this.conversations.splice(0, this.conversations.length, ...snapshot.conversations)
+    this.messages.splice(0, this.messages.length, ...snapshot.messages)
+    this.runs.splice(0, this.runs.length, ...snapshot.runs)
+    this.steps.splice(0, this.steps.length, ...snapshot.steps)
+    this.nextMessageId = snapshot.nextMessageId
+    this.nextRunId = snapshot.nextRunId
+    this.nextStepId = snapshot.nextStepId
+  }
+}
+
+class FakeDeadlineTransaction implements DeadlineTransaction {
+  private statement = 0
+
+  constructor(
+    private readonly prisma: FakePrismaService,
+    private readonly failureAt: number | undefined,
+  ) {}
+
+  async execute<T>(
+    operation: (prisma: Prisma.TransactionClient) => Promise<T>,
+  ): Promise<T> {
+    this.statement += 1
+
+    if (this.statement === this.failureAt)
+      throw new Error('injected transaction failure')
+
+    return await operation(this.prisma as unknown as Prisma.TransactionClient)
+  }
 }
 
 interface StepWhere {
   id?: string
   runId?: string
+  type?: string
   status?: AgentStepStatus | { in: AgentStepStatus[] }
+}
+
+interface MessageWhere {
+  id?: string
+  conversationId?: string
+  role?: MessageRole
+  status?: MessageStatus | { in: MessageStatus[] }
 }
 
 function matchesStep(step: StoredStep, where: StepWhere): boolean {
@@ -415,12 +780,29 @@ function matchesStep(step: StoredStep, where: StepWhere): boolean {
     return false
   if (where.runId !== undefined && step.runId !== where.runId)
     return false
+  if (where.type !== undefined && step.type !== where.type)
+    return false
   if (where.status === undefined)
     return true
   if (typeof where.status === 'object')
     return where.status.in.includes(step.status)
 
   return step.status === where.status
+}
+
+function matchesMessage(message: Message, where: MessageWhere): boolean {
+  if (where.id !== undefined && message.id !== where.id)
+    return false
+  if (where.conversationId !== undefined && message.conversationId !== where.conversationId)
+    return false
+  if (where.role !== undefined && message.role !== where.role)
+    return false
+  if (where.status === undefined)
+    return true
+  if (typeof where.status === 'object')
+    return where.status.in.includes(message.status)
+
+  return message.status === where.status
 }
 
 function requireString(value: unknown): string {

--- a/apps/api/src/agent-runtime/agent-run-recorder.service.ts
+++ b/apps/api/src/agent-runtime/agent-run-recorder.service.ts
@@ -1,7 +1,16 @@
-import type { AgentRun, AgentStep, Prisma } from '../generated/prisma/client.js'
+import type { AgentRun, AgentStep, Message, Prisma } from '../generated/prisma/client.js'
+import type {
+  DatabaseOperationDeadline,
+  DeadlineTransaction,
+} from '../prisma/prisma.service.js'
 import { Inject, Injectable } from '@nestjs/common'
 
-import { AgentRunStatus, AgentStepStatus } from '../generated/prisma/client.js'
+import {
+  AgentRunStatus,
+  AgentStepStatus,
+  MessageRole,
+  MessageStatus,
+} from '../generated/prisma/client.js'
 import { PrismaService } from '../prisma/prisma.service.js'
 
 export const AGENT_STEP_TYPES = {
@@ -50,6 +59,27 @@ interface AbortAgentStepInput extends CompleteAgentStepInput {
   errorMessage?: string
 }
 
+interface CompleteAgentRunInput {
+  runId: string
+  conversationId: string
+  assistantMessageId: string
+  assistantOutputStepId: string
+  content: string
+  output?: Prisma.InputJsonValue
+}
+
+interface CloseAssistantMessageInput {
+  id: string
+  conversationId: string
+  content: string
+}
+
+interface CloseAgentStepInput {
+  id: string
+  errorMessage: string
+  output?: Prisma.InputJsonValue
+}
+
 export class RecorderInvariantError extends Error {
   constructor(message: string) {
     super(message)
@@ -77,27 +107,59 @@ export class AgentRunRecorderService {
     })
   }
 
-  async attachAssistantMessage(runId: string, assistantMessageId: string): Promise<void> {
-    const result = await this.prismaService.agentRun.updateMany({
-      where: {
-        id: runId,
-        status: AgentRunStatus.RUNNING,
-      },
-      data: {
-        assistantMessageId,
-      },
-    })
+  async createAssistantMessage(
+    runId: string,
+    conversationId: string,
+    deadline: DatabaseOperationDeadline,
+  ): Promise<Message> {
+    return await this.prismaService.withDeadlineTransaction(deadline, async (transaction) => {
+      const run = await this.assertRunningRunLocked(transaction, runId)
 
-    this.assertSingleUpdate(result.count, `AgentRun ${runId} 无法关联助手消息`)
+      if (run.conversationId !== conversationId || run.assistantMessageId !== null) {
+        throw new RecorderInvariantError(
+          `AgentRun ${runId} 的会话不匹配或已关联助手消息`,
+        )
+      }
+
+      const message = await transaction.execute(prisma => prisma.message.create({
+        data: {
+          conversationId,
+          role: MessageRole.ASSISTANT,
+          content: '',
+          status: MessageStatus.STREAMING,
+        },
+      }))
+      const result = await transaction.execute(prisma => prisma.agentRun.updateMany({
+        where: {
+          id: runId,
+          status: AgentRunStatus.RUNNING,
+        },
+        data: {
+          assistantMessageId: message.id,
+        },
+      }))
+
+      this.assertSingleUpdate(result.count, `AgentRun ${runId} 无法关联助手消息`)
+
+      await transaction.execute(prisma => prisma.conversation.update({
+        where: { id: conversationId },
+        data: { updatedAt: new Date() },
+      }))
+
+      return message
+    })
   }
 
-  async startStep(input: StartAgentStepInput): Promise<AgentStep> {
-    return await this.prismaService.$transaction(async (prisma) => {
-      await this.assertRunningRunLocked(prisma, input.runId)
-      const sequence = await this.nextStepSequence(prisma, input.runId)
+  async startStep(
+    input: StartAgentStepInput,
+    deadline: DatabaseOperationDeadline,
+  ): Promise<AgentStep> {
+    return await this.prismaService.withDeadlineTransaction(deadline, async (transaction) => {
+      await this.assertRunningRunLocked(transaction, input.runId)
+      const sequence = await this.nextStepSequence(transaction, input.runId)
       const now = new Date()
 
-      return await prisma.agentStep.create({
+      return await transaction.execute(prisma => prisma.agentStep.create({
         data: {
           runId: input.runId,
           sequence,
@@ -107,83 +169,178 @@ export class AgentRunRecorderService {
           ...(input.input === undefined ? {} : { input: input.input }),
           startedAt: now,
         },
-      })
+      }))
     })
   }
 
   async completeStep(
     stepId: string,
+    deadline: DatabaseOperationDeadline,
     input: CompleteAgentStepInput = {},
   ): Promise<void> {
-    await this.transitionStep(stepId, AgentStepStatus.COMPLETED, input)
+    await this.transitionStep(stepId, AgentStepStatus.COMPLETED, deadline, input)
   }
 
-  async failStep(stepId: string, input: FailAgentStepInput): Promise<void> {
-    await this.transitionStep(stepId, AgentStepStatus.FAILED, input)
+  async failStep(
+    stepId: string,
+    deadline: DatabaseOperationDeadline,
+    input: FailAgentStepInput,
+  ): Promise<void> {
+    await this.transitionStep(stepId, AgentStepStatus.FAILED, deadline, input)
   }
 
   async abortStep(
     stepId: string,
+    deadline: DatabaseOperationDeadline,
     input: AbortAgentStepInput = {},
   ): Promise<void> {
-    await this.transitionStep(stepId, AgentStepStatus.ABORTED, input)
+    await this.transitionStep(stepId, AgentStepStatus.ABORTED, deadline, input)
   }
 
-  async completeRun(runId: string): Promise<void> {
-    await this.prismaService.$transaction(async (prisma) => {
-      await this.assertRunningRunLocked(prisma, runId)
-      const unfinishedStepCount = await prisma.agentStep.count({
+  async completeRun(
+    input: CompleteAgentRunInput,
+    deadline: DatabaseOperationDeadline,
+    onCommitOwned: () => void = () => {},
+  ): Promise<Message> {
+    return await this.prismaService.withDeadlineTransaction(deadline, async (transaction) => {
+      const run = await this.assertRunningRunLocked(transaction, input.runId)
+
+      if (
+        run.conversationId !== input.conversationId
+        || run.assistantMessageId !== input.assistantMessageId
+      ) {
+        throw new RecorderInvariantError(
+          `AgentRun ${input.runId} 的会话或助手消息不匹配`,
+        )
+      }
+
+      const messageResult = await transaction.execute(prisma => prisma.message.updateMany({
         where: {
-          runId,
+          id: input.assistantMessageId,
+          conversationId: input.conversationId,
+          role: MessageRole.ASSISTANT,
+          status: {
+            in: [MessageStatus.PENDING, MessageStatus.STREAMING],
+          },
+        },
+        data: {
+          content: input.content,
+          status: MessageStatus.COMPLETED,
+        },
+      }))
+
+      this.assertSingleUpdate(
+        messageResult.count,
+        `Message ${input.assistantMessageId} 已进入终态或不存在`,
+      )
+
+      await transaction.execute(prisma => prisma.conversation.update({
+        where: { id: input.conversationId },
+        data: { updatedAt: new Date() },
+      }))
+
+      const now = new Date()
+      const stepResult = await transaction.execute(prisma => prisma.agentStep.updateMany({
+        where: {
+          id: input.assistantOutputStepId,
+          runId: input.runId,
+          type: AGENT_STEP_TYPES.assistantOutput,
+          status: AgentStepStatus.RUNNING,
+        },
+        data: {
+          status: AgentStepStatus.COMPLETED,
+          ...(input.output === undefined ? {} : { output: input.output }),
+          endedAt: now,
+        },
+      }))
+
+      this.assertSingleUpdate(
+        stepResult.count,
+        `AgentStep ${input.assistantOutputStepId} 已进入终态或尚未开始`,
+      )
+
+      const unfinishedStepCount = await transaction.execute(prisma => prisma.agentStep.count({
+        where: {
+          runId: input.runId,
           status: {
             in: UNFINISHED_STEP_STATUSES,
           },
         },
-      })
+      }))
 
       if (unfinishedStepCount > 0) {
         throw new RecorderInvariantError(
-          `AgentRun ${runId} 仍有 ${unfinishedStepCount} 条非终态 Step，不能完成`,
+          `AgentRun ${input.runId} 仍有 ${unfinishedStepCount} 条非终态 Step，不能完成`,
         )
       }
 
-      await this.transitionRun(prisma, runId, AgentRunStatus.COMPLETED)
-    })
+      const message = await transaction.execute(prisma => prisma.message.findUniqueOrThrow({
+        where: { id: input.assistantMessageId },
+      }))
+
+      await this.transitionRun(
+        transaction,
+        input.runId,
+        AgentRunStatus.COMPLETED,
+        now,
+      )
+
+      return message
+    }, onCommitOwned)
   }
 
-  async failRun(runId: string, errorMessage: string): Promise<void> {
+  async failRun(
+    runId: string,
+    errorMessage: string,
+    deadline: DatabaseOperationDeadline,
+    assistantMessage?: CloseAssistantMessageInput,
+    failedStep?: CloseAgentStepInput,
+  ): Promise<void> {
     await this.closeRunAndUnfinishedSteps(
       runId,
       AgentRunStatus.FAILED,
       AgentStepStatus.FAILED,
+      MessageStatus.FAILED,
+      deadline,
       errorMessage,
+      assistantMessage,
+      failedStep,
     )
   }
 
-  async abortRun(runId: string): Promise<void> {
+  async abortRun(
+    runId: string,
+    deadline: DatabaseOperationDeadline,
+    assistantMessage?: CloseAssistantMessageInput,
+  ): Promise<void> {
     await this.closeRunAndUnfinishedSteps(
       runId,
       AgentRunStatus.ABORTED,
       AgentStepStatus.ABORTED,
+      MessageStatus.ABORTED,
+      deadline,
+      undefined,
+      assistantMessage,
     )
   }
 
   private async transitionStep(
     stepId: string,
     status: typeof AgentStepStatus.COMPLETED | typeof AgentStepStatus.FAILED | typeof AgentStepStatus.ABORTED,
+    deadline: DatabaseOperationDeadline,
     input: CompleteAgentStepInput & { errorMessage?: string },
   ): Promise<void> {
-    await this.prismaService.$transaction(async (prisma) => {
-      const step = await prisma.agentStep.findUnique({
+    await this.prismaService.withDeadlineTransaction(deadline, async (transaction) => {
+      const step = await transaction.execute(prisma => prisma.agentStep.findUnique({
         where: { id: stepId },
         select: { runId: true },
-      })
+      }))
 
       if (!step)
         throw new RecorderInvariantError(`AgentStep ${stepId} 不存在`)
 
-      await this.assertRunningRunLocked(prisma, step.runId)
-      const result = await prisma.agentStep.updateMany({
+      await this.assertRunningRunLocked(transaction, step.runId)
+      const result = await transaction.execute(prisma => prisma.agentStep.updateMany({
         where: {
           id: stepId,
           status: AgentStepStatus.RUNNING,
@@ -194,7 +351,7 @@ export class AgentRunRecorderService {
           ...(input.errorMessage === undefined ? {} : { errorMessage: input.errorMessage }),
           endedAt: new Date(),
         },
-      })
+      }))
 
       this.assertSingleUpdate(result.count, `AgentStep ${stepId} 已进入终态或尚未开始`)
     })
@@ -204,13 +361,100 @@ export class AgentRunRecorderService {
     runId: string,
     runStatus: typeof AgentRunStatus.FAILED | typeof AgentRunStatus.ABORTED,
     stepStatus: typeof AgentStepStatus.FAILED | typeof AgentStepStatus.ABORTED,
+    messageStatus: typeof MessageStatus.FAILED | typeof MessageStatus.ABORTED,
+    deadline: DatabaseOperationDeadline,
     errorMessage?: string,
+    assistantMessage?: CloseAssistantMessageInput,
+    failedStep?: CloseAgentStepInput,
   ): Promise<void> {
-    await this.prismaService.$transaction(async (prisma) => {
-      await this.assertRunningRunLocked(prisma, runId)
+    await this.prismaService.withDeadlineTransaction(deadline, async (transaction) => {
+      const run = await this.assertRunningRunLocked(transaction, runId)
       const now = new Date()
 
-      await prisma.agentStep.updateMany({
+      const assistantMessageId = assistantMessage?.id ?? run.assistantMessageId
+
+      if (assistantMessageId) {
+        if (
+          (
+            assistantMessage
+            && run.conversationId !== assistantMessage.conversationId
+          )
+          || (
+            run.assistantMessageId !== null
+            && run.assistantMessageId !== assistantMessageId
+          )
+        ) {
+          throw new RecorderInvariantError(
+            `AgentRun ${runId} 的会话或助手消息不匹配`,
+          )
+        }
+
+        const messageResult = await transaction.execute(prisma => prisma.message.updateMany({
+          where: {
+            id: assistantMessageId,
+            conversationId: run.conversationId,
+            role: MessageRole.ASSISTANT,
+            status: {
+              in: [MessageStatus.PENDING, MessageStatus.STREAMING],
+            },
+          },
+          data: {
+            content: assistantMessage?.content ?? errorMessage ?? '',
+            status: messageStatus,
+          },
+        }))
+
+        this.assertSingleUpdate(
+          messageResult.count,
+          `Message ${assistantMessageId} 已进入终态或不存在`,
+        )
+
+        await transaction.execute(prisma => prisma.conversation.update({
+          where: { id: run.conversationId },
+          data: { updatedAt: now },
+        }))
+      }
+
+      if (failedStep) {
+        const existingStep = await transaction.execute(prisma => prisma.agentStep.findUnique({
+          where: { id: failedStep.id },
+          select: { runId: true, status: true },
+        }))
+
+        if (!existingStep || existingStep.runId !== runId) {
+          throw new RecorderInvariantError(
+            `AgentStep ${failedStep.id} 不属于 AgentRun ${runId}`,
+          )
+        }
+
+        if (
+          existingStep.status === AgentStepStatus.PENDING
+          || existingStep.status === AgentStepStatus.RUNNING
+        ) {
+          const failedStepResult = await transaction.execute(prisma => prisma.agentStep.updateMany({
+            where: {
+              id: failedStep.id,
+              runId,
+              status: {
+                in: UNFINISHED_STEP_STATUSES,
+              },
+            },
+            data: {
+              status: stepStatus,
+              errorMessage: failedStep.errorMessage,
+              ...(failedStep.output === undefined ? {} : { output: failedStep.output }),
+              endedAt: now,
+            },
+          }))
+
+          this.assertSingleUpdate(
+            failedStepResult.count,
+            `AgentStep ${failedStep.id} 已并发进入终态`,
+          )
+        }
+      }
+
+      await transaction.execute(prisma => prisma.agentStep.updateMany({
         where: {
           runId,
           status: {
@@ -222,19 +466,26 @@ export class AgentRunRecorderService {
           ...(errorMessage === undefined ? {} : { errorMessage }),
           endedAt: now,
         },
-      })
+      }))
 
-      await this.transitionRun(prisma, runId, runStatus, now)
+      await this.transitionRun(
+        transaction,
+        runId,
+        runStatus,
+        now,
+        assistantMessage?.id,
+      )
     })
   }
 
   private async transitionRun(
-    prisma: Prisma.TransactionClient,
+    transaction: DeadlineTransaction,
     runId: string,
     status: typeof AgentRunStatus.COMPLETED | typeof AgentRunStatus.FAILED | typeof AgentRunStatus.ABORTED,
     endedAt = new Date(),
+    assistantMessageId?: string,
   ): Promise<void> {
-    const result = await prisma.agentRun.updateMany({
+    const result = await transaction.execute(prisma => prisma.agentRun.updateMany({
       where: {
         id: runId,
         status: AgentRunStatus.RUNNING,
@@ -242,35 +493,41 @@ export class AgentRunRecorderService {
       data: {
         status,
         endedAt,
+        ...(assistantMessageId === undefined ? {} : { assistantMessageId }),
       },
-    })
+    }))
 
     this.assertSingleUpdate(result.count, `AgentRun ${runId} 已进入终态或不存在`)
   }
 
   private async assertRunningRunLocked(
-    prisma: Prisma.TransactionClient,
+    transaction: DeadlineTransaction,
     runId: string,
-  ): Promise<void> {
-    const runs = await prisma.$queryRaw<Array<Pick<AgentRun, 'id' | 'status'>>>`
-      SELECT "id", "status"
+  ): Promise<Pick<AgentRun, 'id' | 'status' | 'conversationId' | 'assistantMessageId'>> {
+    const runs = await transaction.execute(prisma => prisma.$queryRaw<Array<Pick<
+      AgentRun,
+      'id' | 'status' | 'conversationId' | 'assistantMessageId'
+    >>>`
+      SELECT "id", "status", "conversationId", "assistantMessageId"
       FROM "AgentRun"
       WHERE "id" = ${runId}
       FOR UPDATE
-    `
+    `)
 
     if (runs[0]?.status !== AgentRunStatus.RUNNING)
       throw new RecorderInvariantError(`AgentRun ${runId} 已进入终态或不存在`)
+
+    return runs[0]
   }
 
   private async nextStepSequence(
-    prisma: Prisma.TransactionClient,
+    transaction: DeadlineTransaction,
     runId: string,
   ): Promise<number> {
-    const result = await prisma.agentStep.aggregate({
+    const result = await transaction.execute(prisma => prisma.agentStep.aggregate({
       where: { runId },
       _max: { sequence: true },
-    })
+    }))
 
     return (result._max.sequence ?? 0) + 1
   }

--- a/apps/api/src/agent-runtime/agent-runtime.errors.ts
+++ b/apps/api/src/agent-runtime/agent-runtime.errors.ts
@@ -17,6 +17,17 @@ export class AgentRunDeadlineExceededError extends Error {
   }
 }
 
+/** 终态持久化失败；原始 Run 原因不能被 cleanup 错误覆盖。 */
+export class AgentRunTerminalizationError extends Error {
+  constructor(
+    readonly runCause: unknown,
+    readonly terminalizationCause: unknown,
+  ) {
+    super('Agent Run 终态未能可靠持久化。')
+    this.name = 'AgentRunTerminalizationError'
+  }
+}
+
 /** 当前 sampling 无法作为一条完整助手回答结束。 */
 export class ModelSamplingIncompleteError extends Error {
   constructor(
@@ -54,13 +65,5 @@ export class ModelSamplingIncompleteError extends Error {
           summary,
         )
     }
-  }
-}
-
-/** 用户可见 Message 已由另一条终态路径收口，当前路径不得继续推进 Run。 */
-export class MessageTerminalTransitionError extends Error {
-  constructor(messageId: string) {
-    super(`Message ${messageId} 已进入终态，拒绝迟到更新`)
-    this.name = 'MessageTerminalTransitionError'
   }
 }

--- a/apps/api/src/agent-runtime/agent-runtime.service.test.ts
+++ b/apps/api/src/agent-runtime/agent-runtime.service.test.ts
@@ -6,7 +6,11 @@ import type {
   ModelFinishReason,
   ModelStreamEvent,
 } from '../llm/model-stream.types.js'
-import type { PrismaService } from '../prisma/prisma.service.js'
+import type {
+  DatabaseOperationDeadline,
+  DeadlineTransaction,
+  PrismaService,
+} from '../prisma/prisma.service.js'
 import type { ToolInvocationService } from '../tools/core/tool-invocation.service.js'
 import type { ToolRegistryService } from '../tools/core/tool-registry.service.js'
 import type {
@@ -32,8 +36,13 @@ import {
   MessageRole,
   MessageStatus,
 } from '../generated/prisma/client.js'
+import {
+  DatabaseCommitOutcomeUnknownError,
+  DatabaseOperationDeadlineExceededError,
+} from '../prisma/prisma.service.js'
 import { buildSeoAgentChatMessages } from '../seo/prompts/seo-agent.prompt.js'
 import { toChatStreamEvent } from '../seo/seo-chat-stream-event.mapper.js'
+import { AgentRunTerminalizationError } from './agent-runtime.errors.js'
 import { AgentRuntimeService } from './agent-runtime.service.js'
 
 describe('AgentRuntimeService model stream', () => {
@@ -1019,7 +1028,7 @@ describe('AgentRuntimeService model stream', () => {
     assertNoUnfinishedSteps(harness)
   })
 
-  it('Message 已进入 ABORTED 后拒绝迟到 completion 推进 Step 和 Run', async () => {
+  it('Message 已进入 ABORTED 后拒绝迟到 completion 且不伪造收口成功', async () => {
     const harness = createHarness(() => toModelStream([
       { type: 'text_delta', delta: '迟到回答' },
       { type: 'response_completed', finishReason: 'stop' },
@@ -1035,15 +1044,15 @@ describe('AgentRuntimeService model stream', () => {
     assistantMessage.status = MessageStatus.ABORTED
     assistantMessage.content = '已停止'
 
-    const remainingEvents = await collectEvents(stream)
-
-    assert.deepEqual(remainingEvents.map(event => event.type), ['run_failed'])
+    await assert.rejects(
+      stream.next(),
+      AgentRunTerminalizationError,
+    )
     assert.equal(harness.assistantMessage()?.status, MessageStatus.ABORTED)
     assert.equal(harness.assistantMessage()?.content, '已停止')
     assert.deepEqual(harness.recorder.completedRunIds, [])
-    assert.deepEqual(harness.recorder.failedRunIds, ['run-1'])
-    assert.equal(findStep(harness, 'assistant_output')?.status, AgentStepStatus.FAILED)
-    assertNoUnfinishedSteps(harness)
+    assert.deepEqual(harness.recorder.failedRunIds, [])
+    assert.equal(findStep(harness, 'assistant_output')?.status, AgentStepStatus.RUNNING)
   })
 
   it('不把 length、content_filter 或 unknown 当作完整回答', async () => {
@@ -1095,7 +1104,7 @@ describe('AgentRuntimeService model stream', () => {
     assertNoUnfinishedSteps(harness)
   })
 
-  it('请求开始前已 Abort 时仍产出 start / run_aborted 并收口状态', async () => {
+  it('请求开始前已 Abort 时不再开始 normal DB / sampling 并收口 Run', async () => {
     const abortController = new AbortController()
 
     abortController.abort()
@@ -1108,14 +1117,12 @@ describe('AgentRuntimeService model stream', () => {
 
     const events = await collectEvents(harness.run())
 
-    assert.deepEqual(events.map(event => event.type), [
-      'run_started',
-      'run_aborted',
-    ])
+    assert.deepEqual(events, [])
     assert.equal(harness.llmCalls.length, 0)
-    assert.equal(harness.assistantMessage()?.status, MessageStatus.ABORTED)
+    assert.equal(harness.assistantMessage(), undefined)
     assert.deepEqual(harness.recorder.abortedRunIds, ['run-1'])
     assert.deepEqual(harness.recorder.failedRunIds, [])
+    assert.deepEqual(harness.recorder.steps, [])
     assertNoUnfinishedSteps(harness)
   })
 
@@ -1249,7 +1256,52 @@ describe('AgentRuntimeService model stream', () => {
     assertNoUnfinishedSteps(harness)
   })
 
-  it('Message COMPLETED CAS 后到达的用户 Abort 不覆盖正常完成', async () => {
+  it('Run-budget DB timeout 归因为 deadline 且不开始 sampling', async () => {
+    const harness = createHarness(() => toModelStream([
+      { type: 'response_completed', finishReason: 'stop' },
+    ]))
+
+    harness.prisma.deadlineTransactionError
+      = new DatabaseOperationDeadlineExceededError()
+    const events = await collectEvents(harness.run())
+    const failure = events.at(-1)
+
+    assert.equal(failure?.type, 'run_failed')
+    assert.match(
+      failure?.type === 'run_failed' ? failure.message : '',
+      /执行时限/,
+    )
+    assert.equal(harness.llmCalls.length, 0)
+    assert.deepEqual(harness.recorder.failedRunIds, ['run-1'])
+    assertNoUnfinishedSteps(harness)
+  })
+
+  it('普通 DB failure 先发生时不被随后 Run deadline 改写', async () => {
+    const harness = createHarness(
+      () => toModelStream([
+        { type: 'response_completed', finishReason: 'stop' },
+      ]),
+      undefined,
+      undefined,
+      { runDeadlineMs: 5 },
+    )
+
+    harness.prisma.deadlineTransactionError = new Error('ordinary database failure')
+    harness.recorder.failRunDelayMs = 15
+    const events = await collectEvents(harness.run())
+    const failure = events.at(-1)
+
+    assert.equal(failure?.type, 'run_failed')
+    assert.doesNotMatch(
+      failure?.type === 'run_failed' ? failure.message : '',
+      /执行时限/,
+    )
+    assert.equal(harness.llmCalls.length, 0)
+    assert.deepEqual(harness.recorder.failedRunIds, ['run-1'])
+    assertNoUnfinishedSteps(harness)
+  })
+
+  it('terminal transaction 提交后到达的用户 Abort 不覆盖正常完成', async () => {
     const abortController = new AbortController()
     const harness = createHarness(
       () => toModelStream([
@@ -1258,19 +1310,90 @@ describe('AgentRuntimeService model stream', () => {
       ]),
       abortController.signal,
     )
-    const stream = harness.run()
+    const events = await collectEvents(harness.run())
 
-    assert.equal((await stream.next()).value?.type, 'run_started')
-    assert.equal((await stream.next()).value?.type, 'assistant_delta')
-    harness.prisma.afterTransaction = () => abortController.abort()
-
-    const events = await collectEvents(stream)
-
-    assert.deepEqual(events.map(event => event.type), ['run_completed'])
+    abortController.abort()
+    assert.equal(events.at(-1)?.type, 'run_completed')
     assert.equal(harness.assistantMessage()?.status, MessageStatus.COMPLETED)
     assert.deepEqual(harness.recorder.completedRunIds, ['run-1'])
     assert.deepEqual(harness.recorder.abortedRunIds, [])
     assertNoUnfinishedSteps(harness)
+  })
+
+  it('completion commit ownership 已取得时，提交期间 Abort 不覆盖正常完成', async () => {
+    const abortController = new AbortController()
+    const commitGate = createDeferred()
+    const harness = createHarness(
+      () => toModelStream([
+        { type: 'text_delta', delta: '已完成' },
+        { type: 'response_completed', finishReason: 'stop' },
+      ]),
+      abortController.signal,
+    )
+    harness.recorder.completeRunCommitGate = commitGate.promise
+
+    const eventsPromise = collectEvents(harness.run())
+    await harness.recorder.completionOwnership.promise
+    abortController.abort()
+    commitGate.resolve()
+    const events = await eventsPromise
+
+    assert.equal(events.at(-1)?.type, 'run_completed')
+    assert.equal(harness.assistantMessage()?.status, MessageStatus.COMPLETED)
+    assert.deepEqual(harness.recorder.completedRunIds, ['run-1'])
+    assert.deepEqual(harness.recorder.abortedRunIds, [])
+    assertNoUnfinishedSteps(harness)
+  })
+
+  it('completion commit 失败时恢复提交期间最先到达的 deadline', async () => {
+    const commitGate = createDeferred()
+    const harness = createHarness(
+      () => toModelStream([
+        { type: 'text_delta', delta: '未提交' },
+        { type: 'response_completed', finishReason: 'stop' },
+      ]),
+      undefined,
+      undefined,
+      { runDeadlineMs: 20 },
+    )
+    harness.recorder.completeRunCommitGate = commitGate.promise
+    harness.recorder.completeRunCommitError = new Error('commit failed')
+
+    const eventsPromise = collectEvents(harness.run())
+    await harness.recorder.completionOwnership.promise
+    await new Promise(resolve => setTimeout(resolve, 30))
+    commitGate.resolve()
+    const events = await eventsPromise
+
+    assert.equal(events.at(-1)?.type, 'run_failed')
+    assert.equal(harness.assistantMessage()?.status, MessageStatus.FAILED)
+    assert.deepEqual(harness.recorder.completedRunIds, [])
+    assert.deepEqual(harness.recorder.failedRunIds, ['run-1'])
+    assertNoUnfinishedSteps(harness)
+  })
+
+  it('completion commit 结果未知时不伪造失败收口或启动 cleanup', async () => {
+    const outcomeUnknown = new DatabaseCommitOutcomeUnknownError()
+    const harness = createHarness(() => toModelStream([
+      { type: 'text_delta', delta: '结果未知' },
+      { type: 'response_completed', finishReason: 'stop' },
+    ]))
+    harness.recorder.completeRunCommitError = outcomeUnknown
+
+    await assert.rejects(
+      collectEvents(harness.run()),
+      error => (
+        error instanceof AgentRunTerminalizationError
+        && error.runCause === outcomeUnknown
+        && error.terminalizationCause === outcomeUnknown
+      ),
+    )
+
+    assert.equal(harness.assistantMessage()?.status, MessageStatus.STREAMING)
+    assert.deepEqual(harness.recorder.completedRunIds, [])
+    assert.deepEqual(harness.recorder.failedRunIds, [])
+    assert.deepEqual(harness.recorder.abortedRunIds, [])
+    assert.equal(findStep(harness, 'assistant_output')?.status, AgentStepStatus.RUNNING)
   })
 })
 
@@ -1361,7 +1484,7 @@ function createHarness(
   policy: Partial<AgentRuntimePolicy> = {},
 ) {
   const prisma = new FakePrismaService()
-  const recorder = new FakeAgentRunRecorderService()
+  const recorder = new FakeAgentRunRecorderService(prisma)
   const llmCalls: Array<{
     messages: ModelInputItem[]
     options: ChatStreamOptions | undefined
@@ -1442,7 +1565,7 @@ class FakePrismaService {
   readonly messages: Message[] = []
   readonly findManyArguments: FakeMessageFindManyArguments[] = []
   conversationExists = true
-  afterTransaction: (() => void) | undefined
+  deadlineTransactionError: unknown
 
   readonly conversation = {
     findUnique: async () => this.conversationExists
@@ -1529,11 +1652,37 @@ class FakePrismaService {
   }
 
   async $transaction<T>(operation: (prisma: FakePrismaService) => Promise<T>): Promise<T> {
-    const result = await operation(this)
-    const afterTransaction = this.afterTransaction
+    return await operation(this)
+  }
 
-    this.afterTransaction = undefined
-    afterTransaction?.()
+  async withDeadlineTransaction<T>(
+    deadline: DatabaseOperationDeadline,
+    callback: (transaction: DeadlineTransaction) => Promise<T>,
+  ): Promise<T> {
+    if (this.deadlineTransactionError !== undefined) {
+      const error = this.deadlineTransactionError
+
+      this.deadlineTransactionError = undefined
+      throw error
+    }
+
+    const assertAvailable = (): void => {
+      deadline.signal?.throwIfAborted()
+      if (Date.now() >= deadline.deadlineAt)
+        throw deadline.createTimeoutError()
+    }
+    const transaction: DeadlineTransaction = {
+      execute: async (operation) => {
+        assertAvailable()
+        const result = await operation(this as never)
+        assertAvailable()
+        return result
+      },
+    }
+
+    assertAvailable()
+    const result = await callback(transaction)
+    assertAvailable()
     return result
   }
 
@@ -1569,6 +1718,12 @@ class FakeAgentRunRecorderService {
   readonly failedRunIds: string[] = []
   readonly abortedRunIds: string[] = []
   readonly steps: RecordedAgentStep[] = []
+  readonly completionOwnership = createDeferred()
+  completeRunCommitError: Error | undefined
+  completeRunCommitGate: Promise<void> | undefined
+  failRunDelayMs = 0
+
+  constructor(private readonly prisma: FakePrismaService) {}
 
   async createRun(input: {
     conversationId: string
@@ -1589,13 +1744,28 @@ class FakeAgentRunRecorderService {
     }
   }
 
-  async attachAssistantMessage(): Promise<void> {}
+  async createAssistantMessage(
+    _runId: string,
+    conversationId: string,
+    deadline: DatabaseOperationDeadline,
+  ): Promise<Message> {
+    this.assertDeadline(deadline)
+    return await this.prisma.message.create({
+      data: {
+        conversationId,
+        role: MessageRole.ASSISTANT,
+        content: '',
+        status: MessageStatus.STREAMING,
+      },
+    })
+  }
 
   async startStep(input: {
     runId: string
     type: string
     input?: unknown
-  }): Promise<RecordedAgentStep> {
+  }, deadline: DatabaseOperationDeadline): Promise<RecordedAgentStep> {
+    this.assertDeadline(deadline)
     const now = new Date()
     const step: RecordedAgentStep = {
       id: `step-${this.steps.length + 1}`,
@@ -1614,40 +1784,129 @@ class FakeAgentRunRecorderService {
     return step
   }
 
-  async completeStep(stepId: string, input: { output?: unknown } = {}): Promise<void> {
+  async completeStep(
+    stepId: string,
+    _deadline: DatabaseOperationDeadline,
+    input: { output?: unknown } = {},
+  ): Promise<void> {
+    this.assertDeadline(_deadline)
     this.transitionStep(stepId, AgentStepStatus.COMPLETED, input)
   }
 
   async failStep(
     stepId: string,
+    _deadline: DatabaseOperationDeadline,
     input: { errorMessage: string, output?: unknown },
   ): Promise<void> {
+    this.assertDeadline(_deadline)
     this.transitionStep(stepId, AgentStepStatus.FAILED, input)
   }
 
   async abortStep(
     stepId: string,
+    _deadline: DatabaseOperationDeadline,
     input: { errorMessage?: string, output?: unknown } = {},
   ): Promise<void> {
+    this.assertDeadline(_deadline)
     this.transitionStep(stepId, AgentStepStatus.ABORTED, input)
   }
 
-  async completeRun(runId: string): Promise<void> {
+  async completeRun(
+    input: {
+      runId: string
+      assistantMessageId: string
+      assistantOutputStepId: string
+      content: string
+      output?: unknown
+    },
+    _deadline: DatabaseOperationDeadline,
+    onCommitOwned: () => void = () => {},
+  ): Promise<Message> {
+    this.assertDeadline(_deadline)
+    const message = this.prisma.messages.find(
+      candidate => candidate.id === input.assistantMessageId,
+    )
+
+    assert.ok(message)
+    if (
+      message.status !== MessageStatus.PENDING
+      && message.status !== MessageStatus.STREAMING
+    ) {
+      throw new Error(`Message ${message.id} 已进入终态`)
+    }
+
+    onCommitOwned()
+    this.completionOwnership.resolve()
+    if (this.completeRunCommitGate)
+      await this.completeRunCommitGate
+
+    if (this.completeRunCommitError)
+      throw this.completeRunCommitError
+
+    this.transitionStep(
+      input.assistantOutputStepId,
+      AgentStepStatus.COMPLETED,
+      { output: input.output },
+    )
     assert.equal(
-      this.steps.some(step => step.runId === runId && isUnfinishedStep(step)),
+      this.steps.some(step => step.runId === input.runId && isUnfinishedStep(step)),
       false,
     )
-    this.completedRunIds.push(runId)
+    message.content = input.content
+    message.status = MessageStatus.COMPLETED
+    message.updatedAt = new Date()
+    this.completedRunIds.push(input.runId)
+    return message
   }
 
-  async failRun(runId: string, errorMessage: string): Promise<void> {
+  async failRun(
+    runId: string,
+    errorMessage: string,
+    _deadline: DatabaseOperationDeadline,
+    assistantMessage?: { id: string, content: string },
+    failedStep?: { id: string, errorMessage: string, output?: unknown },
+  ): Promise<void> {
+    if (this.failRunDelayMs > 0) {
+      await new Promise(resolve => setTimeout(resolve, this.failRunDelayMs))
+    }
+    this.closeMessage(assistantMessage, MessageStatus.FAILED)
+    if (failedStep) {
+      this.transitionStep(failedStep.id, AgentStepStatus.FAILED, failedStep)
+    }
     this.closeUnfinishedSteps(runId, AgentStepStatus.FAILED, errorMessage)
     this.failedRunIds.push(runId)
   }
 
-  async abortRun(runId: string): Promise<void> {
+  async abortRun(
+    runId: string,
+    _deadline: DatabaseOperationDeadline,
+    assistantMessage?: { id: string, content: string },
+  ): Promise<void> {
+    this.closeMessage(assistantMessage, MessageStatus.ABORTED)
     this.closeUnfinishedSteps(runId, AgentStepStatus.ABORTED)
     this.abortedRunIds.push(runId)
+  }
+
+  private closeMessage(
+    input: { id: string, content: string } | undefined,
+    status: typeof MessageStatus.FAILED | typeof MessageStatus.ABORTED,
+  ): void {
+    if (!input)
+      return
+
+    const message = this.prisma.messages.find(candidate => candidate.id === input.id)
+
+    if (!message)
+      throw new Error(`Message ${input.id} 不存在`)
+    if (
+      message.status !== MessageStatus.PENDING
+      && message.status !== MessageStatus.STREAMING
+    ) {
+      throw new Error(`Message ${input.id} 已进入终态`)
+    }
+    message.content = input.content
+    message.status = status
+    message.updatedAt = new Date()
   }
 
   private transitionStep(
@@ -1678,6 +1937,12 @@ class FakeAgentRunRecorderService {
       step.errorMessage = errorMessage ?? null
       step.endedAt = new Date()
     }
+  }
+
+  private assertDeadline(deadline: DatabaseOperationDeadline): void {
+    deadline.signal?.throwIfAborted()
+    if (Date.now() >= deadline.deadlineAt)
+      throw deadline.createTimeoutError()
   }
 }
 

--- a/apps/api/src/agent-runtime/agent-runtime.service.ts
+++ b/apps/api/src/agent-runtime/agent-runtime.service.ts
@@ -1,10 +1,12 @@
 import type {
   Message,
+  Prisma,
   MessageRole as PrismaMessageRole,
   MessageStatus as PrismaMessageStatus,
 } from '../generated/prisma/client.js'
 import type { ChatMessage } from '../llm/llm.types.js'
 import type { ModelInputItem } from '../llm/model-input.types.js'
+import type { DatabaseOperationDeadline } from '../prisma/prisma.service.js'
 import type {
   ToolResult,
   UnvalidatedToolCallEnvelope,
@@ -22,7 +24,11 @@ import { Inject, Injectable, NotFoundException } from '@nestjs/common'
 import { MessageRole, MessageStatus } from '../generated/prisma/client.js'
 import { LLMService } from '../llm/llm.service.js'
 import { toModelInputItems } from '../llm/model-input.types.js'
-import { PrismaService } from '../prisma/prisma.service.js'
+import {
+  DatabaseCommitOutcomeUnknownError,
+  DatabaseOperationDeadlineExceededError,
+  PrismaService,
+} from '../prisma/prisma.service.js'
 import { toModelToolSpec } from '../tools/core/model-tool-spec.mapper.js'
 import { ToolInvocationService } from '../tools/core/tool-invocation.service.js'
 import {
@@ -37,7 +43,7 @@ import {
 import {
   AgentLoopLimitExceededError,
   AgentRunDeadlineExceededError,
-  MessageTerminalTransitionError,
+  AgentRunTerminalizationError,
   ModelSamplingIncompleteError,
 } from './agent-runtime.errors.js'
 import { AgentRuntimePolicyService } from './agent-runtime.policy.js'
@@ -48,12 +54,28 @@ const AGENT_RUN_TOOL_NAMES = [
   'get_article_detail',
 ] as const
 
-type RunCancellationSource = 'user' | 'deadline'
+const TERMINALIZATION_DEADLINE_MS = 5_000
+
+type RunTerminationSource = 'completed' | 'completing' | 'deadline' | 'failure' | 'user'
 
 interface RunCancellation {
+  databaseDeadline: DatabaseOperationDeadline
+  reason?: unknown
   signal: AbortSignal
-  source?: RunCancellationSource
+  source?: RunTerminationSource
+  claimCompletion: () => void
+  claimCompleted: () => void
+  claimCompletionFailure: (source: 'deadline' | 'failure', reason: unknown) => void
+  claimDeadline: (reason?: AgentRunDeadlineExceededError) => void
+  claimFailure: (reason: unknown) => void
+  throwIfUnavailable: () => void
   dispose: () => void
+}
+
+interface TerminalStepFailure {
+  id: string
+  errorMessage: string
+  output?: Prisma.InputJsonValue
 }
 
 @Injectable()
@@ -82,8 +104,8 @@ export class AgentRuntimeService {
     let assistantMessage: Message | undefined
     let agentRunId: string | undefined
     let content = ''
-    let hasFinalMessageStatus = false
     let runCancellation: RunCancellation | undefined
+    let terminalStepFailure: TerminalStepFailure | undefined
 
     try {
       await this.assertConversationExists(input.conversationId)
@@ -109,6 +131,7 @@ export class AgentRuntimeService {
         runtimePolicy.runDeadlineMs,
       )
       const runSignal = runCancellation.signal
+      const databaseDeadline = runCancellation.databaseDeadline
 
       const receiveUserMessageStep = await this.agentRunRecorderService.startStep({
         runId: currentAgentRunId,
@@ -117,8 +140,11 @@ export class AgentRuntimeService {
           messageId: userMessage.id,
           messageLength: normalizedMessage.length,
         },
-      })
-      await this.agentRunRecorderService.completeStep(receiveUserMessageStep.id)
+      }, databaseDeadline)
+      await this.agentRunRecorderService.completeStep(
+        receiveUserMessageStep.id,
+        databaseDeadline,
+      )
 
       const historyLimit = input.historyLimit
         ?? runtimePolicy.historyLimit
@@ -128,14 +154,16 @@ export class AgentRuntimeService {
         input: {
           limit: historyLimit,
         },
-      })
+      }, databaseDeadline)
 
       const historyMessages = await this.listRecentChatMessages(
         input.conversationId,
         historyLimit,
+        databaseDeadline,
       )
       await this.agentRunRecorderService.completeStep(
         loadHistoryStep.id,
+        databaseDeadline,
         {
           output: {
             messageCount: historyMessages.length,
@@ -159,19 +187,13 @@ export class AgentRuntimeService {
         ? []
         : toolDefinitions.map(toModelToolSpec)
 
-      // 模型采样前先创建空的流式助手消息，后续将增量内容和最终状态写回该记录。
-      assistantMessage = await this.createMessageAndTouchConversation(
+      // 创建助手消息与 Run 关联必须同事务提交，避免 deadline 下留下未关联的 late Message。
+      assistantMessage = await this.agentRunRecorderService.createAssistantMessage(
+        currentAgentRunId,
         input.conversationId,
-        MessageRole.ASSISTANT,
-        '',
-        MessageStatus.STREAMING,
+        databaseDeadline,
       )
       const assistantMessageId = assistantMessage.id
-
-      await this.agentRunRecorderService.attachAssistantMessage(
-        currentAgentRunId,
-        assistantMessageId,
-      )
 
       yield {
         type: 'run_started',
@@ -192,7 +214,7 @@ export class AgentRuntimeService {
           input: {
             assistantMessageId,
           },
-        })
+        }, databaseDeadline)
         assistantOutputStepId = step.id
       }
 
@@ -214,7 +236,7 @@ export class AgentRuntimeService {
         samplingAttempt <= runtimePolicy.maxSamplingRounds;
         samplingAttempt += 1
       ) {
-        runSignal.throwIfAborted()
+        runCancellation.throwIfUnavailable()
         const samplingAttemptId = `${currentAgentRunId}:sampling-${samplingAttempt}`
         const samplingStep = await this.agentRunRecorderService.startStep({
           runId: currentAgentRunId,
@@ -226,7 +248,7 @@ export class AgentRuntimeService {
             messageCount: modelInputItems.length,
             toolCount: modelTools.length,
           },
-        })
+        }, databaseDeadline)
         const samplingStartedAt = Date.now()
         let samplingDecision: SamplingDecision
 
@@ -239,7 +261,7 @@ export class AgentRuntimeService {
           let samplingResult = await sampling.next()
 
           while (!samplingResult.done) {
-            runSignal.throwIfAborted()
+            runCancellation.throwIfUnavailable()
             await startAssistantOutputStep()
             content += samplingResult.value
             yield {
@@ -253,29 +275,32 @@ export class AgentRuntimeService {
           }
           samplingDecision = samplingResult.value
 
-          runSignal.throwIfAborted()
-          await this.agentRunRecorderService.completeStep(samplingStep.id, {
-            output: this.toSamplingStepOutput(
-              samplingDecision.summary,
-              Date.now() - samplingStartedAt,
-            ),
-          })
-        }
-        catch (error) {
-          if (!runSignal.aborted) {
-            await this.agentRunRecorderService.failStep(samplingStep.id, {
-              errorMessage: this.toChatStreamErrorMessage(error),
-              output: this.toFailedSamplingStepOutput(
-                error,
+          runCancellation.throwIfUnavailable()
+          await this.agentRunRecorderService.completeStep(
+            samplingStep.id,
+            databaseDeadline,
+            {
+              output: this.toSamplingStepOutput(
+                samplingDecision.summary,
                 Date.now() - samplingStartedAt,
               ),
-            })
+            },
+          )
+        }
+        catch (error) {
+          terminalStepFailure = {
+            id: samplingStep.id,
+            errorMessage: this.toChatStreamErrorMessage(error),
+            output: this.toFailedSamplingStepOutput(
+              error,
+              Date.now() - samplingStartedAt,
+            ),
           }
-
+          claimRunTermination(runCancellation, error)
           throw error
         }
 
-        runSignal.throwIfAborted()
+        runCancellation.throwIfUnavailable()
 
         if (samplingDecision.type === 'final_answer') {
           hasFinalAnswer = true
@@ -302,7 +327,7 @@ export class AgentRuntimeService {
             executionAttempt: 1,
             rawArgumentsChars: [...samplingDecision.call.rawArgumentsJson].length,
           },
-        })
+        }, databaseDeadline)
         const toolStartedAt = Date.now()
         let toolResult: ToolResult
 
@@ -322,22 +347,22 @@ export class AgentRuntimeService {
                 runId: currentAgentRunId,
                 conversationId: input.conversationId,
                 signal: runSignal,
+                databaseDeadline,
                 executionAttempt: 1,
               },
             )
           }
-          runSignal.throwIfAborted()
+          runCancellation.throwIfUnavailable()
         }
         catch (error) {
-          if (!runSignal.aborted) {
-            await this.agentRunRecorderService.failStep(toolStep.id, {
-              errorMessage: '工具执行未能安全完成。',
-              output: {
-                durationMs: Date.now() - toolStartedAt,
-              },
-            })
+          terminalStepFailure = {
+            id: toolStep.id,
+            errorMessage: '工具执行未能安全完成。',
+            output: {
+              durationMs: Date.now() - toolStartedAt,
+            },
           }
-
+          claimRunTermination(runCancellation, error)
           throw error
         }
 
@@ -361,18 +386,24 @@ export class AgentRuntimeService {
         }
 
         if (toolResult.ok) {
-          await this.agentRunRecorderService.completeStep(toolStep.id, {
-            output: toolStepOutput,
-          })
+          await this.agentRunRecorderService.completeStep(
+            toolStep.id,
+            databaseDeadline,
+            { output: toolStepOutput },
+          )
         }
         else {
-          await this.agentRunRecorderService.failStep(toolStep.id, {
-            errorMessage: `工具 ${samplingDecision.call.toolName} 返回 ${toolResult.code}。`,
-            output: toolStepOutput,
-          })
+          await this.agentRunRecorderService.failStep(
+            toolStep.id,
+            databaseDeadline,
+            {
+              errorMessage: `工具 ${samplingDecision.call.toolName} 返回 ${toolResult.code}。`,
+              output: toolStepOutput,
+            },
+          )
         }
 
-        runSignal.throwIfAborted()
+        runCancellation.throwIfUnavailable()
         this.appendToolObservation(
           modelInputItems,
           samplingDecision.call,
@@ -387,35 +418,24 @@ export class AgentRuntimeService {
         throw new AgentLoopLimitExceededError()
       }
 
-      runSignal.throwIfAborted()
+      runCancellation.throwIfUnavailable()
       await startAssistantOutputStep()
-      runSignal.throwIfAborted()
-      const completedMessageTransition = await this.updateMessageAndTouchConversation(
-        assistantMessageId,
-        input.conversationId,
-        content,
-        MessageStatus.COMPLETED,
-        runSignal,
-      )
-
-      if (!completedMessageTransition.transitioned) {
-        hasFinalMessageStatus = true
-        throw new MessageTerminalTransitionError(assistantMessageId)
-      }
-
-      const completedMessage = completedMessageTransition.message
-
-      // Message 的 COMPLETED CAS 是正常完成路径的终态所有权边界；之后到达的 abort 属于迟到信号。
-      hasFinalMessageStatus = true
-      await this.agentRunRecorderService.completeStep(
-        assistantOutputStepId!,
+      runCancellation.throwIfUnavailable()
+      const completedMessage = await this.agentRunRecorderService.completeRun(
         {
+          runId: currentAgentRunId,
+          conversationId: input.conversationId,
+          assistantMessageId,
+          assistantOutputStepId: assistantOutputStepId!,
+          content,
           output: {
             contentLength: content.length,
           },
         },
+        databaseDeadline,
+        runCancellation.claimCompletion,
       )
-      await this.agentRunRecorderService.completeRun(currentAgentRunId)
+      runCancellation.claimCompleted()
       runCancellation.dispose()
 
       yield {
@@ -428,24 +448,47 @@ export class AgentRuntimeService {
       }
     }
     catch (error) {
+      if (
+        runCancellation?.source === 'completing'
+        && error instanceof DatabaseCommitOutcomeUnknownError
+      ) {
+        throw new AgentRunTerminalizationError(error, error)
+      }
+
+      if (runCancellation) {
+        claimRunTermination(runCancellation, error)
+
+        if (runCancellation.source === 'completed')
+          throw error
+      }
+
       const userAborted = runCancellation?.source === 'user'
         || (!runCancellation && this.isAbortSignalTriggered(input.signal))
+      const runCause = runCancellation?.reason ?? error
 
       runCancellation?.dispose()
 
       if (userAborted) {
-        if (assistantMessage && !hasFinalMessageStatus) {
-          await this.updateMessageAndTouchConversation(
-            assistantMessage.id,
-            input.conversationId,
-            content,
-            MessageStatus.ABORTED,
-          )
-          hasFinalMessageStatus = true
-        }
-
         if (agentRunId) {
-          await this.agentRunRecorderService.abortRun(agentRunId)
+          try {
+            await this.agentRunRecorderService.abortRun(
+              agentRunId,
+              createTerminalizationDeadline(),
+              assistantMessage
+                ? {
+                    id: assistantMessage.id,
+                    conversationId: input.conversationId,
+                    content,
+                  }
+                : undefined,
+            )
+          }
+          catch (terminalizationCause) {
+            throw new AgentRunTerminalizationError(
+              runCause,
+              terminalizationCause,
+            )
+          }
         }
 
         if (assistantMessage) {
@@ -461,23 +504,30 @@ export class AgentRuntimeService {
         return
       }
 
-      const failure = runCancellation?.source === 'deadline'
-        ? runCancellation.signal.reason
-        : error
-      const errorMessage = this.toChatStreamErrorMessage(failure)
-
-      if (assistantMessage && !hasFinalMessageStatus) {
-        await this.updateMessageAndTouchConversation(
-          assistantMessage.id,
-          input.conversationId,
-          content || errorMessage,
-          MessageStatus.FAILED,
-        )
-        hasFinalMessageStatus = true
-      }
+      const errorMessage = this.toChatStreamErrorMessage(runCause)
 
       if (agentRunId) {
-        await this.agentRunRecorderService.failRun(agentRunId, errorMessage)
+        try {
+          await this.agentRunRecorderService.failRun(
+            agentRunId,
+            errorMessage,
+            createTerminalizationDeadline(),
+            assistantMessage
+              ? {
+                  id: assistantMessage.id,
+                  conversationId: input.conversationId,
+                  content: content || errorMessage,
+                }
+              : undefined,
+            terminalStepFailure,
+          )
+        }
+        catch (terminalizationCause) {
+          throw new AgentRunTerminalizationError(
+            runCause,
+            terminalizationCause,
+          )
+        }
       }
 
       yield {
@@ -493,44 +543,28 @@ export class AgentRuntimeService {
     }
     finally {
       runCancellation?.dispose()
-
-      if (
-        assistantMessage
-        && !hasFinalMessageStatus
-        && (
-          runCancellation?.source === 'user'
-          || (!runCancellation && this.isAbortSignalTriggered(input.signal))
-        )
-      ) {
-        await this.updateMessageAndTouchConversation(
-          assistantMessage.id,
-          input.conversationId,
-          content,
-          MessageStatus.ABORTED,
-        )
-
-        if (agentRunId) {
-          await this.agentRunRecorderService.abortRun(agentRunId)
-        }
-      }
     }
   }
 
   private async listRecentChatMessages(
     conversationId: string,
     limit: number,
+    databaseDeadline: DatabaseOperationDeadline,
   ): Promise<Message[]> {
-    const messages = await this.prismaService.message.findMany({
-      where: {
-        conversationId,
-        status: MessageStatus.COMPLETED,
-      },
-      orderBy: [
-        { createdAt: 'desc' },
-        { id: 'desc' },
-      ],
-      take: limit,
-    })
+    const messages = await this.prismaService.withDeadlineTransaction(
+      databaseDeadline,
+      transaction => transaction.execute(prisma => prisma.message.findMany({
+        where: {
+          conversationId,
+          status: MessageStatus.COMPLETED,
+        },
+        orderBy: [
+          { createdAt: 'desc' },
+          { id: 'desc' },
+        ],
+        take: limit,
+      })),
+    )
 
     return messages.reverse()
   }
@@ -561,55 +595,6 @@ export class AgentRuntimeService {
       })
 
       return message
-    })
-  }
-
-  private async updateMessageAndTouchConversation(
-    messageId: string,
-    conversationId: string,
-    content: string,
-    status: PrismaMessageStatus,
-    signal?: AbortSignal,
-  ): Promise<{ message: Message, transitioned: boolean }> {
-    return this.prismaService.$transaction(async (prisma) => {
-      signal?.throwIfAborted()
-      const result = await prisma.message.updateMany({
-        where: {
-          id: messageId,
-          status: {
-            in: [MessageStatus.PENDING, MessageStatus.STREAMING],
-          },
-        },
-        data: {
-          content,
-          status,
-        },
-      })
-
-      if (result.count === 1) {
-        await prisma.conversation.update({
-          where: {
-            id: conversationId,
-          },
-          data: {
-            updatedAt: new Date(),
-          },
-        })
-      }
-
-      // 在事务提交前再次仲裁；若 abort 已先到达，抛错会回滚刚才的 Message 更新。
-      signal?.throwIfAborted()
-
-      const message = await prisma.message.findUniqueOrThrow({
-        where: { id: messageId },
-      })
-
-      signal?.throwIfAborted()
-
-      return {
-        message,
-        transitioned: result.count === 1,
-      }
     })
   }
 
@@ -686,9 +671,8 @@ export class AgentRuntimeService {
   }
 
   private toFailedSamplingStepOutput(error: unknown, durationMs: number) {
-    if (error instanceof ModelSamplingIncompleteError && error.summary) {
+    if (error instanceof ModelSamplingIncompleteError && error.summary)
       return this.toSamplingStepOutput(error.summary, durationMs)
-    }
 
     return { durationMs }
   }
@@ -730,23 +714,93 @@ function createRunCancellation(
   deadlineMs: number,
 ): RunCancellation {
   const controller = new AbortController()
-  const cancellation: RunCancellation = {
-    signal: controller.signal,
-    dispose: () => {},
-  }
-  const abort = (
-    source: RunCancellationSource,
+  const deadlineAt = Date.now() + deadlineMs
+  let cancellation!: RunCancellation
+  let deadlineId!: NodeJS.Timeout
+  let pendingTermination: {
+    source: 'deadline' | 'user'
+    reason: unknown
+  } | undefined
+  const deadlineError = (): AgentRunDeadlineExceededError => (
+    new AgentRunDeadlineExceededError()
+  )
+  const claim = (
+    source: 'deadline' | 'failure' | 'user',
     reason: unknown,
   ): void => {
+    if (cancellation.source === 'completing') {
+      if (
+        !pendingTermination
+        && (source === 'deadline' || source === 'user')
+      ) {
+        pendingTermination = { source, reason }
+      }
+      return
+    }
+
     if (cancellation.source)
       return
 
     cancellation.source = source
+    cancellation.reason = reason
     controller.abort(reason)
   }
-  const handleUserAbort = (): void => abort('user', userSignal?.reason)
-  const deadlineId = setTimeout(
-    () => abort('deadline', new AgentRunDeadlineExceededError()),
+  const handleUserAbort = (): void => claim('user', userSignal?.reason)
+
+  cancellation = {
+    databaseDeadline: {
+      deadlineAt,
+      signal: controller.signal,
+      createTimeoutError: () => new DatabaseOperationDeadlineExceededError(),
+    },
+    signal: controller.signal,
+    claimCompletion: () => {
+      cancellation.throwIfUnavailable()
+      cancellation.source = 'completing'
+    },
+    claimCompleted: () => {
+      if (cancellation.source !== 'completing')
+        throw new Error('Agent Run 尚未取得 completion commit ownership')
+      cancellation.source = 'completed'
+      pendingTermination = undefined
+    },
+    claimCompletionFailure: (source, reason) => {
+      if (cancellation.source !== 'completing') {
+        claim(source, reason)
+        return
+      }
+
+      const firstCause = pendingTermination ?? { source, reason }
+      cancellation.source = firstCause.source
+      cancellation.reason = firstCause.reason
+      controller.abort(firstCause.reason)
+      pendingTermination = undefined
+    },
+    claimDeadline: (reason = deadlineError()) => {
+      claim('deadline', reason)
+    },
+    claimFailure: (reason) => {
+      claim('failure', reason)
+    },
+    throwIfUnavailable: () => {
+      if (!cancellation.source && Date.now() >= deadlineAt)
+        cancellation.claimDeadline()
+
+      if (
+        cancellation.source === 'user'
+        || cancellation.source === 'deadline'
+        || cancellation.source === 'failure'
+      ) {
+        controller.signal.throwIfAborted()
+      }
+    },
+    dispose: () => {
+      clearTimeout(deadlineId)
+      userSignal?.removeEventListener('abort', handleUserAbort)
+    },
+  }
+  deadlineId = setTimeout(
+    () => claim('deadline', deadlineError()),
     deadlineMs,
   )
 
@@ -755,10 +809,35 @@ function createRunCancellation(
   else
     userSignal?.addEventListener('abort', handleUserAbort, { once: true })
 
-  cancellation.dispose = () => {
-    clearTimeout(deadlineId)
-    userSignal?.removeEventListener('abort', handleUserAbort)
+  return cancellation
+}
+
+function claimRunTermination(
+  cancellation: RunCancellation,
+  error: unknown,
+): void {
+  if (error instanceof DatabaseOperationDeadlineExceededError) {
+    if (cancellation.source === 'completing') {
+      cancellation.claimCompletionFailure(
+        'deadline',
+        new AgentRunDeadlineExceededError(),
+      )
+    }
+    else {
+      cancellation.claimDeadline()
+    }
+    return
   }
 
-  return cancellation
+  if (cancellation.source === 'completing')
+    cancellation.claimCompletionFailure('failure', error)
+  else
+    cancellation.claimFailure(error)
+}
+
+function createTerminalizationDeadline(): DatabaseOperationDeadline {
+  return {
+    deadlineAt: Date.now() + TERMINALIZATION_DEADLINE_MS,
+    createTimeoutError: () => new Error('Agent Run 终态收口超过数据库等待上限。'),
+  }
 }

--- a/apps/api/src/prisma/prisma.service.reliability.test.ts
+++ b/apps/api/src/prisma/prisma.service.reliability.test.ts
@@ -1,3 +1,4 @@
+import type { Prisma } from '../generated/prisma/client.js'
 import assert from 'node:assert/strict'
 import { createRequire } from 'node:module'
 import process from 'node:process'
@@ -15,6 +16,12 @@ import {
 
 interface PgQueryResult<Row> {
   rows: Row[]
+}
+
+interface TimeoutSettings {
+  lock_timeout: string
+  pid: number
+  statement_timeout: string
 }
 
 interface PgQueryable {
@@ -59,39 +66,29 @@ describe('PrismaService database deadline reliability', () => {
     await prisma.$disconnect()
   })
 
-  it('transaction setup 使用固定 session bound，SET LOCAL 后恢复 baseline', async () => {
-    const localSettings = await prisma.withDeadlineTransaction(
+  it('SET LOCAL 在 commit / rollback 后恢复原 pooled session baseline', async () => {
+    const before = await readTimeoutSettings(prisma)
+    const committedLocal = await prisma.withDeadlineTransaction(
       createDeadline(500),
-      transaction => transaction.execute(client => client.$queryRawUnsafe<Array<{
-        lock_timeout: string
-        pid: number
-        statement_timeout: string
-      }>>(`
-        SELECT
-          pg_backend_pid()::int AS pid,
-          current_setting('statement_timeout') AS statement_timeout,
-          current_setting('lock_timeout') AS lock_timeout
-      `)),
+      transaction => transaction.execute(readTimeoutSettings),
     )
+    const afterCommit = await readTimeoutSettings(prisma)
+    let rolledBackLocal: TimeoutSettings | undefined
+    const rollbackFailure = await captureFailure(() => prisma.withDeadlineTransaction(
+      createDeadline(500),
+      async (transaction) => {
+        rolledBackLocal = await transaction.execute(readTimeoutSettings)
+        throw new Error('issue31 forced rollback')
+      },
+    ))
+    const afterRollback = await readTimeoutSettings(prisma)
 
-    assert.notEqual(localSettings[0]!.statement_timeout, '5s')
-    assert.notEqual(localSettings[0]!.lock_timeout, '0')
-
-    const baseline = await prisma.$queryRawUnsafe<Array<{
-      lock_timeout: string
-      pid: number
-      statement_timeout: string
-    }>>(`
-      SELECT
-        pg_backend_pid()::int AS pid,
-        current_setting('statement_timeout') AS statement_timeout,
-        current_setting('lock_timeout') AS lock_timeout
-    `)
-    assert.deepEqual(baseline[0], {
-      lock_timeout: '0',
-      pid: localSettings[0]!.pid,
-      statement_timeout: '5s',
-    })
+    assertDynamicTimeoutSettings(committedLocal)
+    assert.ok(rolledBackLocal)
+    assertDynamicTimeoutSettings(rolledBackLocal)
+    assert.match(errorDetail(rollbackFailure), /issue31 forced rollback/)
+    assert.deepEqual(afterCommit, before)
+    assert.deepEqual(afterRollback, before)
   })
 
   it('statement_timeout 由 PostgreSQL 取消 pg_sleep', async () => {
@@ -213,7 +210,8 @@ describe('PrismaService database deadline reliability', () => {
       ),
     })
     let beginDelayed = false
-    let rollbackObserved = false
+    let rollbackCount = 0
+    let releaseCount = 0
     let callbackInvoked = false
     let backendPid: number | undefined
 
@@ -223,6 +221,12 @@ describe('PrismaService database deadline reliability', () => {
         query: (...args: unknown[]) => Promise<unknown>
       }
       const originalQuery = rawClient.query.bind(client)
+      const originalRelease = client.release.bind(client)
+
+      client.release = () => {
+        releaseCount += 1
+        originalRelease()
+      }
 
       rawClient.query = async (...args: unknown[]): Promise<unknown> => {
         const sql = queryText(args[0])
@@ -235,7 +239,7 @@ describe('PrismaService database deadline reliability', () => {
           await sleep(80)
         }
         if (normalizedSql(sql) === 'ROLLBACK')
-          rollbackObserved = true
+          rollbackCount += 1
 
         return result
       }
@@ -252,8 +256,10 @@ describe('PrismaService database deadline reliability', () => {
 
       assert.equal((failure as { code?: unknown }).code, 'P2028')
       assert.equal(callbackInvoked, false)
-      await waitUntil(() => rollbackObserved)
+      await waitUntil(() => rollbackCount > 0)
       assert.equal(beginDelayed, true)
+      assert.equal(rollbackCount, 1)
+      assert.equal(releaseCount, 1)
       assert.ok(backendPid !== undefined)
 
       pool.connect = originalConnect
@@ -495,6 +501,30 @@ function createDeadline(timeoutMs: number) {
     deadlineAt: Date.now() + timeoutMs,
     createTimeoutError: () => new DatabaseOperationDeadlineExceededError(),
   }
+}
+
+async function readTimeoutSettings(
+  prisma: PrismaService | Prisma.TransactionClient,
+): Promise<TimeoutSettings> {
+  const settings = await prisma.$queryRawUnsafe<TimeoutSettings[]>(`
+    SELECT
+      pg_backend_pid()::int AS pid,
+      current_setting('statement_timeout') AS statement_timeout,
+      current_setting('lock_timeout') AS lock_timeout
+  `)
+
+  return settings[0]!
+}
+
+function assertDynamicTimeoutSettings(settings: TimeoutSettings): void {
+  assert.match(settings.statement_timeout, /^\d+ms$/)
+  assert.match(settings.lock_timeout, /^\d+ms$/)
+
+  const statementTimeoutMs = Number.parseInt(settings.statement_timeout, 10)
+  const lockTimeoutMs = Number.parseInt(settings.lock_timeout, 10)
+
+  assert.ok(statementTimeoutMs > 0 && statementTimeoutMs < 500)
+  assert.ok(lockTimeoutMs > 0 && lockTimeoutMs < statementTimeoutMs)
 }
 
 let commitProbeSequence = 0

--- a/apps/api/src/prisma/prisma.service.reliability.test.ts
+++ b/apps/api/src/prisma/prisma.service.reliability.test.ts
@@ -1,0 +1,652 @@
+import assert from 'node:assert/strict'
+import { createRequire } from 'node:module'
+import process from 'node:process'
+// 项目使用 Node 原生测试运行器，不为真实数据库验证引入额外框架。
+// eslint-disable-next-line test/no-import-node-test
+import { after, before, describe, it } from 'node:test'
+
+import { PrismaClient } from '../generated/prisma/client.js'
+import {
+  DatabaseCommitOutcomeUnknownError,
+  DatabaseOperationDeadlineExceededError,
+  PrismaService,
+  RollbackSafePrismaPg,
+} from './prisma.service.js'
+
+interface PgQueryResult<Row> {
+  rows: Row[]
+}
+
+interface PgQueryable {
+  query: <Row = Record<string, unknown>>(text: string, values?: unknown[]) => Promise<PgQueryResult<Row>>
+}
+
+interface PgClient extends PgQueryable {
+  readonly processID: number
+  release: () => void
+}
+
+interface PgPool extends PgQueryable {
+  readonly waitingCount: number
+  connect: () => Promise<PgClient>
+  end: () => Promise<void>
+}
+
+interface PgPoolConstructor {
+  readonly prototype: Pick<PgPool, 'connect'>
+  new (config: {
+    connectionString: string
+    max: number
+    connectionTimeoutMillis?: number
+  }): PgPool
+}
+
+const { Pool } = createRequire(import.meta.url)('pg') as { Pool: PgPoolConstructor }
+
+const connectionString = process.env.DATABASE_URL?.trim()
+
+if (!connectionString)
+  throw new Error('运行真实数据库验证前请在项目根目录 .env 中设置 DATABASE_URL')
+
+describe('PrismaService database deadline reliability', () => {
+  const prisma = new PrismaService()
+
+  before(async () => {
+    await prisma.$connect()
+  })
+
+  after(async () => {
+    await prisma.$disconnect()
+  })
+
+  it('transaction setup 使用固定 session bound，SET LOCAL 后恢复 baseline', async () => {
+    const localSettings = await prisma.withDeadlineTransaction(
+      createDeadline(500),
+      transaction => transaction.execute(client => client.$queryRawUnsafe<Array<{
+        lock_timeout: string
+        pid: number
+        statement_timeout: string
+      }>>(`
+        SELECT
+          pg_backend_pid()::int AS pid,
+          current_setting('statement_timeout') AS statement_timeout,
+          current_setting('lock_timeout') AS lock_timeout
+      `)),
+    )
+
+    assert.notEqual(localSettings[0]!.statement_timeout, '5s')
+    assert.notEqual(localSettings[0]!.lock_timeout, '0')
+
+    const baseline = await prisma.$queryRawUnsafe<Array<{
+      lock_timeout: string
+      pid: number
+      statement_timeout: string
+    }>>(`
+      SELECT
+        pg_backend_pid()::int AS pid,
+        current_setting('statement_timeout') AS statement_timeout,
+        current_setting('lock_timeout') AS lock_timeout
+    `)
+    assert.deepEqual(baseline[0], {
+      lock_timeout: '0',
+      pid: localSettings[0]!.pid,
+      statement_timeout: '5s',
+    })
+  })
+
+  it('statement_timeout 由 PostgreSQL 取消 pg_sleep', async () => {
+    const startedAt = Date.now()
+    let failure: unknown
+    let backendPid: number | undefined
+
+    try {
+      await prisma.withDeadlineTransaction(
+        createDeadline(80),
+        async (transaction) => {
+          const rows = await transaction.execute(client => client.$queryRawUnsafe<Array<{
+            pid: number
+          }>>('SELECT pg_backend_pid()::int AS pid'))
+          backendPid = rows[0]!.pid
+          await transaction.execute(client => client.$queryRawUnsafe('SELECT pg_sleep(1)'))
+        },
+      )
+    }
+    catch (error) {
+      failure = error
+    }
+
+    assert.ok(failure instanceof DatabaseOperationDeadlineExceededError)
+    assert.match(errorDetail(failure.cause), /57014/)
+    assert.match(errorDetail(failure.cause), /canceling statement due to statement timeout/)
+    assert.ok(Date.now() - startedAt < 750)
+    assert.ok(backendPid !== undefined)
+
+    const monitor = new Pool({ connectionString, max: 1 })
+    try {
+      const activity = await monitor.query<{ state: string, wait_event: string | null }>(
+        'SELECT state, wait_event FROM pg_stat_activity WHERE pid = $1',
+        [backendPid],
+      )
+      assert.notEqual(activity.rows[0]?.wait_event, 'PgSleep')
+      assert.notEqual(activity.rows[0]?.state, 'active')
+    }
+    finally {
+      await monitor.end()
+    }
+  })
+
+  it('lock_timeout 由 PostgreSQL 取消受控 advisory lock wait', async () => {
+    const lockOwner = new Pool({ connectionString, max: 1 })
+    const lockKey = process.pid * 100_000 + Date.now() % 100_000
+    const client = await lockOwner.connect()
+
+    try {
+      await client.query('SELECT pg_advisory_lock($1::bigint)', [lockKey])
+      let failure: unknown
+
+      try {
+        await prisma.withDeadlineTransaction(
+          createDeadline(120),
+          transaction => transaction.execute(database => database.$queryRawUnsafe(
+            'SELECT pg_advisory_xact_lock($1::bigint)',
+            lockKey,
+          )),
+        )
+      }
+      catch (error) {
+        failure = error
+      }
+
+      assert.ok(failure instanceof DatabaseOperationDeadlineExceededError)
+      assert.match(errorDetail(failure.cause), /55P03/)
+      assert.match(errorDetail(failure.cause), /canceling statement due to lock timeout/)
+
+      const postgresFailure = await captureFailure(() => prisma.$transaction(async (database) => {
+        await database.$executeRawUnsafe('SET LOCAL statement_timeout = \'200ms\'')
+        await database.$executeRawUnsafe('SET LOCAL lock_timeout = \'40ms\'')
+        await database.$queryRawUnsafe(
+          'SELECT pg_advisory_xact_lock($1::bigint)',
+          lockKey,
+        )
+      }, { maxWait: 3_000, timeout: 1_000 }))
+      assert.match(errorDetail(postgresFailure), /55P03/)
+      assert.match(errorDetail(postgresFailure), /canceling statement due to lock timeout/)
+    }
+    finally {
+      await client.query('SELECT pg_advisory_unlock($1::bigint)', [lockKey])
+      client.release()
+      await lockOwner.end()
+    }
+  })
+
+  it('caller acquisition timeout 不伪称已取消 pg Pool waiter', async () => {
+    const pool = new Pool({ connectionString, max: 1, connectionTimeoutMillis: 2_000 })
+    const heldClient = await pool.connect()
+    const pendingClient = pool.connect()
+    let heldClientReleased = false
+
+    try {
+      await assert.rejects(
+        waitAsCaller(pendingClient, 40),
+        /caller acquisition timeout/,
+      )
+      assert.equal(pool.waitingCount, 1)
+
+      heldClient.release()
+      heldClientReleased = true
+      const lateClient = await pendingClient
+      lateClient.release()
+    }
+    finally {
+      if (!heldClientReleased)
+        heldClient.release()
+      await pool.end()
+    }
+  })
+
+  it('迟到 BEGIN 被 Prisma 丢弃时 wrapper 真实 ROLLBACK 后释放连接', async () => {
+    const pool = new Pool({ connectionString, max: 1, connectionTimeoutMillis: 2_000 })
+    const originalConnect = pool.connect.bind(pool)
+    const directPrisma = new PrismaClient({
+      adapter: new RollbackSafePrismaPg(
+        pool as unknown as ConstructorParameters<typeof RollbackSafePrismaPg>[0],
+      ),
+    })
+    let beginDelayed = false
+    let rollbackObserved = false
+    let callbackInvoked = false
+    let backendPid: number | undefined
+
+    pool.connect = async () => {
+      const client = await originalConnect()
+      const rawClient = client as unknown as {
+        query: (...args: unknown[]) => Promise<unknown>
+      }
+      const originalQuery = rawClient.query.bind(client)
+
+      rawClient.query = async (...args: unknown[]): Promise<unknown> => {
+        const sql = queryText(args[0])
+        const result = await originalQuery(...args)
+
+        if (normalizedSql(sql) === 'BEGIN' && !beginDelayed) {
+          beginDelayed = true
+          backendPid = client.processID
+          // PostgreSQL 已执行 BEGIN，但 adapter 的 startTransaction 晚于 Prisma maxWait 返回。
+          await sleep(80)
+        }
+        if (normalizedSql(sql) === 'ROLLBACK')
+          rollbackObserved = true
+
+        return result
+      }
+
+      return client
+    }
+
+    try {
+      await directPrisma.$connect()
+      const failure = await captureFailure(() => directPrisma.$transaction(async (transaction) => {
+        callbackInvoked = true
+        await transaction.$queryRawUnsafe('SELECT 1')
+      }, { maxWait: 40, timeout: 500 }))
+
+      assert.equal((failure as { code?: unknown }).code, 'P2028')
+      assert.equal(callbackInvoked, false)
+      await waitUntil(() => rollbackObserved)
+      assert.equal(beginDelayed, true)
+      assert.ok(backendPid !== undefined)
+
+      pool.connect = originalConnect
+      const reusableClient = await pool.connect()
+      try {
+        const reusable = await reusableClient.query<{ value: number, pid: number }>(
+          'SELECT 1::int AS value, pg_backend_pid()::int AS pid',
+        )
+        assert.deepEqual(reusable.rows[0], { value: 1, pid: backendPid })
+      }
+      finally {
+        reusableClient.release()
+      }
+
+      const monitor = new Pool({ connectionString, max: 1 })
+      try {
+        const activity = await monitor.query<{ state: string }>(
+          'SELECT state FROM pg_stat_activity WHERE pid = $1',
+          [backendPid],
+        )
+        assert.notEqual(activity.rows[0]?.state, 'idle in transaction')
+      }
+      finally {
+        await monitor.end()
+      }
+    }
+    finally {
+      pool.connect = originalConnect
+      await directPrisma.$disconnect()
+      await pool.end()
+    }
+  })
+
+  it('deadline 后 late acquisition 不进入业务 callback 且不留 idle transaction', async () => {
+    const probe = await createWriteProbe(prisma)
+    const releaseHolders = deferred<void>()
+    const backendPids: number[] = []
+    const holders = Array.from({ length: 10 }, () => prisma.$transaction(async (client) => {
+      const rows = await client.$queryRawUnsafe<Array<{ pid: number }>>(
+        'SELECT pg_backend_pid()::int AS pid',
+      )
+      backendPids.push(rows[0]!.pid)
+      await releaseHolders.promise
+    }))
+
+    await waitUntil(() => backendPids.length === holders.length)
+
+    let callbackInvoked = false
+    let businessQueryInvoked = false
+    const startedAt = Date.now()
+    const operation = prisma.withDeadlineTransaction(
+      createDeadline(40),
+      async (transaction) => {
+        callbackInvoked = true
+        businessQueryInvoked = true
+        await transaction.execute(client => client.$executeRawUnsafe(
+          `INSERT INTO ${probe.table}(value) VALUES (1)`,
+        ))
+      },
+    )
+
+    try {
+      await assert.rejects(
+        operation,
+        DatabaseOperationDeadlineExceededError,
+      )
+      assert.ok(Date.now() - startedAt < 500)
+      assert.equal(callbackInvoked, false)
+    }
+    finally {
+      releaseHolders.resolve()
+      await Promise.all(holders)
+    }
+
+    await new Promise(resolve => setTimeout(resolve, 100))
+    const monitor = new Pool({ connectionString, max: 1 })
+    try {
+      const activity = await monitor.query<{ count: number }>(
+        `SELECT count(*)::int AS count
+         FROM pg_stat_activity
+         WHERE pid = ANY($1::int[])
+           AND state = 'idle in transaction'`,
+        [backendPids],
+      )
+      const writes = await monitor.query<{ count: number }>(
+        `SELECT count(*)::int AS count FROM ${probe.table}`,
+      )
+
+      assert.equal(activity.rows[0]!.count, 0)
+      assert.equal(writes.rows[0]!.count, 0)
+      assert.equal(callbackInvoked, false)
+      assert.equal(businessQueryInvoked, false)
+    }
+    finally {
+      await monitor.end()
+      await dropProbe(prisma, probe.schema)
+    }
+  })
+
+  it('commit ownership 取得后 caller 等待真实 COMMIT 成功', async () => {
+    const probe = await createCommitProbe(prisma, false)
+
+    try {
+      let commitOwned = false
+      const startedAt = Date.now()
+      await prisma.withDeadlineTransaction(
+        createDeadline(40),
+        transaction => transaction.execute(client => client.$executeRawUnsafe(
+          `INSERT INTO ${probe.table}(value) VALUES (1)`,
+        )),
+        () => {
+          commitOwned = true
+        },
+      )
+      const elapsedMs = Date.now() - startedAt
+      const result = await prisma.$queryRawUnsafe<Array<{ count: number }>>(
+        `SELECT count(*)::int AS count FROM ${probe.table}`,
+      )
+
+      assert.equal(commitOwned, true)
+      assert.ok(elapsedMs >= 180)
+      assert.equal(result[0]!.count, 1)
+    }
+    finally {
+      await dropCommitProbe(prisma, probe.schema)
+    }
+  })
+
+  it('commit ownership 取得后 caller 等待真实 COMMIT 失败并回滚', async () => {
+    const probe = await createCommitProbe(prisma, true)
+
+    try {
+      let commitOwned = false
+      let transactionPid: number | undefined
+      const startedAt = Date.now()
+      const failure = await captureFailure(() => prisma.withDeadlineTransaction(
+        createDeadline(40),
+        async (transaction) => {
+          const rows = await transaction.execute(client => client.$queryRawUnsafe<Array<{
+            pid: number
+          }>>('SELECT pg_backend_pid()::int AS pid'))
+          transactionPid = rows[0]!.pid
+          await transaction.execute(client => client.$executeRawUnsafe(
+            `INSERT INTO ${probe.table}(value) VALUES (1)`,
+          ))
+        },
+        () => {
+          commitOwned = true
+        },
+      ))
+      const elapsedMs = Date.now() - startedAt
+      const result = await prisma.$queryRawUnsafe<Array<{ count: number }>>(
+        `SELECT count(*)::int AS count FROM ${probe.table}`,
+      )
+      const activity = await prisma.$queryRawUnsafe<Array<{ state: string }>>(
+        'SELECT state FROM pg_stat_activity WHERE pid = $1',
+        transactionPid!,
+      )
+
+      assert.equal(commitOwned, true)
+      assert.ok(elapsedMs >= 180)
+      assert.ok(!(failure instanceof DatabaseOperationDeadlineExceededError))
+      assert.match(errorDetail(failure), /issue31 forced commit failure/)
+      assert.equal(result[0]!.count, 0)
+      assert.notEqual(activity[0]?.state, 'idle in transaction')
+    }
+    finally {
+      await dropCommitProbe(prisma, probe.schema)
+    }
+  })
+
+  it('普通 transaction 的 COMMIT in-flight 不绕过 caller deadline', async () => {
+    const probe = await createCommitProbe(prisma, true)
+
+    try {
+      const startedAt = Date.now()
+      const failure = await captureFailure(() => prisma.withDeadlineTransaction(
+        createDeadline(40),
+        transaction => transaction.execute(client => client.$executeRawUnsafe(
+          `INSERT INTO ${probe.table}(value) VALUES (1)`,
+        )),
+      ))
+
+      assert.ok(failure instanceof DatabaseOperationDeadlineExceededError)
+      assert.ok(Date.now() - startedAt < 180)
+
+      await sleep(250)
+      const result = await prisma.$queryRawUnsafe<Array<{ count: number }>>(
+        `SELECT count(*)::int AS count FROM ${probe.table}`,
+      )
+      assert.equal(result[0]!.count, 0)
+    }
+    finally {
+      await dropCommitProbe(prisma, probe.schema)
+    }
+  })
+
+  it('completion COMMIT 超过内部 outcome 上界时返回结果未知并消费迟到 settlement', async () => {
+    const probe = await createCommitProbe(prisma, false, 0.4)
+
+    try {
+      let commitOwned = false
+      const startedAt = Date.now()
+      const failure = await captureFailure(() => prisma.withDeadlineTransaction(
+        createDeadline(40),
+        transaction => transaction.execute(client => client.$executeRawUnsafe(
+          `INSERT INTO ${probe.table}(value) VALUES (1)`,
+        )),
+        () => {
+          commitOwned = true
+        },
+        60,
+      ))
+      const elapsedMs = Date.now() - startedAt
+      const pendingResult = await prisma.$queryRawUnsafe<Array<{ count: number }>>(
+        `SELECT count(*)::int AS count FROM ${probe.table}`,
+      )
+
+      assert.equal(commitOwned, true)
+      assert.ok(failure instanceof DatabaseCommitOutcomeUnknownError)
+      assert.ok(elapsedMs >= 50)
+      assert.ok(elapsedMs < 300)
+      assert.equal(pendingResult[0]!.count, 0)
+
+      await sleep(450)
+      const settledResult = await prisma.$queryRawUnsafe<Array<{ count: number }>>(
+        `SELECT count(*)::int AS count FROM ${probe.table}`,
+      )
+      assert.equal(settledResult[0]!.count, 1)
+    }
+    finally {
+      await dropCommitProbe(prisma, probe.schema)
+    }
+  })
+})
+
+function createDeadline(timeoutMs: number) {
+  return {
+    deadlineAt: Date.now() + timeoutMs,
+    createTimeoutError: () => new DatabaseOperationDeadlineExceededError(),
+  }
+}
+
+let commitProbeSequence = 0
+
+async function createWriteProbe(
+  prisma: PrismaService,
+): Promise<{ schema: string, table: string }> {
+  commitProbeSequence += 1
+  const schema = `issue31_reliability_${process.pid}_${commitProbeSequence}`
+  const table = `"${schema}"."write_probe"`
+
+  await prisma.$executeRawUnsafe(`CREATE SCHEMA "${schema}"`)
+  await prisma.$executeRawUnsafe(`CREATE TABLE ${table}(value int)`)
+
+  return { schema, table }
+}
+
+async function createCommitProbe(
+  prisma: PrismaService,
+  failOnCommit: boolean,
+  commitDelaySeconds = 0.2,
+): Promise<{ schema: string, table: string }> {
+  commitProbeSequence += 1
+  const schema = `issue31_reliability_${process.pid}_${commitProbeSequence}`
+  const table = `"${schema}"."commit_probe"`
+  const failure = failOnCommit
+    ? 'RAISE EXCEPTION \'issue31 forced commit failure\';'
+    : ''
+
+  await prisma.$executeRawUnsafe(`CREATE SCHEMA "${schema}"`)
+  await prisma.$executeRawUnsafe(`CREATE TABLE ${table}(value int)`)
+  await prisma.$executeRawUnsafe(`
+    CREATE FUNCTION "${schema}".delay_commit()
+    RETURNS trigger
+    LANGUAGE plpgsql
+    AS $$
+    BEGIN
+      PERFORM pg_sleep(${commitDelaySeconds});
+      ${failure}
+      RETURN NEW;
+    END
+    $$
+  `)
+  await prisma.$executeRawUnsafe(`
+    CREATE CONSTRAINT TRIGGER issue31_delay_commit
+    AFTER INSERT ON ${table}
+    DEFERRABLE INITIALLY DEFERRED
+    FOR EACH ROW
+    EXECUTE FUNCTION "${schema}".delay_commit()
+  `)
+
+  return { schema, table }
+}
+
+async function dropCommitProbe(
+  prisma: PrismaService,
+  schema: string,
+): Promise<void> {
+  await dropProbe(prisma, schema)
+}
+
+async function dropProbe(
+  prisma: PrismaService,
+  schema: string,
+): Promise<void> {
+  await prisma.$executeRawUnsafe(`DROP SCHEMA IF EXISTS "${schema}" CASCADE`)
+}
+
+function errorDetail(error: unknown): string {
+  const candidate = error as { message?: unknown, meta?: unknown }
+  return `${
+    typeof candidate?.message === 'string' ? candidate.message : ''
+  } ${safeJson(candidate?.meta)}`
+}
+
+async function captureFailure(operation: () => Promise<unknown>): Promise<unknown> {
+  try {
+    await operation()
+  }
+  catch (error) {
+    return error
+  }
+
+  assert.fail('预期数据库操作失败')
+}
+
+function safeJson(value: unknown): string {
+  try {
+    return JSON.stringify(value)
+  }
+  catch {
+    return ''
+  }
+}
+
+function waitAsCaller<T>(operation: Promise<T>, timeoutMs: number): Promise<T> {
+  return new Promise<T>((resolve, reject) => {
+    const timer = setTimeout(
+      () => reject(new Error('caller acquisition timeout')),
+      timeoutMs,
+    )
+
+    operation.then(
+      (result) => {
+        clearTimeout(timer)
+        resolve(result)
+      },
+      (error) => {
+        clearTimeout(timer)
+        reject(error)
+      },
+    )
+  })
+}
+
+function queryText(query: unknown): string {
+  if (typeof query === 'string')
+    return query
+  if (
+    typeof query === 'object'
+    && query !== null
+    && 'text' in query
+    && typeof query.text === 'string'
+  ) {
+    return query.text
+  }
+  return ''
+}
+
+function normalizedSql(sql: string): string {
+  return sql.trim().replace(/;$/, '').toUpperCase()
+}
+
+function sleep(timeoutMs: number): Promise<void> {
+  return new Promise(resolve => setTimeout(resolve, timeoutMs))
+}
+
+function deferred<T>() {
+  let resolve!: (value: T | PromiseLike<T>) => void
+  const promise = new Promise<T>((promiseResolve) => {
+    resolve = promiseResolve
+  })
+
+  return { promise, resolve }
+}
+
+async function waitUntil(predicate: () => boolean): Promise<void> {
+  const deadlineAt = Date.now() + 1_500
+
+  while (!predicate()) {
+    if (Date.now() >= deadlineAt)
+      throw new Error('等待 Prisma Pool 占满超时')
+    await new Promise(resolve => setTimeout(resolve, 5))
+  }
+}

--- a/apps/api/src/prisma/prisma.service.reliability.test.ts
+++ b/apps/api/src/prisma/prisma.service.reliability.test.ts
@@ -1,4 +1,5 @@
 import type { Prisma } from '../generated/prisma/client.js'
+import type { DeadlineTransaction } from './prisma.service.js'
 import assert from 'node:assert/strict'
 import { createRequire } from 'node:module'
 import process from 'node:process'
@@ -422,12 +423,97 @@ describe('PrismaService database deadline reliability', () => {
       assert.equal(commitOwned, true)
       assert.ok(elapsedMs >= 180)
       assert.ok(!(failure instanceof DatabaseOperationDeadlineExceededError))
+      assert.ok(!(failure instanceof DatabaseCommitOutcomeUnknownError))
       assert.match(errorDetail(failure), /issue31 forced commit failure/)
       assert.equal(result[0]!.count, 0)
       assert.notEqual(activity[0]?.state, 'idle in transaction')
     }
     finally {
       await dropCommitProbe(prisma, probe.schema)
+    }
+  })
+
+  it('durable COMMIT 后 adapter response-loss 映射为 outcome unknown', async () => {
+    const probe = await createWriteProbe(prisma)
+    const pool = new Pool({ connectionString, max: 1, connectionTimeoutMillis: 2_000 })
+    const originalConnect = pool.connect.bind(pool)
+    const directPrisma = new PrismaClient({
+      adapter: new RollbackSafePrismaPg(
+        pool as unknown as ConstructorParameters<typeof RollbackSafePrismaPg>[0],
+      ),
+    })
+    let commitResponseLost = false
+    let commitOwned = false
+    let backendPid: number | undefined
+
+    pool.connect = async () => {
+      const client = await originalConnect()
+      const rawClient = client as unknown as {
+        query: (...args: unknown[]) => Promise<unknown>
+      }
+      const originalQuery = rawClient.query.bind(client)
+
+      rawClient.query = async (...args: unknown[]): Promise<unknown> => {
+        const sql = queryText(args[0])
+        const result = await originalQuery(...args)
+
+        if (normalizedSql(sql) === 'COMMIT' && !commitResponseLost) {
+          // PostgreSQL 已返回 durable COMMIT；随后注入 adapter response-loss。
+          commitResponseLost = true
+          throw Object.assign(new Error('read ECONNRESET'), {
+            code: 'ECONNRESET',
+            errno: -54,
+            syscall: 'read',
+          })
+        }
+
+        return result
+      }
+
+      return client
+    }
+
+    try {
+      await directPrisma.$connect()
+      const failure = await captureFailure(() => (
+        PrismaService.prototype.withDeadlineTransaction.call(
+          directPrisma,
+          createDeadline(500),
+          async (transaction: DeadlineTransaction) => {
+            const rows = await transaction.execute(client =>
+              client.$queryRawUnsafe<Array<{ pid: number }>>(
+                'SELECT pg_backend_pid()::int AS pid',
+              ))
+            backendPid = rows[0]!.pid
+            await transaction.execute(client => client.$executeRawUnsafe(
+              `INSERT INTO ${probe.table}(value) VALUES (1)`,
+            ))
+          },
+          () => {
+            commitOwned = true
+          },
+        )
+      ))
+      const result = await prisma.$queryRawUnsafe<Array<{ count: number }>>(
+        `SELECT count(*)::int AS count FROM ${probe.table}`,
+      )
+      const activity = await prisma.$queryRawUnsafe<Array<{ state: string }>>(
+        'SELECT state FROM pg_stat_activity WHERE pid = $1',
+        backendPid!,
+      )
+
+      assert.equal(commitOwned, true)
+      assert.equal(commitResponseLost, true)
+      assert.ok(failure instanceof DatabaseCommitOutcomeUnknownError)
+      assert.match(errorDetail(failure.cause), /ConnectionClosed/)
+      assert.equal(result[0]!.count, 1)
+      assert.notEqual(activity[0]?.state, 'idle in transaction')
+    }
+    finally {
+      pool.connect = originalConnect
+      await directPrisma.$disconnect()
+      await pool.end()
+      await dropProbe(prisma, probe.schema)
     }
   })
 
@@ -551,7 +637,7 @@ async function createCommitProbe(
   const schema = `issue31_reliability_${process.pid}_${commitProbeSequence}`
   const table = `"${schema}"."commit_probe"`
   const failure = failOnCommit
-    ? 'RAISE EXCEPTION \'issue31 forced commit failure\';'
+    ? 'RAISE EXCEPTION \'issue31 forced commit failure: connection closed P1017 ECONNRESET 08006\';'
     : ''
 
   await prisma.$executeRawUnsafe(`CREATE SCHEMA "${schema}"`)

--- a/apps/api/src/prisma/prisma.service.ts
+++ b/apps/api/src/prisma/prisma.service.ts
@@ -1,9 +1,54 @@
 import type { OnModuleDestroy, OnModuleInit } from '@nestjs/common'
+import type { Prisma } from '../generated/prisma/client.js'
 import process from 'node:process'
 import { Injectable } from '@nestjs/common'
 import { PrismaPg } from '@prisma/adapter-pg'
 
 import { PrismaClient } from '../generated/prisma/client.js'
+
+const PG_POOL_ACQUISITION_TIMEOUT_MS = 2_000
+const PG_SESSION_STATEMENT_TIMEOUT_MS = 5_000
+const PG_STATEMENT_TIMEOUT_LEAD_MS = 25
+const PG_LOCK_TIMEOUT_LEAD_MS = 25
+const PRISMA_TRANSACTION_START_TIMEOUT_MS = 8_000
+const DATABASE_COMMIT_OUTCOME_TIMEOUT_MS = 5_000
+
+export interface DatabaseOperationDeadline {
+  deadlineAt: number
+  signal?: AbortSignal
+  createTimeoutError: () => Error
+}
+
+export interface DeadlineTransaction {
+  execute: <T>(operation: (prisma: Prisma.TransactionClient) => Promise<T>) => Promise<T>
+}
+
+export class DatabaseOperationDeadlineExceededError extends Error {
+  constructor(message = '数据库操作超过可用 deadline budget') {
+    super(message)
+    this.name = 'DatabaseOperationDeadlineExceededError'
+  }
+}
+
+export class DatabaseCommitOutcomeUnknownError extends Error {
+  constructor(message = '数据库事务 COMMIT 在内部等待上界内未返回，结果未知') {
+    super(message)
+    this.name = 'DatabaseCommitOutcomeUnknownError'
+  }
+}
+
+type PgAdapter = Awaited<ReturnType<PrismaPg['connect']>>
+type PgTransaction = Awaited<ReturnType<PgAdapter['startTransaction']>>
+
+export class RollbackSafePrismaPg extends PrismaPg {
+  override async connect(): Promise<PgAdapter> {
+    return withRollbackSafeTransactions(await super.connect())
+  }
+
+  override async connectToShadowDb(): Promise<PgAdapter> {
+    return withRollbackSafeTransactions(await super.connectToShadowDb())
+  }
+}
 
 @Injectable()
 export class PrismaService extends PrismaClient implements OnModuleInit, OnModuleDestroy {
@@ -14,9 +59,94 @@ export class PrismaService extends PrismaClient implements OnModuleInit, OnModul
       throw new Error('请在项目根目录 .env 中设置 DATABASE_URL')
     }
 
-    const adapter = new PrismaPg({ connectionString })
+    const adapter = new RollbackSafePrismaPg({
+      connectionString,
+      connectionTimeoutMillis: PG_POOL_ACQUISITION_TIMEOUT_MS,
+      // Prisma 7.8 adapter 不把 per-operation timeout 传给 startTransaction。
+      // 因此 BEGIN / 首条 timeout setup 只能由固定 session 上界约束；这不是
+      // dynamic remaining-budget cancellation，迟到结果仍必须依赖 ownership fence。
+      statement_timeout: PG_SESSION_STATEMENT_TIMEOUT_MS,
+    })
 
     super({ adapter })
+  }
+
+  async withDeadlineTransaction<T>(
+    deadline: DatabaseOperationDeadline,
+    callback: (transaction: DeadlineTransaction) => Promise<T>,
+    onCommitOwned?: () => void,
+    commitOutcomeTimeoutMs = DATABASE_COMMIT_OUTCOME_TIMEOUT_MS,
+  ): Promise<T> {
+    const transactionTimeoutMs = remainingTimeoutMs(deadline)
+    const commitState: CommitState = { started: false }
+    const transactionPromise = this.$transaction(async (prisma) => {
+      assertDeadlineAvailable(deadline)
+
+      const transaction: DeadlineTransaction = {
+        execute: async <TResult>(
+          operation: (prisma: Prisma.TransactionClient) => Promise<TResult>,
+        ): Promise<TResult> => {
+          const remainingBudgetMs = remainingTimeoutMs(deadline)
+          const statementTimeoutMs = Math.max(
+            1,
+            remainingBudgetMs - PG_STATEMENT_TIMEOUT_LEAD_MS,
+          )
+          const statementTimeout = `${statementTimeoutMs}ms`
+          const lockTimeout = `${Math.max(
+            1,
+            statementTimeoutMs - PG_LOCK_TIMEOUT_LEAD_MS,
+          )}ms`
+
+          // 此 setup statement 自身仍受上面的固定 session timeout 约束；只有它
+          // 成功返回后的 business statement 才具有 dynamic remaining-budget 上界。
+          await prisma.$queryRaw`
+            SELECT
+              set_config('statement_timeout', ${statementTimeout}, true),
+              set_config('lock_timeout', ${lockTimeout}, true)
+          `
+          assertDeadlineAvailable(deadline)
+
+          try {
+            const result = await operation(prisma)
+            assertDeadlineAvailable(deadline)
+            return result
+          }
+          catch (error) {
+            if (deadline.signal?.aborted)
+              deadline.signal.throwIfAborted()
+            if (isScopedPostgresTimeout(error))
+              throw createTimeoutError(deadline, error)
+            throw error
+          }
+        },
+      }
+
+      const result = await callback(transaction)
+      assertDeadlineAvailable(deadline)
+      onCommitOwned?.()
+      // callback 已全部完成且 ownership 复核通过；completion transaction 从这一
+      // 同步点起等待 COMMIT / ROLLBACK 真实结果，不能再用 Run deadline 伪装结果。
+      commitState.started = true
+      commitState.startedAt = Date.now()
+      commitState.onStarted?.()
+      return result
+    }, {
+      // 固定 acquisition + session statement 上界通常先于 maxWait；极端迟到
+      // 仍由 RollbackSafePrismaPg 在 Prisma discard 路径真实发出 ROLLBACK。
+      maxWait: PRISMA_TRANSACTION_START_TIMEOUT_MS,
+      timeout: transactionTimeoutMs,
+    })
+
+    // 这里只限制调用方等待并隔离迟到结果，不代表底层 acquisition 已取消。
+    // 背景 transaction 仍保留 rejection handler；迟到 callback 会在首行失去 ownership
+    // 并抛错，由 Prisma 的正常路径 ROLLBACK / release。
+    return await waitForDeadline(
+      transactionPromise,
+      deadline,
+      commitState,
+      onCommitOwned !== undefined,
+      commitOutcomeTimeoutMs,
+    )
   }
 
   async onModuleInit(): Promise<void> {
@@ -26,4 +156,206 @@ export class PrismaService extends PrismaClient implements OnModuleInit, OnModul
   async onModuleDestroy(): Promise<void> {
     await this.$disconnect()
   }
+}
+
+function withRollbackSafeTransactions(adapter: PgAdapter): PgAdapter {
+  const startTransaction = adapter.startTransaction.bind(adapter)
+
+  adapter.startTransaction = async (...args): Promise<PgTransaction> => (
+    withRollbackSafeRelease(await startTransaction(...args))
+  )
+
+  return adapter
+}
+
+function withRollbackSafeRelease(transaction: PgTransaction): PgTransaction {
+  const executeRaw = transaction.executeRaw.bind(transaction)
+  const releaseAfterRollback = transaction.rollback.bind(transaction)
+  let terminalStatementCompleted = false
+
+  transaction.executeRaw = async (query) => {
+    const result = await executeRaw(query)
+    if (isTerminalTransactionSql(query.sql))
+      terminalStatementCompleted = true
+    return result
+  }
+  transaction.rollback = async () => {
+    try {
+      if (!terminalStatementCompleted) {
+        await transaction.executeRaw({
+          sql: 'ROLLBACK',
+          args: [],
+          argTypes: [],
+        })
+      }
+    }
+    finally {
+      await releaseAfterRollback()
+    }
+  }
+
+  return transaction
+}
+
+function isTerminalTransactionSql(sql: string): boolean {
+  const normalized = sql.trim().replace(/;$/, '').toUpperCase()
+  return normalized === 'COMMIT' || normalized === 'ROLLBACK'
+}
+
+function remainingTimeoutMs(deadline: DatabaseOperationDeadline): number {
+  assertDeadlineAvailable(deadline)
+  return Math.max(1, Math.floor(deadline.deadlineAt - Date.now()))
+}
+
+function assertDeadlineAvailable(deadline: DatabaseOperationDeadline): void {
+  deadline.signal?.throwIfAborted()
+  if (deadline.deadlineAt <= Date.now())
+    throw createTimeoutError(deadline)
+}
+
+function createTimeoutError(
+  deadline: DatabaseOperationDeadline,
+  cause?: unknown,
+): Error {
+  const error = deadline.createTimeoutError()
+
+  if (cause !== undefined && !('cause' in error)) {
+    Object.defineProperty(error, 'cause', {
+      value: cause,
+      configurable: true,
+    })
+  }
+
+  return error
+}
+
+function isScopedPostgresTimeout(error: unknown): boolean {
+  const candidate = error as { message?: unknown, meta?: unknown }
+  const detail = `${
+    typeof candidate?.message === 'string' ? candidate.message : ''
+  } ${safeJson(candidate?.meta)}`
+
+  return (
+    detail.includes('57014')
+    && detail.includes('canceling statement due to statement timeout')
+  ) || (
+    detail.includes('55P03')
+    && detail.includes('canceling statement due to lock timeout')
+  )
+}
+
+function safeJson(value: unknown): string {
+  try {
+    return JSON.stringify(value)
+  }
+  catch {
+    return ''
+  }
+}
+
+function waitForDeadline<T>(
+  operation: Promise<T>,
+  deadline: DatabaseOperationDeadline,
+  commitState: CommitState,
+  commitResultOwnsCompletion: boolean,
+  commitOutcomeTimeoutMs: number,
+): Promise<T> {
+  let callerTimeoutMs: number
+
+  try {
+    callerTimeoutMs = remainingTimeoutMs(deadline)
+  }
+  catch (error) {
+    // transaction 已经创建；即使调用方此刻失去 ownership，也必须消费其迟到 rejection。
+    void operation.catch(() => {})
+    return Promise.reject(error)
+  }
+
+  return new Promise<T>((resolve, reject) => {
+    let settled = false
+    let timer: NodeJS.Timeout
+    let commitOutcomeTimer: NodeJS.Timeout | undefined
+    let handleAbort: () => void
+    const signal = deadline.signal
+    const finish = (callback: () => void): void => {
+      if (settled)
+        return
+      settled = true
+      clearTimeout(timer)
+      clearTimeout(commitOutcomeTimer)
+      delete commitState.onStarted
+      signal?.removeEventListener('abort', handleAbort)
+      callback()
+    }
+    const waitForCommitOutcome = (): void => {
+      if (
+        settled
+        || !commitResultOwnsCompletion
+        || commitOutcomeTimer !== undefined
+      ) {
+        return
+      }
+
+      const timeoutMs = Math.max(
+        0,
+        (commitState.startedAt ?? Date.now())
+        + Math.max(1, Math.floor(commitOutcomeTimeoutMs))
+        - Date.now(),
+      )
+      commitOutcomeTimer = setTimeout(
+        () => finish(() => reject(new DatabaseCommitOutcomeUnknownError())),
+        timeoutMs,
+      )
+      commitOutcomeTimer.unref?.()
+    }
+    handleAbort = (): void => {
+      if (commitResultOwnsCompletion && commitState.started)
+        return
+      finish(() => {
+        try {
+          signal?.throwIfAborted()
+        }
+        catch (error) {
+          reject(error)
+        }
+      })
+    }
+    timer = setTimeout(
+      () => {
+        if (commitResultOwnsCompletion && commitState.started)
+          return
+        finish(() => reject(createTimeoutError(deadline)))
+      },
+      callerTimeoutMs,
+    )
+    timer.unref?.()
+
+    commitState.onStarted = waitForCommitOutcome
+    if (commitState.started)
+      waitForCommitOutcome()
+
+    if (signal?.aborted)
+      handleAbort()
+    else
+      signal?.addEventListener('abort', handleAbort, { once: true })
+    operation.then(
+      result => finish(() => {
+        try {
+          if (!commitResultOwnsCompletion)
+            assertDeadlineAvailable(deadline)
+          resolve(result)
+        }
+        catch (error) {
+          reject(error)
+        }
+      }),
+      error => finish(() => reject(error)),
+    )
+  })
+}
+
+interface CommitState {
+  started: boolean
+  startedAt?: number
+  onStarted?: () => void
 }

--- a/apps/api/src/prisma/prisma.service.ts
+++ b/apps/api/src/prisma/prisma.service.ts
@@ -7,7 +7,7 @@ import { PrismaPg } from '@prisma/adapter-pg'
 import { PrismaClient } from '../generated/prisma/client.js'
 
 const PG_POOL_ACQUISITION_TIMEOUT_MS = 2_000
-const PG_STATEMENT_TIMEOUT_LEAD_MS = 25
+const PG_STATEMENT_TIMEOUT_LEAD_MS = 50
 const PG_LOCK_TIMEOUT_LEAD_MS = 25
 const PRISMA_TRANSACTION_START_TIMEOUT_MS = 8_000
 const DATABASE_COMMIT_OUTCOME_TIMEOUT_MS = 5_000
@@ -30,8 +30,11 @@ export class DatabaseOperationDeadlineExceededError extends Error {
 }
 
 export class DatabaseCommitOutcomeUnknownError extends Error {
-  constructor(message = '数据库事务 COMMIT 在内部等待上界内未返回，结果未知') {
-    super(message)
+  constructor(
+    message = '数据库事务 COMMIT 在内部等待上界内未返回，结果未知',
+    options?: ErrorOptions,
+  ) {
+    super(message, options)
     this.name = 'DatabaseCommitOutcomeUnknownError'
   }
 }
@@ -345,9 +348,73 @@ function waitForDeadline<T>(
           reject(error)
         }
       }),
-      error => finish(() => reject(error)),
+      error => finish(() => reject(
+        commitResultOwnsCompletion
+        && commitState.started
+        && isCommitTransportFailure(error)
+          ? new DatabaseCommitOutcomeUnknownError(
+              '数据库事务 COMMIT 的连接响应不确定，结果未知',
+              { cause: error },
+            )
+          : error,
+      )),
     )
   })
+}
+
+function isCommitTransportFailure(error: unknown): boolean {
+  return hasCommitTransportFailure(error, new Set())
+}
+
+function hasCommitTransportFailure(
+  value: unknown,
+  seen: Set<object>,
+): boolean {
+  if (typeof value !== 'object' || value === null || seen.has(value))
+    return false
+
+  seen.add(value)
+  const candidate = value as {
+    cause?: unknown
+    code?: unknown
+    kind?: unknown
+    meta?: { driverAdapterError?: unknown }
+    originalCode?: unknown
+  }
+  const transportCodes = new Set([
+    'P1001',
+    'P1002',
+    'P1008',
+    'P1017',
+    'CONNECTIONCLOSED',
+    'SOCKETTIMEOUT',
+    'ECONNRESET',
+    'ECONNABORTED',
+    'ETIMEDOUT',
+    'EPIPE',
+    'ERR_STREAM_PREMATURE_CLOSE',
+  ])
+  const hasTransportCode = [candidate.code, candidate.originalCode].some(code => (
+    typeof code === 'string'
+    && (
+      transportCodes.has(code.toUpperCase())
+      || /^08[A-Z0-9]{3}$/i.test(code)
+    )
+  ))
+
+  if (hasTransportCode)
+    return true
+
+  if (
+    candidate.kind === 'ConnectionClosed'
+    || candidate.kind === 'SocketTimeout'
+    || candidate.kind === 'DatabaseNotReachable'
+  ) {
+    return true
+  }
+
+  return hasCommitTransportFailure(candidate.cause, seen)
+    || hasCommitTransportFailure(candidate.meta?.driverAdapterError, seen)
 }
 
 interface CommitState {

--- a/apps/api/src/prisma/prisma.service.ts
+++ b/apps/api/src/prisma/prisma.service.ts
@@ -7,7 +7,6 @@ import { PrismaPg } from '@prisma/adapter-pg'
 import { PrismaClient } from '../generated/prisma/client.js'
 
 const PG_POOL_ACQUISITION_TIMEOUT_MS = 2_000
-const PG_SESSION_STATEMENT_TIMEOUT_MS = 5_000
 const PG_STATEMENT_TIMEOUT_LEAD_MS = 25
 const PG_LOCK_TIMEOUT_LEAD_MS = 25
 const PRISMA_TRANSACTION_START_TIMEOUT_MS = 8_000
@@ -62,10 +61,6 @@ export class PrismaService extends PrismaClient implements OnModuleInit, OnModul
     const adapter = new RollbackSafePrismaPg({
       connectionString,
       connectionTimeoutMillis: PG_POOL_ACQUISITION_TIMEOUT_MS,
-      // Prisma 7.8 adapter 不把 per-operation timeout 传给 startTransaction。
-      // 因此 BEGIN / 首条 timeout setup 只能由固定 session 上界约束；这不是
-      // dynamic remaining-budget cancellation，迟到结果仍必须依赖 ownership fence。
-      statement_timeout: PG_SESSION_STATEMENT_TIMEOUT_MS,
     })
 
     super({ adapter })
@@ -97,8 +92,9 @@ export class PrismaService extends PrismaClient implements OnModuleInit, OnModul
             statementTimeoutMs - PG_LOCK_TIMEOUT_LEAD_MS,
           )}ms`
 
-          // 此 setup statement 自身仍受上面的固定 session timeout 约束；只有它
-          // 成功返回后的 business statement 才具有 dynamic remaining-budget 上界。
+          // 这条 timeout setup 属于 transaction bootstrap/control-plane；不宣称
+          // 它本身获得 dynamic cancellation。成功返回并复核 ownership 后，
+          // 后续 business statement 才具有 dynamic remaining-budget 上界。
           await prisma.$queryRaw`
             SELECT
               set_config('statement_timeout', ${statementTimeout}, true),
@@ -131,7 +127,7 @@ export class PrismaService extends PrismaClient implements OnModuleInit, OnModul
       commitState.onStarted?.()
       return result
     }, {
-      // 固定 acquisition + session statement 上界通常先于 maxWait；极端迟到
+      // pg acquisition 与 Prisma transaction start 都有固定等待上界；极端迟到
       // 仍由 RollbackSafePrismaPg 在 Prisma discard 路径真实发出 ROLLBACK。
       maxWait: PRISMA_TRANSACTION_START_TIMEOUT_MS,
       timeout: transactionTimeoutMs,

--- a/apps/api/src/tools/articles/get-article-detail.tool.test.ts
+++ b/apps/api/src/tools/articles/get-article-detail.tool.test.ts
@@ -1,4 +1,7 @@
-import type { PrismaService } from '../../prisma/prisma.service.js'
+import type {
+  DatabaseOperationDeadline,
+  PrismaService,
+} from '../../prisma/prisma.service.js'
 import type {
   ToolExecutionContext,
   ValidatedToolInvocation,
@@ -64,12 +67,15 @@ describe('get_article_detail', () => {
       },
     })
     const { invocationService } = createTools(fakePrisma)
+    const context = createContext()
 
     const result = await invocationService.invoke(
       createEnvelope({ sourceId: 25 }),
-      createContext(),
+      context,
     )
 
+    assert.deepEqual(fakePrisma.transactionDeadlines, [context.databaseDeadline])
+    assert.equal(fakePrisma.executeCount, 1)
     assert.deepEqual(fakePrisma.findUniqueArguments, [{
       where: { sourceId: 25 },
       select: {
@@ -180,6 +186,7 @@ describe('get_article_detail', () => {
       () => getArticleDetailDefinition.input.parse({ sourceId: Number.NaN }),
       /invalid get_article_detail sourceId/,
     )
+    assert.equal(fakePrisma.transactionDeadlines.length, 0)
     assert.equal(fakePrisma.findUniqueArguments.length, 0)
   })
 
@@ -218,7 +225,47 @@ describe('get_article_detail', () => {
       ),
       { name: 'AbortError' },
     )
+    assert.equal(fakePrisma.transactionDeadlines.length, 0)
     assert.equal(fakePrisma.findUniqueArguments.length, 0)
+  })
+
+  it('late transaction start 后重新检查 Tool signal，且不开始详情查询', async () => {
+    const abortController = new AbortController()
+    const fakePrisma = new FakePrismaService({
+      beforeTransactionCallback: () => abortController.abort(),
+    })
+    const tool = new GetArticleDetailTool(fakePrisma as unknown as PrismaService)
+    const context = createContext(abortController.signal)
+
+    await assert.rejects(
+      tool.execute(
+        createValidatedInvocation({ sourceId: 25 }),
+        context,
+      ),
+      { name: 'AbortError' },
+    )
+    assert.deepEqual(fakePrisma.transactionDeadlines, [context.databaseDeadline])
+    assert.equal(fakePrisma.executeCount, 0)
+    assert.equal(fakePrisma.findUniqueArguments.length, 0)
+  })
+
+  it('详情查询返回后重新检查 Tool signal，不返回迟到正常结果', async () => {
+    const abortController = new AbortController()
+    const fakePrisma = new FakePrismaService({
+      record: createFakeArticleRecord(),
+      afterFindUnique: () => abortController.abort(),
+    })
+    const tool = new GetArticleDetailTool(fakePrisma as unknown as PrismaService)
+
+    await assert.rejects(
+      tool.execute(
+        createValidatedInvocation({ sourceId: 25 }),
+        createContext(abortController.signal),
+      ),
+      { name: 'AbortError' },
+    )
+    assert.equal(fakePrisma.executeCount, 1)
+    assert.equal(fakePrisma.findUniqueArguments.length, 1)
   })
 })
 
@@ -239,22 +286,55 @@ interface FakeArticleRecord {
 interface FakePrismaOptions {
   record?: FakeArticleRecord
   error?: Error
+  beforeTransactionCallback?: () => void
+  afterFindUnique?: () => void
 }
 
 class FakePrismaService {
   readonly findUniqueArguments: FakeFindUniqueArguments[] = []
-  readonly article = {
-    findUnique: async (arguments_: FakeFindUniqueArguments) => {
-      this.findUniqueArguments.push(arguments_)
+  readonly transactionDeadlines: DatabaseOperationDeadline[] = []
+  executeCount = 0
+  private readonly transactionClient: FakeTransactionClient = {
+    article: {
+      findUnique: async (arguments_: FakeFindUniqueArguments) => {
+        this.findUniqueArguments.push(arguments_)
 
-      if (this.options.error)
-        throw this.options.error
+        if (this.options.error)
+          throw this.options.error
 
-      return this.options.record ?? null
+        this.options.afterFindUnique?.()
+        return this.options.record ?? null
+      },
+    },
+  }
+
+  private readonly transaction = {
+    execute: async <T>(
+      operation: (prisma: FakeTransactionClient) => Promise<T>,
+    ): Promise<T> => {
+      this.executeCount += 1
+      return await operation(this.transactionClient)
     },
   }
 
   constructor(private readonly options: FakePrismaOptions = {}) {}
+
+  async withDeadlineTransaction<T>(
+    deadline: DatabaseOperationDeadline,
+    callback: (transaction: typeof this.transaction) => Promise<T>,
+  ): Promise<T> {
+    this.transactionDeadlines.push(deadline)
+    this.options.beforeTransactionCallback?.()
+    return await callback(this.transaction)
+  }
+}
+
+interface FakeTransactionClient {
+  article: {
+    findUnique: (
+      arguments_: FakeFindUniqueArguments,
+    ) => Promise<FakeArticleRecord | null>
+  }
 }
 
 interface FakeFindUniqueArguments {
@@ -305,7 +385,32 @@ function createContext(
   return {
     runId: 'run-1',
     conversationId: 'conversation-1',
+    databaseDeadline: createDatabaseDeadline(signal),
     signal,
     executionAttempt: 1,
+  }
+}
+
+function createDatabaseDeadline(signal: AbortSignal): DatabaseOperationDeadline {
+  return {
+    deadlineAt: Date.now() + 60_000,
+    signal,
+    createTimeoutError: () => new Error('test database deadline exceeded'),
+  }
+}
+
+function createFakeArticleRecord(): FakeArticleRecord {
+  return {
+    id: 'internal-database-id',
+    sourceId: 25,
+    slug: 'complete-article',
+    languageCode: 'zh-cn',
+    title: '完整文章',
+    content: LONG_CONTENT,
+    seoTitle: '受控 SEO 标题',
+    seoDescription: null,
+    createdAt: new Date('2026-01-02T03:04:05.000Z'),
+    updatedAt: new Date('2026-06-07T08:09:10.000Z'),
+    internalSecret: 'database password: secret',
   }
 }

--- a/apps/api/src/tools/articles/get-article-detail.tool.test.ts
+++ b/apps/api/src/tools/articles/get-article-detail.tool.test.ts
@@ -74,7 +74,15 @@ describe('get_article_detail', () => {
       context,
     )
 
-    assert.deepEqual(fakePrisma.transactionDeadlines, [context.databaseDeadline])
+    assert.equal(fakePrisma.transactionDeadlines.length, 1)
+    assert.ok(
+      fakePrisma.transactionDeadlines[0]!.deadlineAt
+      < context.databaseDeadline.deadlineAt,
+    )
+    assert.notEqual(
+      fakePrisma.transactionDeadlines[0]!.signal,
+      context.databaseDeadline.signal,
+    )
     assert.equal(fakePrisma.executeCount, 1)
     assert.deepEqual(fakePrisma.findUniqueArguments, [{
       where: { sourceId: 25 },

--- a/apps/api/src/tools/articles/get-article-detail.tool.ts
+++ b/apps/api/src/tools/articles/get-article-detail.tool.ts
@@ -69,20 +69,32 @@ export class GetArticleDetailTool implements ToolExecutor<
     context.signal.throwIfAborted()
 
     const { sourceId } = invocation.input
-    const record = await this.prismaService.article.findUnique({
-      where: { sourceId },
-      select: {
-        sourceId: true,
-        slug: true,
-        languageCode: true,
-        title: true,
-        content: true,
-        seoTitle: true,
-        seoDescription: true,
-        createdAt: true,
-        updatedAt: true,
+    const record = await this.prismaService.withDeadlineTransaction(
+      context.databaseDeadline,
+      async (transaction) => {
+        context.signal.throwIfAborted()
+        const record = await transaction.execute(prisma =>
+          prisma.article.findUnique({
+            where: { sourceId },
+            select: {
+              sourceId: true,
+              slug: true,
+              languageCode: true,
+              title: true,
+              content: true,
+              seoTitle: true,
+              seoDescription: true,
+              createdAt: true,
+              updatedAt: true,
+            },
+          }))
+
+        context.signal.throwIfAborted()
+        return record
       },
-    })
+    )
+
+    context.signal.throwIfAborted()
 
     if (!record) {
       const data: GetArticleDetailOutput = {

--- a/apps/api/src/tools/articles/search-articles.tool.test.ts
+++ b/apps/api/src/tools/articles/search-articles.tool.test.ts
@@ -1,6 +1,15 @@
-import type { PrismaService } from '../../prisma/prisma.service.js'
-import type { ToolExecutionContext } from '../core/tool.types.js'
-import type { SearchArticlesOutput } from './search-articles.tool.js'
+import type {
+  DatabaseOperationDeadline,
+  PrismaService,
+} from '../../prisma/prisma.service.js'
+import type {
+  ToolExecutionContext,
+  ValidatedToolInvocation,
+} from '../core/tool.types.js'
+import type {
+  SearchArticlesInput,
+  SearchArticlesOutput,
+} from './search-articles.tool.js'
 import assert from 'node:assert/strict'
 // 项目本轮使用 Node 原生测试运行器，不引入额外测试框架。
 // eslint-disable-next-line test/no-import-node-test
@@ -56,13 +65,18 @@ describe('search_articles', () => {
       }],
     })
     const { invocationService } = createTools(fakePrisma)
+    const context = createContext()
 
     const result = await invocationService.invoke(
       createEnvelope({ query: '  Alpha%_\\  ', languageCode: ' ZH-CN ', limit: 10 }),
-      createContext(),
+      context,
     )
 
     assert.equal(result.ok, true)
+    assert.deepEqual(fakePrisma.transactionDeadlines, [context.databaseDeadline])
+    assert.equal(fakePrisma.executeCount, 2)
+    assert.deepEqual(fakePrisma.queryOrder, ['count', 'findMany'])
+    assert.equal(fakePrisma.findManyStartedBeforeCountCompleted, false)
     assert.deepEqual(
       fakePrisma.countArguments[0]?.where,
       fakePrisma.findManyArguments[0]?.where,
@@ -156,6 +170,63 @@ describe('search_articles', () => {
       modelContent: '没有找到与“missing”匹配的文章。',
     })
   })
+
+  it('Executor 在 transaction acquisition 前响应已触发的 Tool signal', async () => {
+    const fakePrisma = new FakePrismaService()
+    const tool = new SearchArticlesTool(fakePrisma as unknown as PrismaService)
+    const abortController = new AbortController()
+
+    abortController.abort()
+
+    await assert.rejects(
+      tool.execute(
+        createValidatedInvocation({ query: 'seo', limit: 5 }),
+        createContext(abortController.signal),
+      ),
+      { name: 'AbortError' },
+    )
+    assert.equal(fakePrisma.transactionDeadlines.length, 0)
+    assert.deepEqual(fakePrisma.queryOrder, [])
+  })
+
+  it('late transaction start 后重新检查 Tool signal，且不开始第一条查询', async () => {
+    const abortController = new AbortController()
+    const fakePrisma = new FakePrismaService({
+      beforeTransactionCallback: () => abortController.abort(),
+    })
+    const tool = new SearchArticlesTool(fakePrisma as unknown as PrismaService)
+    const context = createContext(abortController.signal)
+
+    await assert.rejects(
+      tool.execute(
+        createValidatedInvocation({ query: 'seo', limit: 5 }),
+        context,
+      ),
+      { name: 'AbortError' },
+    )
+    assert.deepEqual(fakePrisma.transactionDeadlines, [context.databaseDeadline])
+    assert.equal(fakePrisma.executeCount, 0)
+    assert.deepEqual(fakePrisma.queryOrder, [])
+  })
+
+  it('第一条查询返回后重新检查 Tool signal，且不开始第二条查询', async () => {
+    const abortController = new AbortController()
+    const fakePrisma = new FakePrismaService({
+      afterCount: () => abortController.abort(),
+    })
+    const tool = new SearchArticlesTool(fakePrisma as unknown as PrismaService)
+
+    await assert.rejects(
+      tool.execute(
+        createValidatedInvocation({ query: 'seo', limit: 5 }),
+        createContext(abortController.signal),
+      ),
+      { name: 'AbortError' },
+    )
+    assert.equal(fakePrisma.executeCount, 1)
+    assert.deepEqual(fakePrisma.queryOrder, ['count'])
+    assert.equal(fakePrisma.findManyArguments.length, 0)
+  })
 })
 
 interface FakeArticleRecord {
@@ -171,23 +242,63 @@ interface FakeArticleRecord {
 interface FakePrismaOptions {
   total?: number
   records?: FakeArticleRecord[]
+  beforeTransactionCallback?: () => void
+  afterCount?: () => void
 }
 
 class FakePrismaService {
   readonly countArguments: FakeCountArguments[] = []
   readonly findManyArguments: FakeFindManyArguments[] = []
-  readonly article = {
-    count: async (arguments_: FakeCountArguments) => {
-      this.countArguments.push(arguments_)
-      return this.options.total ?? 0
+  readonly queryOrder: Array<'count' | 'findMany'> = []
+  readonly transactionDeadlines: DatabaseOperationDeadline[] = []
+  executeCount = 0
+  findManyStartedBeforeCountCompleted = false
+  private countCompleted = false
+  private readonly transactionClient: FakeTransactionClient = {
+    article: {
+      count: async (arguments_: FakeCountArguments) => {
+        this.queryOrder.push('count')
+        this.countArguments.push(arguments_)
+        await Promise.resolve()
+        this.countCompleted = true
+        this.options.afterCount?.()
+        return this.options.total ?? 0
+      },
+      findMany: async (arguments_: FakeFindManyArguments) => {
+        this.queryOrder.push('findMany')
+        this.findManyStartedBeforeCountCompleted = !this.countCompleted
+        this.findManyArguments.push(arguments_)
+        return this.options.records ?? []
+      },
     },
-    findMany: async (arguments_: FakeFindManyArguments) => {
-      this.findManyArguments.push(arguments_)
-      return this.options.records ?? []
+  }
+
+  private readonly transaction = {
+    execute: async <T>(
+      operation: (prisma: FakeTransactionClient) => Promise<T>,
+    ): Promise<T> => {
+      this.executeCount += 1
+      return await operation(this.transactionClient)
     },
   }
 
   constructor(private readonly options: FakePrismaOptions = {}) {}
+
+  async withDeadlineTransaction<T>(
+    deadline: DatabaseOperationDeadline,
+    callback: (transaction: typeof this.transaction) => Promise<T>,
+  ): Promise<T> {
+    this.transactionDeadlines.push(deadline)
+    this.options.beforeTransactionCallback?.()
+    return await callback(this.transaction)
+  }
+}
+
+interface FakeTransactionClient {
+  article: {
+    count: (arguments_: FakeCountArguments) => Promise<number>
+    findMany: (arguments_: FakeFindManyArguments) => Promise<FakeArticleRecord[]>
+  }
 }
 
 interface FakeWhere {
@@ -230,11 +341,34 @@ function createEnvelope(input: Record<string, unknown>) {
   }
 }
 
-function createContext(): ToolExecutionContext {
+function createValidatedInvocation(
+  input: SearchArticlesInput,
+): ValidatedToolInvocation<SearchArticlesInput> {
+  return {
+    callId: 'call-search-1',
+    toolName: 'search_articles',
+    toolVersion: '1',
+    samplingAttemptId: 'sampling-1',
+    input,
+  }
+}
+
+function createContext(
+  signal = new AbortController().signal,
+): ToolExecutionContext {
   return {
     runId: 'run-1',
     conversationId: 'conversation-1',
-    signal: new AbortController().signal,
+    databaseDeadline: createDatabaseDeadline(signal),
+    signal,
     executionAttempt: 1,
+  }
+}
+
+function createDatabaseDeadline(signal: AbortSignal): DatabaseOperationDeadline {
+  return {
+    deadlineAt: Date.now() + 60_000,
+    signal,
+    createTimeoutError: () => new Error('test database deadline exceeded'),
   }
 }

--- a/apps/api/src/tools/articles/search-articles.tool.test.ts
+++ b/apps/api/src/tools/articles/search-articles.tool.test.ts
@@ -73,7 +73,15 @@ describe('search_articles', () => {
     )
 
     assert.equal(result.ok, true)
-    assert.deepEqual(fakePrisma.transactionDeadlines, [context.databaseDeadline])
+    assert.equal(fakePrisma.transactionDeadlines.length, 1)
+    assert.ok(
+      fakePrisma.transactionDeadlines[0]!.deadlineAt
+      < context.databaseDeadline.deadlineAt,
+    )
+    assert.notEqual(
+      fakePrisma.transactionDeadlines[0]!.signal,
+      context.databaseDeadline.signal,
+    )
     assert.equal(fakePrisma.executeCount, 2)
     assert.deepEqual(fakePrisma.queryOrder, ['count', 'findMany'])
     assert.equal(fakePrisma.findManyStartedBeforeCountCompleted, false)

--- a/apps/api/src/tools/articles/search-articles.tool.ts
+++ b/apps/api/src/tools/articles/search-articles.tool.ts
@@ -1,6 +1,7 @@
 import type { Prisma } from '../../generated/prisma/client.js'
 import type {
   ToolDefinition,
+  ToolExecutionContext,
   ToolExecutor,
   ValidatedToolInvocation,
 } from '../core/tool.types.js'
@@ -70,7 +71,10 @@ export class SearchArticlesTool implements ToolExecutor<SearchArticlesInput, Sea
 
   async execute(
     invocation: ValidatedToolInvocation<SearchArticlesInput>,
+    context: ToolExecutionContext,
   ) {
+    context.signal.throwIfAborted()
+
     // 零结果属于正常查询结果；未捕获的数据库或执行异常由 ToolInvocationService 统一兜底。
     const { languageCode, limit, query } = invocation.input
     const queryPattern = query.replace(/[\\%_]/g, '\\$&')
@@ -85,26 +89,39 @@ export class SearchArticlesTool implements ToolExecutor<SearchArticlesInput, Sea
       ],
     }
 
-    const [total, records] = await Promise.all([
-      this.prismaService.article.count({ where }),
-      this.prismaService.article.findMany({
-        where,
-        select: {
-          sourceId: true,
-          slug: true,
-          languageCode: true,
-          title: true,
-          seoTitle: true,
-          seoDescription: true,
-          content: true,
-        },
-        orderBy: [
-          { updatedAt: 'desc' },
-          { sourceId: 'asc' },
-        ],
-        take: limit,
-      }),
-    ])
+    const { total, records } = await this.prismaService.withDeadlineTransaction(
+      context.databaseDeadline,
+      async (transaction) => {
+        context.signal.throwIfAborted()
+        const total = await transaction.execute(prisma =>
+          prisma.article.count({ where }))
+
+        context.signal.throwIfAborted()
+        const records = await transaction.execute(prisma =>
+          prisma.article.findMany({
+            where,
+            select: {
+              sourceId: true,
+              slug: true,
+              languageCode: true,
+              title: true,
+              seoTitle: true,
+              seoDescription: true,
+              content: true,
+            },
+            orderBy: [
+              { updatedAt: 'desc' },
+              { sourceId: 'asc' },
+            ],
+            take: limit,
+          }))
+
+        context.signal.throwIfAborted()
+        return { total, records }
+      },
+    )
+
+    context.signal.throwIfAborted()
     const articles = records.map(({ content, ...article }) => ({
       ...article,
       excerpt: toExcerpt(content),

--- a/apps/api/src/tools/core/tool-invocation.service.test.ts
+++ b/apps/api/src/tools/core/tool-invocation.service.test.ts
@@ -81,6 +81,7 @@ describe('ToolInvocationService', () => {
     }))
     const service = new ToolInvocationService(registry)
     const context = createContext()
+    const startedAt = Date.now()
 
     const result = await service.invoke(createEnvelope(), context)
 
@@ -99,7 +100,10 @@ describe('ToolInvocationService', () => {
     assert.ok(receivedContext)
     assert.equal(receivedContext.runId, context.runId)
     assert.equal(receivedContext.conversationId, context.conversationId)
-    assert.equal(receivedContext.databaseDeadline, context.databaseDeadline)
+    assert.notEqual(receivedContext.databaseDeadline, context.databaseDeadline)
+    assert.equal(receivedContext.databaseDeadline.signal, receivedContext.signal)
+    assert.ok(receivedContext.databaseDeadline.deadlineAt >= startedAt)
+    assert.ok(receivedContext.databaseDeadline.deadlineAt < context.databaseDeadline.deadlineAt)
     assert.equal(receivedContext.executionAttempt, 1)
     assert.notEqual(receivedContext.signal, context.signal)
     assert.equal(receivedContext.signal.aborted, false)
@@ -119,17 +123,49 @@ describe('ToolInvocationService', () => {
     assert.doesNotMatch(result.modelContent, /password|secret/)
   })
 
-  it('保留数据库 deadline 错误并交回 Runtime 归因', async () => {
+  it('Tool deadline 更早时把数据库 timeout 保持为 Tool timeout', async () => {
+    let receivedDeadline: DatabaseOperationDeadline | undefined
+    const registry = new ToolRegistryService()
+    const tool = createEchoTool('echo', async (_, context) => {
+      receivedDeadline = context.databaseDeadline
+      throw context.databaseDeadline.createTimeoutError()
+    })
+
+    tool.definition.timeoutMs = 20
+    registry.register(tool)
+    const service = new ToolInvocationService(registry)
+    const context = createContext()
+    const result = await service.invoke(createEnvelope(), context)
+
+    assert.ok(receivedDeadline)
+    assert.ok(receivedDeadline.deadlineAt < context.databaseDeadline.deadlineAt)
+    assert.deepEqual(result, {
+      ok: false,
+      code: 'timeout',
+      modelContent: '工具 echo 执行超时。',
+      retryable: false,
+    })
+  })
+
+  it('Run deadline 更早时保留数据库 deadline 错误并交回 Runtime 归因', async () => {
     const deadlineError = new DatabaseOperationDeadlineExceededError()
     const registry = new ToolRegistryService()
+    const tool = createEchoTool('echo', async (_, context) => {
+      throw context.databaseDeadline.createTimeoutError()
+    })
+    const context = createContext()
 
-    registry.register(createEchoTool('echo', async () => {
-      throw deadlineError
-    }))
+    tool.definition.timeoutMs = 1_000
+    context.databaseDeadline = {
+      ...context.databaseDeadline,
+      deadlineAt: Date.now() + 100,
+      createTimeoutError: () => deadlineError,
+    }
+    registry.register(tool)
     const service = new ToolInvocationService(registry)
 
     await assert.rejects(
-      service.invoke(createEnvelope(), createContext()),
+      service.invoke(createEnvelope(), context),
       error => error === deadlineError,
     )
   })

--- a/apps/api/src/tools/core/tool-invocation.service.test.ts
+++ b/apps/api/src/tools/core/tool-invocation.service.test.ts
@@ -1,3 +1,4 @@
+import type { DatabaseOperationDeadline } from '../../prisma/prisma.service.js'
 import type {
   RegisteredTool,
   ToolExecutionContext,
@@ -10,6 +11,7 @@ import assert from 'node:assert/strict'
 // eslint-disable-next-line test/no-import-node-test
 import { describe, it } from 'node:test'
 
+import { DatabaseOperationDeadlineExceededError } from '../../prisma/prisma.service.js'
 import { ToolInvocationService } from './tool-invocation.service.js'
 import { ToolRegistryService } from './tool-registry.service.js'
 
@@ -97,6 +99,7 @@ describe('ToolInvocationService', () => {
     assert.ok(receivedContext)
     assert.equal(receivedContext.runId, context.runId)
     assert.equal(receivedContext.conversationId, context.conversationId)
+    assert.equal(receivedContext.databaseDeadline, context.databaseDeadline)
     assert.equal(receivedContext.executionAttempt, 1)
     assert.notEqual(receivedContext.signal, context.signal)
     assert.equal(receivedContext.signal.aborted, false)
@@ -114,6 +117,21 @@ describe('ToolInvocationService', () => {
     assert.equal(result.ok, false)
     assert.equal(result.ok ? undefined : result.code, 'execution_failed')
     assert.doesNotMatch(result.modelContent, /password|secret/)
+  })
+
+  it('保留数据库 deadline 错误并交回 Runtime 归因', async () => {
+    const deadlineError = new DatabaseOperationDeadlineExceededError()
+    const registry = new ToolRegistryService()
+
+    registry.register(createEchoTool('echo', async () => {
+      throw deadlineError
+    }))
+    const service = new ToolInvocationService(registry)
+
+    await assert.rejects(
+      service.invoke(createEnvelope(), createContext()),
+      error => error === deadlineError,
+    )
   })
 
   it('拒绝当前阶段不支持的风险和审批配置，且不执行工具', async () => {
@@ -212,7 +230,7 @@ describe('ToolInvocationService', () => {
     )
   })
 
-  it('Executor 忽略 signal 且永不结束时按 deadline 返回 timeout，且不重试', async () => {
+  it('Executor 忽略 signal 时调用方仍按 Tool timeout 返回，但不声称底层工作已停止', async () => {
     let executionCount = 0
     const registry = new ToolRegistryService()
     const tool = createEchoTool('echo', async () => {
@@ -432,8 +450,17 @@ function createContext(signal = new AbortController().signal): ToolExecutionCont
   return {
     runId: 'run-1',
     conversationId: 'conversation-1',
+    databaseDeadline: createDatabaseDeadline(signal),
     signal,
     executionAttempt: 1,
+  }
+}
+
+function createDatabaseDeadline(signal: AbortSignal): DatabaseOperationDeadline {
+  return {
+    deadlineAt: Date.now() + 60_000,
+    signal,
+    createTimeoutError: () => new DatabaseOperationDeadlineExceededError(),
   }
 }
 

--- a/apps/api/src/tools/core/tool-invocation.service.ts
+++ b/apps/api/src/tools/core/tool-invocation.service.ts
@@ -6,6 +6,7 @@ import type {
 } from './tool.types.js'
 import { Inject, Injectable } from '@nestjs/common'
 
+import { DatabaseOperationDeadlineExceededError } from '../../prisma/prisma.service.js'
 import { ToolRegistryService } from './tool-registry.service.js'
 
 @Injectable()
@@ -107,10 +108,11 @@ export class ToolInvocationService {
       }))
       .then<ToolInvocationOutcome, ToolInvocationOutcome>(
         result => ({ type: 'result', result }),
-        () => ({ type: 'error' }),
+        error => ({ type: 'error', error }),
       )
 
     try {
+      // 这里只仲裁调用方的返回结果；若 Executor 忽略 signal，Promise.race 不代表底层工作已停止。
       const outcome = await Promise.race([execution, cancellation])
 
       switch (outcome.type) {
@@ -132,6 +134,10 @@ export class ToolInvocationService {
 
         case 'error':
           context.signal.throwIfAborted()
+
+          if (outcome.error instanceof DatabaseOperationDeadlineExceededError)
+            throw outcome.error
+
           return {
             ok: false,
             code: 'execution_failed',
@@ -149,6 +155,6 @@ export class ToolInvocationService {
 
 type ToolInvocationOutcome
   = | { type: 'aborted' }
-    | { type: 'error' }
+    | { type: 'error', error: unknown }
     | { type: 'result', result: ToolResult }
     | { type: 'timeout' }

--- a/apps/api/src/tools/core/tool-invocation.service.ts
+++ b/apps/api/src/tools/core/tool-invocation.service.ts
@@ -1,3 +1,4 @@
+import type { DatabaseOperationDeadline } from '../../prisma/prisma.service.js'
 import type {
   ToolExecutionContext,
   ToolResult,
@@ -72,6 +73,12 @@ export class ToolInvocationService {
       input,
     }
     const executionController = new AbortController()
+    const toolDeadlineAt = Date.now() + tool.definition.timeoutMs
+    const databaseDeadline = createToolDatabaseDeadline(
+      context.databaseDeadline,
+      executionController.signal,
+      toolDeadlineAt,
+    )
     let hasCancellationOutcome = false
     let resolveCancellation!: (outcome: ToolInvocationOutcome) => void
     const cancellation = new Promise<ToolInvocationOutcome>((resolve) => {
@@ -97,13 +104,17 @@ export class ToolInvocationService {
           new DOMException('tool execution timeout', 'TimeoutError'),
         )
       }
-    }, tool.definition.timeoutMs)
+    }, Math.max(0, toolDeadlineAt - Date.now()))
 
-    context.signal.addEventListener('abort', handleRunAbort, { once: true })
+    if (context.signal.aborted)
+      handleRunAbort()
+    else
+      context.signal.addEventListener('abort', handleRunAbort, { once: true })
 
     const execution = Promise.resolve()
       .then(() => tool.executor.execute(invocation, {
         ...context,
+        databaseDeadline,
         signal: executionController.signal,
       }))
       .then<ToolInvocationOutcome, ToolInvocationOutcome>(
@@ -135,6 +146,15 @@ export class ToolInvocationService {
         case 'error':
           context.signal.throwIfAborted()
 
+          if (outcome.error instanceof ToolDatabaseDeadlineExceededError) {
+            return {
+              ok: false,
+              code: 'timeout',
+              modelContent: `工具 ${envelope.toolName} 执行超时。`,
+              retryable: false,
+            }
+          }
+
           if (outcome.error instanceof DatabaseOperationDeadlineExceededError)
             throw outcome.error
 
@@ -158,3 +178,26 @@ type ToolInvocationOutcome
     | { type: 'error', error: unknown }
     | { type: 'result', result: ToolResult }
     | { type: 'timeout' }
+
+class ToolDatabaseDeadlineExceededError extends Error {
+  constructor() {
+    super('工具数据库操作超过可用 timeout budget')
+    this.name = 'ToolDatabaseDeadlineExceededError'
+  }
+}
+
+function createToolDatabaseDeadline(
+  runDeadline: DatabaseOperationDeadline,
+  signal: AbortSignal,
+  toolDeadlineAt: number,
+): DatabaseOperationDeadline {
+  const toolDeadlineIsFirst = toolDeadlineAt < runDeadline.deadlineAt
+
+  return {
+    deadlineAt: Math.min(runDeadline.deadlineAt, toolDeadlineAt),
+    signal,
+    createTimeoutError: toolDeadlineIsFirst
+      ? () => new ToolDatabaseDeadlineExceededError()
+      : runDeadline.createTimeoutError,
+  }
+}

--- a/apps/api/src/tools/core/tool.types.ts
+++ b/apps/api/src/tools/core/tool.types.ts
@@ -1,3 +1,5 @@
+import type { DatabaseOperationDeadline } from '../../prisma/prisma.service.js'
+
 /** 当前工具输入需要的最小 JSON Schema 子集。 */
 export type JsonSchemaProperty
   = | { type: 'boolean', description?: string }
@@ -58,6 +60,7 @@ export interface ValidatedToolInvocation<TInput = unknown> {
 export interface ToolExecutionContext {
   runId: string
   conversationId: string
+  databaseDeadline: DatabaseOperationDeadline
   signal: AbortSignal
   executionAttempt: number
 }


### PR DESCRIPTION
## Gate 结论

- Q-01：`RESOLVED`
- Gate：`READY`
- 原因：D-06 已明确保留 Prisma 7.8 / `@prisma/adapter-pg` / `pg` 与共享 Pool，不再要求 per-operation 物理取消 acquisition waiter；实现目标改为 caller bounded wait、late ownership fencing，以及取得可控 statement 边界后的真实 PostgreSQL timeout。
- 尚存阻塞性歧义：无。

## 改动摘要

- Runtime 只创建一份 Run `deadlineAt`，model sampling、Tool、history、Recorder 与 Message transaction 共用同一 remaining budget / ownership。
- Prisma 增加 deadline transaction 边界：
  - Pool acquisition 使用 `connectionTimeoutMillis=2000`，Prisma transaction start 使用固定有界 `maxWait=8000`；
  - 每条 business statement 前刷新 transaction-local `statement_timeout` / `lock_timeout`，数据库 timeout 比 caller deadline 提前 50ms / 75ms；
  - PostgreSQL `57014` / `55P03` 只在该 scoped operation provenance 内映射为 Run deadline，普通 Prisma / PostgreSQL 错误保持原归因；
  - Prisma 7.8 late-discard / rollback 路径补发真实 `ROLLBACK` 后再 release，避免连接以 `idle in transaction` 回池。
- normal DB operation 在 acquisition 前、transaction callback 首行、statement 前后和返回后复核 ownership；late acquisition / late result 不进入 sampling、Tool、Observation 或成功终态路径。
- Message、assistant Step、AgentRun 的 completion 改为窄事务原子收口；failure / Abort cleanup 同样在独立短预算事务内原子收口，无需巨大通用事务。
- completion 最终 CAS 后取得 commit ownership；commit 成功才发 `run_completed`，commit 明确失败时恢复最早 pending cause。COMMIT 超过内部 5s 上界或 transport response 不确定时返回明确 indeterminate error，不启动竞争 cleanup，也不伪造终态事件。
- Article Search / Detail 接入同一 DB deadline；`search_articles` 改为 count → findMany 顺序执行，并在 acquisition / query 前后复核 signal。
- Tool Invocation 为 DB 派生 `min(Run deadline, Tool deadline)` 与 execution signal；Tool timeout 和 Run DB deadline 保持独立 provenance，普通 executor error 仍脱敏。
- 外部 Chat / NDJSON 五类协议、sync / stream 共用 Runtime 的结构保持不变。

## AC-01 ~ AC-11 映射

| AC | 证据 |
| --- | --- |
| AC-01 | `createRunCancellation` 单一 `deadlineAt`；所有 normal work 前后 ownership 检查 |
| AC-02 | `PrismaService.withDeadlineTransaction` + 真实 PG `57014` / `55P03` + bounded acquisition |
| AC-03 | history、Recorder、Message、两个 Article Tool 全部接入统一 DB boundary |
| AC-04 | scoped timeout provenance、ordinary DB error、Abort / deadline first-cause 测试 |
| AC-05 | late acquisition、late result、late Step commit、completion / cleanup CAS 与无 late success/write 证据 |
| AC-06 | user-first / deadline-first / completed-first 自动测试 |
| AC-07 | Message + Step + Run 原子 completion / cleanup，cleanup failure 整笔回滚且不伪造成功 |
| AC-08 | direct final、0/1/2 Tool、Tool failure/timeout、loop limit、sampling/Tool/DB deadline、Abort 回归全部通过 |
| AC-09 | SEO sync / stream 与既有五类外部事件回归通过，无 contracts/web 改动 |
| AC-10 | 新增真实 PostgreSQL reliability test 11/11 |
| AC-11 | 未新增 Tool、协议、schema、migration、依赖、公开 env 或 DB topology |

## 验证结果

真实环境：Docker `postgres:16-alpine`，PostgreSQL `16.14`。

- `pnpm --filter @agent/api test:tool-loop`：39/39
- `pnpm --filter @agent/api test:model-stream`：54/54
- `pnpm --filter @agent/api test:agent-recorder`：14/14
- `pnpm --filter @agent/api test:tools`：40/40
- `pnpm --filter @agent/api test:seo-service`：10/10
- `pnpm --filter @agent/api test:db-reliability`：11/11
- `pnpm --filter @agent/api typecheck`：通过
- `pnpm --filter @agent/api lint`：通过
- `pnpm --filter @agent/web typecheck`：通过
- `pnpm typecheck`：通过
- `git diff --check`：通过

真实数据库 11 项证据覆盖：

1. 读取普通 pooled connection 的真实 timeout baseline；Run 内 `SET LOCAL` 使用 dynamic timeout，commit / rollback 后均恢复为同一 baseline，不假设 baseline 的具体值；
2. wrapper 内 `pg_sleep` 由 PostgreSQL `57014` / statement timeout 取消，并确认 backend 不再 active / `PgSleep`；
3. advisory lock wait 由 PostgreSQL `55P03` / lock timeout 取消；
4. caller acquisition 等待有界，同时如实观察到底层 Pool waiter 仍存在；
5. delayed `BEGIN` 超过 Prisma `maxWait` 后执行真实 `ROLLBACK`、连接可复用且无 `idle in transaction`；
6. late acquisition 不进入业务 callback、不写 probe 数据、无 idle transaction；
7. completion commit ownership 后 delayed COMMIT 成功；
8. delayed COMMIT 失败时回滚、无持久化写入；
9. durable COMMIT 后注入 adapter response-loss，结构化 transport provenance 映射为 outcome unknown；明确 PostgreSQL `P0001` failure 即使消息含 transport 关键词也不会误判；
10. 普通 transaction COMMIT in-flight 时 caller deadline 仍有界；
11. completion COMMIT outcome 超过内部上界时先返回 indeterminate；不伪造 rollback，迟到真实 commit 由后台 settlement handler 消费。

## 已知能力边界与风险

- 共享 Pool waiter 在 caller timeout 后可能继续排队；当前栈不支持 per-operation physical cancellation。本实现只声明 caller bounded + ownership fencing，不声明底层 waiter 已取消。
- `pool.connect / BEGIN / 首条 timeout setup` 属于 transaction bootstrap/control-plane：pool acquisition 使用固定 2s 上界，transaction start 使用 8s Prisma `maxWait`，并由 caller bounded wait 与 late ownership fencing 隔离；不声称首条 SET 已获得 dynamic remaining cancellation。setup 返回并复核 ownership 后，business statement 才使用 dynamic remaining-bound PostgreSQL timeout。
- 未设置 application-wide session `statement_timeout`；Task 2 不改变普通非 Run Prisma query 的 timeout。Run 的 `SET LOCAL` 在 commit / rollback 后恢复原 pooled session baseline，不污染下一位使用者。
- PostgreSQL `statement_timeout` 不约束 COMMIT。completion 使用 commit-ownership 线性化点与独立 5s outcome 上界；超界时结果未知，Runtime 不竞争 cleanup、不发伪终态事件。
- 连接断开或 terminalization COMMIT outcome 不确定时，Run 可能保留 `RUNNING` 或由迟到 COMMIT 最终落盘；本 Task 按 E-08 明确暴露风险，不实现 Durable Recovery。
- 如果尚未 settle 的 normal transaction 持有 Run 行锁超过独立 5s cleanup budget，terminalization 会由真实 DB timeout 有界失败并抛出 `AgentRunTerminalizationError`，不得伪造 `run_failed` / `run_aborted` 已持久化；Run 可能保留 `RUNNING`，本 Task 不实现 durable retry。

实现参考：

- [Prisma 7.8 transaction manager](https://github.com/prisma/prisma/blob/7.8.0/packages/client-engine-runtime/src/transaction-manager/transaction-manager.ts)
- [Prisma adapter-pg 7.8](https://github.com/prisma/prisma/blob/7.8.0/packages/adapter-pg/src/pg.ts)
- [node-postgres Pool](https://node-postgres.com/apis/pool)
- [PostgreSQL timeout settings](https://www.postgresql.org/docs/16/runtime-config-client.html)
- [PostgreSQL SET LOCAL](https://www.postgresql.org/docs/current/sql-set.html)

## 未做事项

- 未修改 docs 正式任务状态；
- 未把 Task 2 / Phase 6 标记 Completed；
- 未关闭 Issue、转 Ready、合并或删除分支；
- 未实现 Durable Recovery 或任何 Phase 6 非目标能力。

Refs #31