### PR TITLE
fix(web): 优化会话滚动跟随与响应式布局

### DIFF
--- a/apps/web/src/components/agent/AgentAssistantReply.vue
+++ b/apps/web/src/components/agent/AgentAssistantReply.vue
@@ -85,10 +85,10 @@ onUnmounted(() => {
 </script>
 
 <template>
-  <div class="group/reply max-w-[760px] pt-1">
+  <div class="group/reply max-w-[700px] pt-1">
     <div
       v-if="isStreaming"
-      class="whitespace-pre-wrap text-[17px] font-medium leading-[1.72] text-agent-ink-soft"
+      class="whitespace-pre-wrap text-base font-medium leading-[1.7] text-agent-ink-soft min-[960px]:text-[15px] min-[960px]:leading-[1.65]"
     >
       {{ text.trim() }}
     </div>

--- a/apps/web/src/components/agent/AgentConversation.vue
+++ b/apps/web/src/components/agent/AgentConversation.vue
@@ -5,7 +5,6 @@ import { computed, ref } from 'vue'
 import { useI18n } from 'vue-i18n'
 
 import AppIcon from '@/components/common/AppIcon.vue'
-import { ScrollArea } from '@/components/ui/scroll-area'
 import { useAgentConversationScroll } from '@/hooks/useAgentConversationScroll'
 import { useConversationScrollMemory } from '@/hooks/useConversationScrollMemory'
 
@@ -26,10 +25,10 @@ const emit = defineEmits<{
 }>()
 
 const { t } = useI18n()
-const conversationRootRef = ref<HTMLElement | null>(null)
+const conversationViewportRef = ref<HTMLElement | null>(null)
 
 const activeTurnId = computed(() => {
-  if (!props.anchorLatestTurn || props.turns.length <= 1)
+  if (!props.anchorLatestTurn)
     return undefined
 
   return props.turns[props.turns.length - 1]?.id
@@ -41,7 +40,7 @@ const activeTurnSignature = computed(() => {
 
   const activeTurn = props.turns[props.turns.length - 1]
 
-  if (!activeTurn || props.turns.length <= 1)
+  if (!activeTurn)
     return ''
 
   return [
@@ -53,13 +52,8 @@ const activeTurnSignature = computed(() => {
   ].join(':')
 })
 
-const {
-  activeTopSpacerHeight,
-  activeTopSpacerStyle,
-  activeBottomSpacerHeight,
-  activeBottomSpacerStyle,
-} = useAgentConversationScroll({
-  containerRef: conversationRootRef,
+useAgentConversationScroll({
+  viewportRef: conversationViewportRef,
   activeTurnId,
   activeTurnSignature,
   enabled: computed(() => props.anchorLatestTurn),
@@ -68,7 +62,7 @@ const {
 const {
   isRestoringScroll,
 } = useConversationScrollMemory({
-  containerRef: conversationRootRef,
+  viewportRef: conversationViewportRef,
   conversationId: computed(() => props.conversationId),
   canRestore: computed(() => props.turns.length > 0 && !props.anchorLatestTurn),
 })
@@ -100,12 +94,11 @@ const starterPrompts = computed(() => [
 
 <template>
   <section
-    ref="conversationRootRef"
-    class="mx-auto flex min-h-0 w-full max-w-[920px] flex-1 flex-col px-4 pt-5 sm:pt-6"
+    class="relative flex min-h-0 w-full flex-1 flex-col"
   >
     <div
       v-if="turns.length === 0 && showEmptyState"
-      class="flex min-h-0 flex-1 items-center justify-center px-1 pb-7 pt-5 sm:px-4 sm:pb-9 lg:pb-10"
+      class="flex min-h-0 flex-1 items-center justify-center overflow-y-auto px-5 pb-8 pt-[72px] sm:px-8"
     >
       <div class="w-full max-w-2xl text-center">
         <div class="mx-auto mb-4 inline-flex items-center justify-center text-agent-accent">
@@ -146,42 +139,38 @@ const starterPrompts = computed(() => [
       :aria-busy="isLoadingMessages ? 'true' : undefined"
     />
 
-    <ScrollArea
+    <div
       v-else
-      class="min-h-0 flex-1 pr-1"
+      ref="conversationViewportRef"
+      data-agent-conversation-viewport
+      class="min-h-0 flex-1 touch-pan-y overflow-y-auto overscroll-y-contain"
       :class="isRestoringScroll ? 'invisible' : undefined"
     >
-      <div class="py-5 sm:py-6">
+      <div class="mx-auto flex min-h-full w-full max-w-[840px] flex-col px-4 pb-10 pt-[72px] sm:px-5 sm:pb-12">
         <div
           v-if="lastGeneratedAt !== '--:--'"
           class="pb-3 text-right text-xs font-semibold text-agent-ink-muted"
         >
           {{ t('conversation.lastReply', { time: lastGeneratedAt }) }}
         </div>
-        <div class="pb-14 sm:pb-16">
-          <div
-            v-if="activeTopSpacerHeight > 0"
-            :style="activeTopSpacerStyle"
-            aria-hidden="true"
-          />
-
+        <div>
           <div class="space-y-6 sm:space-y-7">
             <template
-              v-for="turn in turns"
+              v-for="(turn, turnIndex) in turns"
               :key="turn.id"
             >
               <AgentMessage
                 role="user"
+                :data-agent-user-turn-id="turn.id"
               >
-                <div class="max-w-[720px] whitespace-pre-wrap rounded-2xl bg-agent-user-bubble px-5 py-3.5 text-[17px] font-semibold leading-7 text-agent-user-bubble-text ring-1 ring-agent-user-bubble-border">
+                <div class="max-w-[660px] whitespace-pre-wrap rounded-2xl bg-agent-user-bubble px-4 py-3 text-base font-semibold leading-7 text-agent-user-bubble-text ring-1 ring-agent-user-bubble-border min-[960px]:text-[15px] min-[960px]:leading-6">
                   {{ turn.userMessage }}
                 </div>
               </AgentMessage>
 
               <AgentMessage
                 role="agent"
-                data-agent-active-turn-anchor="true"
-                :data-agent-turn-id="turn.id"
+                :class="anchorLatestTurn && turnIndex === turns.length - 1 ? 'min-h-[40dvh]' : undefined"
               >
                 <div
                   v-if="(turn.status === 'thinking' || turn.status === 'generating') && !turn.reply"
@@ -224,14 +213,8 @@ const starterPrompts = computed(() => [
               </AgentMessage>
             </template>
           </div>
-
-          <div
-            v-if="activeBottomSpacerHeight > 0"
-            :style="activeBottomSpacerStyle"
-            aria-hidden="true"
-          />
         </div>
       </div>
-    </ScrollArea>
+    </div>
   </section>
 </template>

--- a/apps/web/src/components/agent/AgentMarkdownContent.vue
+++ b/apps/web/src/components/agent/AgentMarkdownContent.vue
@@ -61,9 +61,16 @@ function setTokenAttr(token: Token, name: string, value: string) {
 <style scoped>
 .agent-markdown-content {
   color: var(--agent-ink-soft);
-  font-size: 17px;
+  font-size: 16px;
   font-weight: 500;
-  line-height: 1.72;
+  line-height: 1.7;
+}
+
+@media (min-width: 960px) {
+  .agent-markdown-content {
+    font-size: 15px;
+    line-height: 1.65;
+  }
 }
 
 .agent-markdown-content :deep(*) {

--- a/apps/web/src/components/agent/AgentMessage.vue
+++ b/apps/web/src/components/agent/AgentMessage.vue
@@ -40,7 +40,7 @@ const agentAvatarUrl = computed(() => {
 
     <div
       class="min-w-0"
-      :class="role === 'user' ? 'max-w-[78%]' : 'max-w-[920px] flex-1'"
+      :class="role === 'user' ? 'max-w-[78%]' : 'max-w-[840px] flex-1'"
     >
       <slot />
     </div>

--- a/apps/web/src/components/layout/AppHeader.vue
+++ b/apps/web/src/components/layout/AppHeader.vue
@@ -41,22 +41,22 @@ const { t } = useI18n()
 </script>
 
 <template>
-  <header class="flex h-14 shrink-0 items-center justify-between gap-3 bg-transparent px-3 lg:h-16 lg:gap-4 lg:px-7">
-    <div class="flex min-w-0 items-center gap-2.5 lg:gap-3">
+  <header class="pointer-events-none absolute inset-x-0 top-0 z-30 flex h-14 items-center justify-between gap-3 bg-transparent px-3 min-[960px]:px-6">
+    <div class="pointer-events-auto flex min-w-0 items-center gap-2.5">
       <Button
         type="button"
         variant="ghost"
         size="icon-lg"
         :title="t('layout.mobileNavigation.open')"
         :aria-label="t('layout.mobileNavigation.open')"
-        class="size-9 rounded-lg bg-transparent text-agent-ink-muted shadow-none hover:bg-agent-surface-sunken hover:text-agent-ink lg:hidden"
+        class="size-9 rounded-lg bg-transparent text-agent-ink-muted shadow-none hover:bg-agent-surface-sunken hover:text-agent-ink min-[960px]:hidden"
         @click="emit('openNavigation')"
       >
         <AppIcon name="tabler:layout-sidebar-left-expand" :size="21" />
       </Button>
     </div>
 
-    <div class="flex shrink-0 items-center gap-1.5 sm:gap-2 lg:gap-3">
+    <div class="pointer-events-auto flex shrink-0 items-center gap-1.5 sm:gap-2 min-[960px]:gap-2.5">
       <WorkspaceThemeSwitcher
         :model-value="workspaceTheme"
         :options="workspaceThemeOptions"
@@ -68,7 +68,7 @@ const { t } = useI18n()
       <Badge
         as="div"
         variant="outline"
-        class="hidden h-10 items-center gap-2 rounded-full border-agent-border bg-agent-surface-raised px-3 text-sm font-bold text-agent-ink-soft shadow-none lg:flex"
+        class="hidden h-9 items-center gap-2 rounded-full border-agent-border bg-agent-surface-raised px-3 text-[13px] font-bold text-agent-ink-soft shadow-none min-[960px]:flex"
       >
         <span class="size-2 rounded-full" :class="balanceToneClass" />
         <span class="hidden sm:inline">{{ balanceLabel }}</span>

--- a/apps/web/src/components/layout/AppShell.vue
+++ b/apps/web/src/components/layout/AppShell.vue
@@ -47,8 +47,8 @@ const { t } = useI18n()
 
 const desktopGridClass = computed(() => {
   return sidebarCollapsed.value
-    ? 'lg:grid-cols-[76px_minmax(0,1fr)]'
-    : 'lg:grid-cols-[292px_minmax(0,1fr)]'
+    ? 'min-[960px]:grid-cols-[68px_minmax(0,1fr)]'
+    : 'min-[960px]:grid-cols-[264px_minmax(0,1fr)]'
 })
 
 function toggleSidebar() {
@@ -81,7 +81,7 @@ function handleRenameChat(chatId: string, title: string) {
 
 <template>
   <main
-    class="grid h-screen w-full overflow-hidden bg-agent-canvas text-agent-ink transition-[grid-template-columns] duration-300"
+    class="grid h-screen w-full grid-rows-1 overflow-hidden bg-agent-canvas text-agent-ink transition-[grid-template-columns] duration-300"
     :class="desktopGridClass"
     :data-agent-workspace-theme="props.workspaceTheme"
   >
@@ -102,7 +102,7 @@ function handleRenameChat(chatId: string, title: string) {
     <Sheet v-model:open="mobileSidebarOpen">
       <SheetContent
         side="left"
-        class="w-[288px] max-w-[calc(100vw-28px)] gap-0 border-r border-agent-border bg-agent-sidebar p-0 shadow-[20px_0_48px_rgb(61_49_36/10%)] duration-300 ease-[cubic-bezier(.22,1,.36,1)] will-change-transform data-[side=left]:data-[state=open]:slide-in-from-left-12 data-[side=left]:data-[state=closed]:slide-out-to-left-12 lg:hidden"
+        class="w-[288px] max-w-[calc(100vw-28px)] gap-0 border-r border-agent-border bg-agent-sidebar p-0 shadow-[20px_0_48px_rgb(61_49_36/10%)] duration-300 ease-[cubic-bezier(.22,1,.36,1)] will-change-transform data-[side=left]:data-[state=open]:slide-in-from-left-12 data-[side=left]:data-[state=closed]:slide-out-to-left-12 min-[960px]:hidden"
         :show-close-button="false"
       >
         <SheetTitle class="sr-only">

--- a/apps/web/src/components/layout/AppSidebar.vue
+++ b/apps/web/src/components/layout/AppSidebar.vue
@@ -31,10 +31,10 @@ const { t } = useI18n()
 
 <template>
   <aside
-    class="relative flex h-full shrink-0 flex-col border-r border-agent-border bg-agent-sidebar py-5 transition-[width,padding] duration-300"
+    class="relative flex h-full shrink-0 flex-col border-r border-agent-border bg-agent-sidebar py-5 font-sans text-sm transition-[width,padding] duration-300"
     :class="[
-      collapsed ? 'w-[76px] px-3' : 'w-[292px] px-5',
-      mobile ? 'flex' : 'hidden lg:flex',
+      mobile ? 'flex w-full px-5' : collapsed ? 'w-[68px] px-3' : 'w-[264px] px-4',
+      mobile ? undefined : 'hidden min-[960px]:flex',
     ]"
   >
     <div
@@ -62,10 +62,10 @@ const { t } = useI18n()
           >
         </div>
         <div class="min-w-0">
-          <h1 class="truncate text-lg font-extrabold tracking-normal text-agent-ink">
+          <h1 class="truncate text-lg font-semibold tracking-normal text-agent-ink">
             SEO Agent
           </h1>
-          <p class="text-xs font-semibold text-agent-ink-muted">
+          <p class="text-xs font-normal text-agent-ink-muted">
             {{ t('layout.sidebar.productSubtitle') }}
           </p>
         </div>
@@ -88,7 +88,7 @@ const { t } = useI18n()
       type="button"
       :title="collapsed ? t('layout.sidebar.newChat') : undefined"
       :aria-label="collapsed ? t('layout.sidebar.newChat') : undefined"
-      class="mb-6 inline-flex h-11 items-center justify-center gap-2 rounded-2xl bg-agent-primary px-4 text-sm font-bold text-white transition hover:bg-agent-primary-hover focus-visible:outline-none focus-visible:ring-3 focus-visible:ring-agent-focus/55"
+      class="mb-6 inline-flex h-11 items-center justify-center gap-2 rounded-2xl bg-agent-primary px-4 text-sm font-medium text-white transition hover:bg-agent-primary-hover focus-visible:outline-none focus-visible:ring-3 focus-visible:ring-agent-focus/55"
       :class="{ 'px-0': collapsed }"
       @click="emit('newChat')"
     >
@@ -103,7 +103,7 @@ const { t } = useI18n()
         type="button"
         :title="collapsed ? item.label : undefined"
         :aria-label="collapsed ? item.label : undefined"
-        class="flex h-11 w-full items-center rounded-xl text-sm font-semibold text-agent-ink-muted transition hover:bg-agent-surface-raised hover:text-agent-ink focus-visible:outline-none focus-visible:ring-3 focus-visible:ring-agent-focus/40"
+        class="flex h-11 w-full items-center rounded-xl text-sm font-normal text-agent-ink-muted transition hover:bg-agent-surface-raised hover:text-agent-ink focus-visible:outline-none focus-visible:ring-3 focus-visible:ring-agent-focus/40"
         :class="[
           collapsed ? 'justify-center px-0' : 'gap-3 px-3',
           item.active ? 'bg-agent-accent-soft text-agent-ink ring-1 ring-agent-border-soft' : '',
@@ -123,7 +123,7 @@ const { t } = useI18n()
       class="mt-8 flex min-h-0 flex-1 flex-col"
     >
       <div class="mb-3 flex items-center justify-between gap-3">
-        <h2 class="text-xs font-bold tracking-normal text-agent-ink-muted">
+        <h2 class="text-xs font-medium tracking-normal text-agent-ink-muted">
           {{ t('layout.sidebar.recentChats') }}
         </h2>
         <button
@@ -141,10 +141,10 @@ const { t } = useI18n()
         v-if="recentChats.length === 0"
         class="rounded-2xl border border-dashed border-agent-border bg-agent-surface/72 px-3.5 py-4"
       >
-        <p class="text-sm font-semibold leading-5 text-agent-ink-soft">
+        <p class="text-sm font-medium leading-5 text-agent-ink-soft">
           {{ t('layout.sidebar.emptyRecentTitle') }}
         </p>
-        <p class="mt-1 text-xs font-medium leading-5 text-agent-ink-muted">
+        <p class="mt-1 text-xs font-normal leading-5 text-agent-ink-muted">
           {{ t('layout.sidebar.emptyRecentDescription') }}
         </p>
       </div>

--- a/apps/web/src/components/layout/ConversationList.vue
+++ b/apps/web/src/components/layout/ConversationList.vue
@@ -37,7 +37,7 @@ function handleScroll(event: Event) {
 
 <template>
   <div
-    class="min-h-0 flex-1 space-y-1 overflow-y-auto pr-1"
+    class="min-h-0 flex-1 space-y-1 overflow-y-auto [scrollbar-width:none] [&::-webkit-scrollbar]:hidden"
     @scroll="handleScroll"
   >
     <ConversationListItem

--- a/apps/web/src/components/layout/ConversationListItem.vue
+++ b/apps/web/src/components/layout/ConversationListItem.vue
@@ -95,7 +95,7 @@ function deleteChat() {
       ref="renameInputRef"
       v-model="titleDraft"
       maxlength="80"
-      class="h-9 w-full rounded-lg border border-agent-border bg-agent-sidebar px-3 pr-9 text-sm font-semibold text-agent-ink outline-none transition focus:border-agent-accent focus:ring-3 focus:ring-agent-focus/35"
+      class="h-9 w-full rounded-lg border border-agent-border bg-agent-sidebar px-3 pr-9 text-sm font-normal text-agent-ink outline-none transition focus:border-agent-accent focus:ring-3 focus:ring-agent-focus/35"
       :aria-label="t('layout.sidebar.renameChat')"
       @blur="submitRename"
       @click.stop
@@ -106,7 +106,7 @@ function deleteChat() {
     <button
       v-else
       type="button"
-      class="flex h-9 w-full min-w-0 items-center rounded-lg px-3 pr-9 text-left text-sm font-semibold transition focus-visible:outline-none focus-visible:ring-3 focus-visible:ring-agent-focus/40"
+      class="flex h-9 w-full min-w-0 items-center rounded-lg px-3 pr-9 text-left text-sm font-normal transition focus-visible:outline-none focus-visible:ring-3 focus-visible:ring-agent-focus/40"
       :class="chat.active ? 'text-agent-ink' : 'text-agent-ink-soft'"
       @click="selectChat"
     >
@@ -138,7 +138,7 @@ function deleteChat() {
       >
         <button
           type="button"
-          class="flex h-9 w-full items-center gap-2 rounded-lg px-2.5 text-left text-sm font-semibold text-agent-ink-soft transition hover:bg-agent-surface-sunken hover:text-agent-ink"
+          class="flex h-9 w-full items-center gap-2 rounded-lg px-2.5 text-left text-sm font-normal text-agent-ink-soft transition hover:bg-agent-surface-sunken hover:text-agent-ink"
           @click="startRename"
         >
           <AppIcon name="tabler:pencil" :size="17" />
@@ -146,7 +146,7 @@ function deleteChat() {
         </button>
         <button
           type="button"
-          class="flex h-9 w-full items-center gap-2 rounded-lg px-2.5 text-left text-sm font-semibold text-agent-copper transition hover:bg-agent-copper-soft"
+          class="flex h-9 w-full items-center gap-2 rounded-lg px-2.5 text-left text-sm font-normal text-agent-copper transition hover:bg-agent-copper-soft"
           @click="deleteChat"
         >
           <AppIcon name="tabler:trash" :size="17" />

--- a/apps/web/src/components/layout/WorkspaceThemeSwitcher.vue
+++ b/apps/web/src/components/layout/WorkspaceThemeSwitcher.vue
@@ -52,11 +52,11 @@ function updateTheme(value: unknown) {
   >
     <SelectTrigger
       :aria-label="t('layout.themeSwitcher.ariaLabel')"
-      class="group h-9 w-9 overflow-hidden rounded-full border-agent-border bg-agent-surface-raised px-0 text-agent-ink-soft shadow-none hover:border-agent-border hover:bg-agent-surface focus:ring-agent-focus/35 sm:w-[92px] sm:px-3 lg:h-10 lg:w-[112px]"
+      class="group h-9 w-9 overflow-hidden rounded-full border-agent-border bg-agent-surface-raised px-0 text-agent-ink-soft shadow-none hover:border-agent-border hover:bg-agent-surface focus:ring-agent-focus/35 sm:w-[92px] sm:px-3 min-[960px]:w-[100px]"
     >
       <AppIcon :name="selectedTheme.icon" :size="17" class="shrink-0 text-agent-ink-muted transition group-hover:text-agent-ink" />
       <SelectValue :placeholder="t('layout.themeSwitcher.placeholder')">
-        <span class="hidden truncate text-xs font-bold sm:inline lg:text-sm">
+        <span class="hidden truncate text-xs font-bold sm:inline">
           {{ t(selectedTheme.shortLabelKey) }}
         </span>
       </SelectValue>

--- a/apps/web/src/components/seo/SeoChatComposer.vue
+++ b/apps/web/src/components/seo/SeoChatComposer.vue
@@ -75,16 +75,16 @@ function updateSelectedModel(value: unknown) {
 </script>
 
 <template>
-  <section class="relative z-10 shrink-0 px-3 pb-3 pt-4 sm:px-4 sm:pb-4 sm:pt-5">
-    <div class="mx-auto w-full max-w-[760px]">
+  <section class="relative z-10 shrink-0 px-3 pb-3 pt-3 sm:px-4 sm:pb-4">
+    <div class="mx-auto w-full max-w-[700px]">
       <div
-        class="rounded-2xl border border-agent-border bg-agent-surface-raised p-2 shadow-[0_4px_8px_rgb(61_49_36/5%)] sm:p-3"
+        class="rounded-2xl border border-agent-border bg-agent-surface-raised p-2.5 shadow-[0_4px_8px_rgb(61_49_36/5%)]"
       >
         <Textarea
           :model-value="message"
           :maxlength="SEO_CHAT_MESSAGE_MAX_CHARS"
           rows="1"
-          class="max-h-40 min-h-[72px] resize-none border-0 bg-transparent px-3 pb-2 pt-2 text-[15px] font-medium leading-6 text-agent-ink shadow-none focus-visible:ring-0 sm:min-h-24 sm:px-4 sm:pt-3 placeholder:font-medium placeholder:text-agent-ink-muted"
+          class="max-h-40 min-h-16 resize-none border-0 bg-transparent px-3 pb-2 pt-2 text-base font-medium leading-6 text-agent-ink shadow-none focus-visible:ring-0 min-[960px]:min-h-20 min-[960px]:text-[15px] sm:px-4 sm:pt-3 placeholder:font-medium placeholder:text-agent-ink-muted"
           :placeholder="hasConversation ? '' : t('composer.placeholder')"
           @update:model-value="updateMessage"
           @keydown.enter.exact.prevent="submitComposer"
@@ -97,7 +97,7 @@ function updateSelectedModel(value: unknown) {
           >
             <SelectTrigger
               :aria-label="t('composer.modelSelectAria')"
-              class="h-9 max-w-[calc(100vw-148px)] min-w-0 overflow-hidden rounded-full border-agent-border bg-agent-surface px-3 text-[14px] font-medium tracking-normal text-agent-ink-soft shadow-none hover:border-agent-border hover:bg-agent-surface-raised focus:ring-agent-focus/35 sm:h-10 sm:max-w-none sm:min-w-[210px]"
+              class="h-11 max-w-[calc(100vw-148px)] min-w-0 overflow-hidden rounded-full border-agent-border bg-agent-surface px-3 text-[14px] font-medium tracking-normal text-agent-ink-soft shadow-none hover:border-agent-border hover:bg-agent-surface-raised focus:ring-agent-focus/35 sm:max-w-none sm:min-w-[190px] min-[960px]:h-9"
             >
               <SelectValue :placeholder="t('composer.modelPlaceholder')" />
             </SelectTrigger>
@@ -122,7 +122,7 @@ function updateSelectedModel(value: unknown) {
               size="icon-lg"
               :title="t('composer.reset')"
               :aria-label="t('composer.reset')"
-              class="size-9 rounded-lg bg-transparent text-agent-ink-muted shadow-none hover:bg-agent-surface-sunken hover:text-agent-ink disabled:text-agent-ink-faint sm:size-10"
+              class="size-11 rounded-lg bg-transparent text-agent-ink-muted shadow-none hover:bg-agent-surface-sunken hover:text-agent-ink disabled:text-agent-ink-faint min-[960px]:size-10"
               :disabled="!canReset || isGenerationInProgress"
               @click="emit('reset')"
             >
@@ -133,7 +133,7 @@ function updateSelectedModel(value: unknown) {
               size="icon-lg"
               :title="isGenerationInProgress ? t('composer.stop') : t('composer.send')"
               :aria-label="isGenerationInProgress ? t('composer.stop') : t('composer.send')"
-              class="size-10 rounded-full text-white shadow-none disabled:bg-agent-border sm:size-11"
+              class="size-11 rounded-full text-white shadow-none disabled:bg-agent-border min-[960px]:size-10"
               :class="isGenerationInProgress ? 'bg-agent-copper hover:bg-agent-copper' : 'bg-agent-primary hover:bg-agent-primary-hover'"
               :disabled="!isGenerationInProgress && !message.trim()"
               @click="triggerPrimaryAction"

--- a/apps/web/src/hooks/useAgentConversationScroll.ts
+++ b/apps/web/src/hooks/useAgentConversationScroll.ts
@@ -48,19 +48,33 @@ export function useAgentConversationScroll(options: UseAgentConversationScrollOp
     }
 
     const handleWheel = (event: WheelEvent) => {
+      if (event.ctrlKey)
+        return
+
       if (event.deltaY < 0)
         shouldFollowLatest = false
+      else if (event.deltaY > 0 && isNearBottom(viewport))
+        shouldFollowLatest = true
     }
 
     const handleTouchStart = (event: TouchEvent) => {
-      lastTouchY = event.touches[0]?.clientY
+      lastTouchY = event.touches.length === 1 ? event.touches[0]?.clientY : undefined
     }
 
     const handleTouchMove = (event: TouchEvent) => {
+      if (event.touches.length !== 1) {
+        lastTouchY = undefined
+        return
+      }
+
       const nextTouchY = event.touches[0]?.clientY
 
-      if (lastTouchY !== undefined && nextTouchY !== undefined && nextTouchY > lastTouchY)
-        shouldFollowLatest = false
+      if (lastTouchY !== undefined && nextTouchY !== undefined) {
+        if (nextTouchY > lastTouchY)
+          shouldFollowLatest = false
+        else if (nextTouchY < lastTouchY && isNearBottom(viewport))
+          shouldFollowLatest = true
+      }
 
       lastTouchY = nextTouchY
     }

--- a/apps/web/src/hooks/useAgentConversationScroll.ts
+++ b/apps/web/src/hooks/useAgentConversationScroll.ts
@@ -1,163 +1,122 @@
-import type { ComputedRef, CSSProperties, Ref } from 'vue'
+import type { ComputedRef, Ref } from 'vue'
 
-import { computed, nextTick, onUnmounted, ref, watch } from 'vue'
+import { nextTick, onUnmounted, watch } from 'vue'
 
 interface UseAgentConversationScrollOptions {
-  containerRef: Ref<HTMLElement | null>
+  viewportRef: Ref<HTMLElement | null>
   activeTurnId: ComputedRef<string | undefined>
   activeTurnSignature: ComputedRef<string>
   enabled: ComputedRef<boolean>
 }
 
-interface ConversationScrollMetrics {
-  anchorTop: number
-  baseScrollHeight: number
-  viewport: HTMLElement
-}
-
-const ACTIVE_TURN_TOP_RATIO = 0.42
-const SCROLLABLE_TOLERANCE_PX = 2
+const BOTTOM_THRESHOLD_PX = 96
 
 /**
- * 将最新一轮 AI 回复区域锚定在对话视口中部偏上的位置。
- *
- * 这个 hook 只负责展示层滚动：首次对话保持自然布局；历史内容溢出后，
- * 最新一轮 loading、成功、错误状态共用同一个 active turn 锚点。
+ * 新一轮开始时定位到用户消息；流式输出只在用户仍停留在底部时自动跟随。
  */
 export function useAgentConversationScroll(options: UseAgentConversationScrollOptions) {
-  const activeTopSpacerHeight = ref(0)
-  const activeBottomSpacerHeight = ref(0)
-
-  const activeTopSpacerStyle = computed<CSSProperties>(() => ({
-    height: `${activeTopSpacerHeight.value}px`,
-  }))
-
-  const activeBottomSpacerStyle = computed<CSSProperties>(() => ({
-    height: `${activeBottomSpacerHeight.value}px`,
-  }))
-
   let alignmentRunId = 0
-  let resizeObserver: ResizeObserver | undefined
+  let shouldFollowLatest = true
+  let ignoreScrollEvents = false
   let observedViewport: HTMLElement | undefined
+  let removeScrollListener: (() => void) | undefined
+
+  function bindScrollListener() {
+    const viewport = options.viewportRef.value
+
+    if (observedViewport === viewport)
+      return
+
+    removeScrollListener?.()
+    observedViewport = viewport ?? undefined
+
+    if (!viewport)
+      return
+
+    const handleScroll = () => {
+      if (ignoreScrollEvents)
+        return
+
+      shouldFollowLatest = isNearBottom(viewport)
+    }
+
+    viewport.addEventListener('scroll', handleScroll, { passive: true })
+    removeScrollListener = () => viewport.removeEventListener('scroll', handleScroll)
+  }
 
   async function alignActiveTurn() {
-    if (!options.enabled.value) {
-      resetSpacers()
-      return
-    }
-
     const activeTurnId = options.activeTurnId.value
 
-    if (!activeTurnId) {
-      resetSpacers()
+    if (!options.enabled.value || !activeTurnId)
       return
-    }
 
     const runId = ++alignmentRunId
 
     await waitForLayout()
 
-    if (!isCurrentAlignment(runId))
+    if (!isCurrentAlignment(runId, activeTurnId))
       return
 
-    const metrics = readMetrics(activeTurnId)
+    bindScrollListener()
 
-    if (!metrics)
-      return
-
-    bindViewportResizeObserver(metrics.viewport)
-
-    if (!isContentScrollable(metrics)) {
-      resetSpacers()
-      return
-    }
-
-    const targetTop = metrics.viewport.clientHeight * ACTIVE_TURN_TOP_RATIO
-    const nextTopSpacerHeight = Math.max(0, targetTop - metrics.anchorTop)
-    const adjustedAnchorTop = metrics.anchorTop + nextTopSpacerHeight
-    const adjustedScrollHeight = metrics.baseScrollHeight + nextTopSpacerHeight
-    const adjustedMaxScrollTop = Math.max(0, adjustedScrollHeight - metrics.viewport.clientHeight)
-    const targetScrollTop = Math.max(0, adjustedAnchorTop - targetTop)
-    const nextBottomSpacerHeight = Math.max(0, targetScrollTop - adjustedMaxScrollTop)
-    const finalMaxScrollTop = adjustedMaxScrollTop + nextBottomSpacerHeight
-
-    activeTopSpacerHeight.value = Math.ceil(nextTopSpacerHeight)
-    activeBottomSpacerHeight.value = Math.ceil(nextBottomSpacerHeight)
-    await waitForLayout()
-
-    if (!isCurrentAlignment(runId))
-      return
-
-    const finalTargetScrollTop = clampScrollTop(targetScrollTop, finalMaxScrollTop)
-
-    metrics.viewport.scrollTo({
-      top: finalTargetScrollTop,
-      behavior: 'auto',
-    })
-  }
-
-  function readMetrics(activeTurnId: string): ConversationScrollMetrics | null {
-    const viewport = getScrollViewport()
-    const anchor = getActiveTurnAnchor(activeTurnId)
+    const viewport = options.viewportRef.value
+    const anchor = findUserTurnAnchor(viewport, activeTurnId)
 
     if (!viewport || !anchor)
-      return null
+      return
 
     const viewportRect = viewport.getBoundingClientRect()
     const anchorRect = anchor.getBoundingClientRect()
-    const currentTopSpacerHeight = activeTopSpacerHeight.value
-    const currentBottomSpacerHeight = activeBottomSpacerHeight.value
-    const anchorTop = anchorRect.top - viewportRect.top + viewport.scrollTop - currentTopSpacerHeight
+    const targetTop = viewport.scrollTop + anchorRect.top - viewportRect.top - 16
 
-    return {
-      anchorTop,
-      baseScrollHeight: Math.max(0, viewport.scrollHeight - currentTopSpacerHeight - currentBottomSpacerHeight),
-      viewport,
-    }
+    shouldFollowLatest = true
+    scrollViewport(viewport, targetTop)
   }
 
-  function getScrollViewport() {
-    return options.containerRef.value?.querySelector<HTMLElement>('[data-slot="scroll-area-viewport"]') ?? null
+  async function followActiveTurn() {
+    const activeTurnId = options.activeTurnId.value
+
+    if (!options.enabled.value || !activeTurnId || !shouldFollowLatest)
+      return
+
+    const runId = alignmentRunId
+
+    await waitForLayout()
+
+    if (!isCurrentAlignment(runId, activeTurnId) || !shouldFollowLatest)
+      return
+
+    const viewport = options.viewportRef.value
+
+    if (viewport)
+      scrollViewport(viewport, viewport.scrollHeight)
   }
 
-  function getActiveTurnAnchor(activeTurnId: string) {
+  function scrollViewport(viewport: HTMLElement, top: number) {
+    ignoreScrollEvents = true
+    viewport.scrollTo({ top, behavior: 'auto' })
+
+    window.requestAnimationFrame(() => {
+      ignoreScrollEvents = false
+    })
+  }
+
+  function findUserTurnAnchor(viewport: HTMLElement | null, activeTurnId: string) {
     const anchors = Array.from(
-      options.containerRef.value?.querySelectorAll<HTMLElement>('[data-agent-active-turn-anchor="true"]') ?? [],
+      viewport?.querySelectorAll<HTMLElement>('[data-agent-user-turn-id]') ?? [],
     )
 
-    return anchors.find(anchor => anchor.dataset.agentTurnId === activeTurnId) ?? null
+    return anchors.find(anchor => anchor.dataset.agentUserTurnId === activeTurnId) ?? null
   }
 
-  function bindViewportResizeObserver(viewport: HTMLElement) {
-    if (!('ResizeObserver' in window))
-      return
-
-    if (observedViewport === viewport)
-      return
-
-    resizeObserver?.disconnect()
-    observedViewport = viewport
-    resizeObserver = new ResizeObserver(() => {
-      void alignActiveTurn()
-    })
-    resizeObserver.observe(viewport)
+  function isCurrentAlignment(runId: number, activeTurnId: string) {
+    return runId === alignmentRunId
+      && options.enabled.value
+      && options.activeTurnId.value === activeTurnId
   }
 
-  function resetSpacers() {
-    activeTopSpacerHeight.value = 0
-    activeBottomSpacerHeight.value = 0
-  }
-
-  function isCurrentAlignment(runId: number) {
-    return runId === alignmentRunId && options.enabled.value && Boolean(options.activeTurnId.value)
-  }
-
-  function isContentScrollable(metrics: ConversationScrollMetrics) {
-    return metrics.baseScrollHeight - metrics.viewport.clientHeight > SCROLLABLE_TOLERANCE_PX
-  }
-
-  function clampScrollTop(value: number, maxScrollTop: number) {
-    return Math.min(Math.max(0, value), maxScrollTop)
+  function isNearBottom(viewport: HTMLElement) {
+    return viewport.scrollHeight - viewport.scrollTop - viewport.clientHeight <= BOTTOM_THRESHOLD_PX
   }
 
   async function waitForLayout() {
@@ -169,29 +128,26 @@ export function useAgentConversationScroll(options: UseAgentConversationScrollOp
 
   watch(
     [
-      () => options.activeTurnSignature.value,
+      () => options.activeTurnId.value,
       () => options.enabled.value,
-      () => options.containerRef.value,
+      () => options.viewportRef.value,
     ],
     () => {
+      bindScrollListener()
       void alignActiveTurn()
     },
-    {
-      flush: 'post',
-      immediate: true,
-    },
+    { flush: 'post', immediate: true },
+  )
+
+  watch(
+    () => options.activeTurnSignature.value,
+    () => void followActiveTurn(),
+    { flush: 'post' },
   )
 
   onUnmounted(() => {
-    resizeObserver?.disconnect()
+    removeScrollListener?.()
     observedViewport = undefined
     alignmentRunId += 1
   })
-
-  return {
-    activeTopSpacerHeight,
-    activeTopSpacerStyle,
-    activeBottomSpacerHeight,
-    activeBottomSpacerStyle,
-  }
 }

--- a/apps/web/src/hooks/useAgentConversationScroll.ts
+++ b/apps/web/src/hooks/useAgentConversationScroll.ts
@@ -34,6 +34,7 @@ export function useAgentConversationScroll(options: UseAgentConversationScrollOp
       return
 
     lastScrollTop = viewport.scrollTop
+    let lastTouchY: number | undefined
 
     const handleScroll = () => {
       const nextScrollTop = viewport.scrollTop
@@ -46,8 +47,42 @@ export function useAgentConversationScroll(options: UseAgentConversationScrollOp
       lastScrollTop = nextScrollTop
     }
 
+    const handleWheel = (event: WheelEvent) => {
+      if (event.deltaY < 0)
+        shouldFollowLatest = false
+    }
+
+    const handleTouchStart = (event: TouchEvent) => {
+      lastTouchY = event.touches[0]?.clientY
+    }
+
+    const handleTouchMove = (event: TouchEvent) => {
+      const nextTouchY = event.touches[0]?.clientY
+
+      if (lastTouchY !== undefined && nextTouchY !== undefined && nextTouchY > lastTouchY)
+        shouldFollowLatest = false
+
+      lastTouchY = nextTouchY
+    }
+
+    const handleTouchEnd = () => {
+      lastTouchY = undefined
+    }
+
     viewport.addEventListener('scroll', handleScroll, { passive: true })
-    removeScrollListener = () => viewport.removeEventListener('scroll', handleScroll)
+    viewport.addEventListener('wheel', handleWheel, { passive: true })
+    viewport.addEventListener('touchstart', handleTouchStart, { passive: true })
+    viewport.addEventListener('touchmove', handleTouchMove, { passive: true })
+    viewport.addEventListener('touchend', handleTouchEnd, { passive: true })
+    viewport.addEventListener('touchcancel', handleTouchEnd, { passive: true })
+    removeScrollListener = () => {
+      viewport.removeEventListener('scroll', handleScroll)
+      viewport.removeEventListener('wheel', handleWheel)
+      viewport.removeEventListener('touchstart', handleTouchStart)
+      viewport.removeEventListener('touchmove', handleTouchMove)
+      viewport.removeEventListener('touchend', handleTouchEnd)
+      viewport.removeEventListener('touchcancel', handleTouchEnd)
+    }
   }
 
   async function alignActiveTurn() {

--- a/apps/web/src/hooks/useAgentConversationScroll.ts
+++ b/apps/web/src/hooks/useAgentConversationScroll.ts
@@ -17,7 +17,7 @@ const BOTTOM_THRESHOLD_PX = 96
 export function useAgentConversationScroll(options: UseAgentConversationScrollOptions) {
   let alignmentRunId = 0
   let shouldFollowLatest = true
-  let ignoreScrollEvents = false
+  let lastScrollTop = 0
   let observedViewport: HTMLElement | undefined
   let removeScrollListener: (() => void) | undefined
 
@@ -33,11 +33,17 @@ export function useAgentConversationScroll(options: UseAgentConversationScrollOp
     if (!viewport)
       return
 
-    const handleScroll = () => {
-      if (ignoreScrollEvents)
-        return
+    lastScrollTop = viewport.scrollTop
 
-      shouldFollowLatest = isNearBottom(viewport)
+    const handleScroll = () => {
+      const nextScrollTop = viewport.scrollTop
+
+      if (nextScrollTop < lastScrollTop)
+        shouldFollowLatest = false
+      else if (isNearBottom(viewport))
+        shouldFollowLatest = true
+
+      lastScrollTop = nextScrollTop
     }
 
     viewport.addEventListener('scroll', handleScroll, { passive: true })
@@ -93,12 +99,8 @@ export function useAgentConversationScroll(options: UseAgentConversationScrollOp
   }
 
   function scrollViewport(viewport: HTMLElement, top: number) {
-    ignoreScrollEvents = true
     viewport.scrollTo({ top, behavior: 'auto' })
-
-    window.requestAnimationFrame(() => {
-      ignoreScrollEvents = false
-    })
+    lastScrollTop = viewport.scrollTop
   }
 
   function findUserTurnAnchor(viewport: HTMLElement | null, activeTurnId: string) {

--- a/apps/web/src/hooks/useConversationScrollMemory.ts
+++ b/apps/web/src/hooks/useConversationScrollMemory.ts
@@ -3,7 +3,7 @@ import type { ComputedRef, Ref } from 'vue'
 import { nextTick, onUnmounted, ref, watch } from 'vue'
 
 interface UseConversationScrollMemoryOptions {
-  containerRef: Ref<HTMLElement | null>
+  viewportRef: Ref<HTMLElement | null>
   conversationId: ComputedRef<string | null>
   canRestore: ComputedRef<boolean>
 }
@@ -92,7 +92,7 @@ export function useConversationScrollMemory(options: UseConversationScrollMemory
   }
 
   function getScrollViewport() {
-    return options.containerRef.value?.querySelector<HTMLElement>('[data-slot="scroll-area-viewport"]') ?? null
+    return options.viewportRef.value
   }
 
   function isCurrentRestore(runId: number) {
@@ -138,7 +138,7 @@ export function useConversationScrollMemory(options: UseConversationScrollMemory
     [
       () => options.conversationId.value,
       () => options.canRestore.value,
-      () => options.containerRef.value,
+      () => options.viewportRef.value,
     ],
     () => {
       void restoreScrollPosition()


### PR DESCRIPTION
Closes #37

## 变更

- 将 Chat 会话区域改为原生可控滚动 viewport；
- 新一轮开始定位当前用户消息；
- 流式输出仅在用户仍位于底部附近时自动跟随；
- 用户上滚后暂停跟随，重新回到底部附近后恢复；
- 忽略 `ctrl + wheel` 缩放与多指触控的错误滚动意图；
- 保留历史会话 scroll memory；
- 同步调整 Chat、Sidebar、Header、Composer 等响应式宽度和间距。

## 范围

本 PR 只包含 `apps/web/**` 的 Web Chat UI / scroll follow-up，不包含 Admin Task 3、API、Prisma 或 Agent Runtime 改动。

## 验证

现有提交记录：

- `pnpm --filter @agent/web typecheck` PASS
- `pnpm --filter @agent/web lint` PASS
- `pnpm --filter @agent/web build` PASS
- `git diff --check` PASS

GPT 已核对最终 diff，未发现阻塞合并的问题。