### PR TITLE
refactor: 建立 Context Boundary 与安全 Context Snapshot

### DIFF
--- a/apps/api/src/agent-runtime/agent-runtime.service.test.ts
+++ b/apps/api/src/agent-runtime/agent-runtime.service.test.ts
@@ -44,6 +44,7 @@ import { buildSeoAgentChatMessages } from '../seo/prompts/seo-agent.prompt.js'
 import { toChatStreamEvent } from '../seo/seo-chat-stream-event.mapper.js'
 import { AgentRunTerminalizationError } from './agent-runtime.errors.js'
 import { AgentRuntimeService } from './agent-runtime.service.js'
+import { ModelContext } from './model-context.js'
 
 describe('AgentRuntimeService model stream', () => {
   it('保持普通文本流的现有完成行为', async () => {
@@ -66,6 +67,11 @@ describe('AgentRuntimeService model stream', () => {
     assert.equal(harness.assistantMessage()?.status, MessageStatus.COMPLETED)
     assert.deepEqual(harness.recorder.completedRunIds, ['run-1'])
     assert.equal(harness.llmCalls.length, 1)
+    assert.deepEqual(harness.llmCalls[0]?.messages, [{
+      type: 'message',
+      role: 'user',
+      content: '问题',
+    }])
     assert.equal(harness.toolInvocations.length, 0)
     assert.deepEqual(
       harness.llmCalls[0]?.options?.tools?.map(tool => tool.name),
@@ -325,7 +331,12 @@ describe('AgentRuntimeService model stream', () => {
         ['search_articles', 'get_article_detail'],
       ],
     )
-    assert.deepEqual(harness.llmCalls[1]?.messages.slice(-2), [
+    assert.deepEqual(harness.llmCalls[1]?.messages, [
+      {
+        type: 'message',
+        role: 'user',
+        content: '问题',
+      },
       {
         type: 'assistant_tool_call',
         callId: 'call-1',
@@ -484,7 +495,12 @@ describe('AgentRuntimeService model stream', () => {
         samplingAttemptId: 'run-1:sampling-2',
       },
     ])
-    assert.deepEqual(harness.llmCalls[2]?.messages.slice(-4), [
+    assert.deepEqual(harness.llmCalls[2]?.messages, [
+      {
+        type: 'message',
+        role: 'user',
+        content: '问题',
+      },
       {
         type: 'assistant_tool_call',
         callId: 'call-search',
@@ -1394,6 +1410,216 @@ describe('AgentRuntimeService model stream', () => {
     assert.deepEqual(harness.recorder.failedRunIds, [])
     assert.deepEqual(harness.recorder.abortedRunIds, [])
     assert.equal(findStep(harness, 'assistant_output')?.status, AgentStepStatus.RUNNING)
+  })
+})
+
+describe('ModelContext', () => {
+  it('保持 direct-final、一次 Tool 和两次顺序 Tool 的 items 与安全 Snapshot', () => {
+    const context = ModelContext.fromHistory(
+      [{ role: 'user', content: 'USER' }],
+      historyMessages => [
+        { role: 'system', content: 'SYS' },
+        ...historyMessages,
+      ],
+    )
+
+    assert.deepEqual(context.forSampling(), [
+      { type: 'message', role: 'system', content: 'SYS' },
+      { type: 'message', role: 'user', content: 'USER' },
+    ])
+    assert.deepEqual(context.snapshot(1), {
+      samplingIndex: 1,
+      itemCount: 2,
+      characterCount: 7,
+      hasToolExchange: false,
+      toolExchangeCount: 0,
+      items: [
+        {
+          source: 'instructions',
+          category: 'system_message',
+          characterCount: 3,
+        },
+        {
+          source: 'conversation',
+          category: 'user_message',
+          characterCount: 4,
+        },
+      ],
+    })
+
+    context.appendToolExchange({
+      call: {
+        callId: 'c1',
+        toolName: 't1',
+        rawArgumentsJson: 'A',
+        samplingAttemptId: 's1',
+      },
+      intermediateText: 'I',
+      reasoningContent: 'R',
+      observationContent: 'O',
+      ok: true,
+    })
+
+    assert.deepEqual(context.forSampling().slice(-2), [
+      {
+        type: 'assistant_tool_call',
+        callId: 'c1',
+        name: 't1',
+        rawArgumentsJson: 'A',
+        reasoningContent: 'R',
+        content: 'I',
+      },
+      {
+        type: 'tool_result',
+        callId: 'c1',
+        name: 't1',
+        content: 'O',
+        ok: true,
+      },
+    ])
+    assert.deepEqual(context.snapshot(2), {
+      samplingIndex: 2,
+      itemCount: 4,
+      characterCount: 17,
+      hasToolExchange: true,
+      toolExchangeCount: 1,
+      items: [
+        {
+          source: 'instructions',
+          category: 'system_message',
+          characterCount: 3,
+        },
+        {
+          source: 'conversation',
+          category: 'user_message',
+          characterCount: 4,
+        },
+        {
+          source: 'tool_exchange',
+          category: 'assistant_tool_call',
+          characterCount: 7,
+        },
+        {
+          source: 'tool_exchange',
+          category: 'tool_result',
+          characterCount: 3,
+        },
+      ],
+    })
+
+    context.appendToolExchange({
+      call: {
+        callId: 'c2',
+        toolName: 't2',
+        rawArgumentsJson: 'B',
+        samplingAttemptId: 's2',
+      },
+      intermediateText: 'J',
+      reasoningContent: 'S',
+      observationContent: 'P',
+      ok: false,
+    })
+
+    assert.deepEqual(context.snapshot(3), {
+      samplingIndex: 3,
+      itemCount: 6,
+      characterCount: 27,
+      hasToolExchange: true,
+      toolExchangeCount: 2,
+      items: [
+        {
+          source: 'instructions',
+          category: 'system_message',
+          characterCount: 3,
+        },
+        {
+          source: 'conversation',
+          category: 'user_message',
+          characterCount: 4,
+        },
+        {
+          source: 'tool_exchange',
+          category: 'assistant_tool_call',
+          characterCount: 7,
+        },
+        {
+          source: 'tool_exchange',
+          category: 'tool_result',
+          characterCount: 3,
+        },
+        {
+          source: 'tool_exchange',
+          category: 'assistant_tool_call',
+          characterCount: 7,
+        },
+        {
+          source: 'tool_exchange',
+          category: 'tool_result',
+          characterCount: 3,
+        },
+      ],
+    })
+  })
+
+  it('Snapshot whitelist 不暴露 prompt、reasoning、raw arguments、data 或 Observation', () => {
+    const systemPrompt = 'system-secret'
+    const rawArgumentsJson = '{"token":"raw-secret"}'
+    const reasoningContent = 'reasoning-secret'
+    const observationContent = 'observation-secret'
+    const toolResult: ToolResult = {
+      ok: true,
+      data: { password: 'data-secret' },
+      modelContent: observationContent,
+    }
+    const context = ModelContext.fromHistory(
+      [{ role: 'user', content: 'user-secret' }],
+      historyMessages => [
+        { role: 'system', content: systemPrompt },
+        ...historyMessages,
+      ],
+    )
+
+    context.appendToolExchange({
+      call: {
+        callId: 'call-secret',
+        toolName: 'search_articles',
+        rawArgumentsJson,
+        samplingAttemptId: 'run-secret:sampling-1',
+      },
+      intermediateText: 'intermediate-secret',
+      reasoningContent,
+      observationContent: toolResult.modelContent,
+      ok: toolResult.ok,
+    })
+
+    const snapshot = context.snapshot(2)
+    const serialized = JSON.stringify(snapshot)
+
+    assert.deepEqual(Object.keys(snapshot), [
+      'samplingIndex',
+      'itemCount',
+      'characterCount',
+      'hasToolExchange',
+      'toolExchangeCount',
+      'items',
+    ])
+    assert.equal(snapshot.items.every(item => (
+      Object.keys(item).join(',') === 'source,category,characterCount'
+    )), true)
+    for (const secret of [
+      systemPrompt,
+      'user-secret',
+      'call-secret',
+      'search_articles',
+      rawArgumentsJson,
+      reasoningContent,
+      'intermediate-secret',
+      observationContent,
+      'data-secret',
+      'run-secret',
+    ]) {
+      assert.doesNotMatch(serialized, new RegExp(secret))
+    }
   })
 })
 

--- a/apps/api/src/agent-runtime/agent-runtime.service.ts
+++ b/apps/api/src/agent-runtime/agent-runtime.service.ts
@@ -5,12 +5,8 @@ import type {
   MessageStatus as PrismaMessageStatus,
 } from '../generated/prisma/client.js'
 import type { ChatMessage } from '../llm/llm.types.js'
-import type { ModelInputItem } from '../llm/model-input.types.js'
 import type { DatabaseOperationDeadline } from '../prisma/prisma.service.js'
-import type {
-  ToolResult,
-  UnvalidatedToolCallEnvelope,
-} from '../tools/core/tool.types.js'
+import type { ToolResult } from '../tools/core/tool.types.js'
 import type {
   AgentRuntimeEvent,
   RunTurnStreamInput,
@@ -23,7 +19,6 @@ import { Inject, Injectable, NotFoundException } from '@nestjs/common'
 
 import { MessageRole, MessageStatus } from '../generated/prisma/client.js'
 import { LLMService } from '../llm/llm.service.js'
-import { toModelInputItems } from '../llm/model-input.types.js'
 import {
   DatabaseCommitOutcomeUnknownError,
   DatabaseOperationDeadlineExceededError,
@@ -47,6 +42,7 @@ import {
   ModelSamplingIncompleteError,
 } from './agent-runtime.errors.js'
 import { AgentRuntimePolicyService } from './agent-runtime.policy.js'
+import { ModelContext } from './model-context.js'
 import { streamModelSampling } from './model-sampling-decision.js'
 
 const AGENT_RUN_TOOL_NAMES = [
@@ -171,10 +167,10 @@ export class AgentRuntimeService {
         },
       )
 
-      const llmMessages = input.buildModelMessages(
+      const modelContext = ModelContext.fromHistory(
         historyMessages.map(message => this.toLlmMessage(message)),
+        messages => input.buildModelMessages(messages),
       )
-      const modelInputItems = toModelInputItems(llmMessages)
       const registeredToolDefinitions = this.toolRegistryService.listDefinitions()
       const toolDefinitions = AGENT_RUN_TOOL_NAMES.flatMap((name) => {
         const definition = registeredToolDefinitions.find(
@@ -238,6 +234,7 @@ export class AgentRuntimeService {
       ) {
         runCancellation.throwIfUnavailable()
         const samplingAttemptId = `${currentAgentRunId}:sampling-${samplingAttempt}`
+        const contextSnapshot = modelContext.snapshot(samplingAttempt)
         const samplingStep = await this.agentRunRecorderService.startStep({
           runId: currentAgentRunId,
           type: AGENT_STEP_TYPES.modelSampling,
@@ -245,7 +242,7 @@ export class AgentRuntimeService {
             samplingIndex: samplingAttempt,
             samplingAttemptId,
             requestedModel: input.model ?? null,
-            messageCount: modelInputItems.length,
+            messageCount: contextSnapshot.itemCount,
             toolCount: modelTools.length,
           },
         }, databaseDeadline)
@@ -255,7 +252,10 @@ export class AgentRuntimeService {
         try {
           // 两层 async generator 此时只创建迭代器；首次 sampling.next() 才启动模型请求并拉取事件。
           const sampling = streamModelSampling(
-            this.llmService.chatStream(modelInputItems, chatStreamOptions),
+            this.llmService.chatStream(
+              modelContext.forSampling(),
+              chatStreamOptions,
+            ),
             samplingAttemptId,
           )
           let samplingResult = await sampling.next()
@@ -404,14 +404,13 @@ export class AgentRuntimeService {
         }
 
         runCancellation.throwIfUnavailable()
-        this.appendToolObservation(
-          modelInputItems,
-          samplingDecision.call,
-          samplingDecision.intermediateText,
-          samplingDecision.reasoningContent,
-          observation.content,
-          toolResult.ok,
-        )
+        modelContext.appendToolExchange({
+          call: samplingDecision.call,
+          intermediateText: samplingDecision.intermediateText,
+          reasoningContent: samplingDecision.reasoningContent,
+          observationContent: observation.content,
+          ok: toolResult.ok,
+        })
       }
 
       if (!hasFinalAnswer) {
@@ -675,33 +674,6 @@ export class AgentRuntimeService {
       return this.toSamplingStepOutput(error.summary, durationMs)
 
     return { durationMs }
-  }
-
-  private appendToolObservation(
-    modelInputItems: ModelInputItem[],
-    call: UnvalidatedToolCallEnvelope,
-    intermediateText: string,
-    reasoningContent: string,
-    content: string,
-    ok: boolean,
-  ): void {
-    modelInputItems.push(
-      {
-        type: 'assistant_tool_call',
-        callId: call.callId,
-        name: call.toolName,
-        rawArgumentsJson: call.rawArgumentsJson,
-        reasoningContent,
-        ...(intermediateText ? { content: intermediateText } : {}),
-      },
-      {
-        type: 'tool_result',
-        callId: call.callId,
-        name: call.toolName,
-        content,
-        ok,
-      },
-    )
   }
 
   private isAbortSignalTriggered(signal: AbortSignal | undefined): boolean {

--- a/apps/api/src/agent-runtime/model-context.ts
+++ b/apps/api/src/agent-runtime/model-context.ts
@@ -1,0 +1,126 @@
+import type { ChatMessage } from '../llm/llm.types.js'
+import type { ModelInputItem } from '../llm/model-input.types.js'
+import type { UnvalidatedToolCallEnvelope } from '../tools/core/tool.types.js'
+
+import { toModelInputItems } from '../llm/model-input.types.js'
+
+export interface ModelContextSnapshotItem {
+  source: 'conversation' | 'instructions' | 'tool_exchange'
+  category:
+    | 'assistant_message'
+    | 'assistant_tool_call'
+    | 'system_message'
+    | 'tool_result'
+    | 'user_message'
+  characterCount: number
+}
+
+export interface ModelContextSnapshot {
+  samplingIndex: number
+  itemCount: number
+  characterCount: number
+  hasToolExchange: boolean
+  toolExchangeCount: number
+  items: ModelContextSnapshotItem[]
+}
+
+/** 单次 Run 内的 model-visible context；不负责选择、预算或生命周期。 */
+export class ModelContext {
+  private constructor(private readonly items: ModelInputItem[]) {}
+
+  static fromHistory(
+    historyMessages: ChatMessage[],
+    buildModelMessages: (historyMessages: ChatMessage[]) => ChatMessage[],
+  ): ModelContext {
+    return new ModelContext(
+      toModelInputItems(buildModelMessages(historyMessages)),
+    )
+  }
+
+  forSampling(): ModelInputItem[] {
+    return this.items
+  }
+
+  appendToolExchange(input: {
+    call: UnvalidatedToolCallEnvelope
+    intermediateText: string
+    reasoningContent: string
+    observationContent: string
+    ok: boolean
+  }): void {
+    this.items.push(
+      {
+        type: 'assistant_tool_call',
+        callId: input.call.callId,
+        name: input.call.toolName,
+        rawArgumentsJson: input.call.rawArgumentsJson,
+        reasoningContent: input.reasoningContent,
+        ...(input.intermediateText ? { content: input.intermediateText } : {}),
+      },
+      {
+        type: 'tool_result',
+        callId: input.call.callId,
+        name: input.call.toolName,
+        content: input.observationContent,
+        ok: input.ok,
+      },
+    )
+  }
+
+  snapshot(samplingIndex: number): ModelContextSnapshot {
+    const items = this.items.map(toSnapshotItem)
+    const toolExchangeCount = items.filter(
+      item => item.category === 'assistant_tool_call',
+    ).length
+
+    return {
+      samplingIndex,
+      itemCount: items.length,
+      characterCount: items.reduce(
+        (total, item) => total + item.characterCount,
+        0,
+      ),
+      hasToolExchange: toolExchangeCount > 0,
+      toolExchangeCount,
+      items,
+    }
+  }
+}
+
+function toSnapshotItem(item: ModelInputItem): ModelContextSnapshotItem {
+  switch (item.type) {
+    case 'message':
+      return {
+        source: item.role === 'system' ? 'instructions' : 'conversation',
+        category: `${item.role}_message`,
+        characterCount: countCharacters(item.content),
+      }
+
+    case 'assistant_tool_call':
+      return {
+        source: 'tool_exchange',
+        category: 'assistant_tool_call',
+        characterCount: countCharacters(
+          item.callId,
+          item.name,
+          item.rawArgumentsJson,
+          item.reasoningContent,
+          item.content,
+        ),
+      }
+
+    case 'tool_result':
+      return {
+        source: 'tool_exchange',
+        category: 'tool_result',
+        characterCount: countCharacters(item.callId, item.content),
+      }
+  }
+}
+
+function countCharacters(...values: Array<string | undefined>): number {
+  return values.reduce(
+    (total, value) => total + (value ? [...value].length : 0),
+    0,
+  )
+}

--- a/docs/README.md
+++ b/docs/README.md
@@ -6,12 +6,17 @@
 
 ```text
 阶段 1-6：Completed
-阶段 7：Context Engineering / Next
-当前 Agent 主线：无 Active Task
-下一正式 Task：Phase 7 Task 0 / Context Boundary & Snapshot / Next
+阶段 7：Context Engineering / Active
+Active Agent Task：Task 0 / Context Boundary & Snapshot
+Issue：#40
+Gate：第二轮 READY
+实施状态：已实现
+验收状态：待验收
+PR：#41 / Draft
+Task 1-3：Planned
 ```
 
-Phase 6 已完成并统一归档到 `docs/tasks/completed/**`，不再在 active tasks 区保留兼容目录。Phase 7 已完成阶段级规划，但 Task 0 尚未创建正式 Issue，因此当前仍无 Active Agent Task。
+Phase 6 已完成并统一归档到 `docs/tasks/completed/**`，不再在 active tasks 区保留兼容目录。Phase 7 当前为 Active；Task 0 已通过第二轮 Gate 并完成实现，正在 Draft PR #41 等待验收。Task 1-3 仍为 Planned，均未启动。
 
 ## 文档入口
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -6,17 +6,16 @@
 
 项目已经完成从基础 LLM Chat 到 Session、Streaming、Agent Runtime、最小 Tool Calling，再到 bounded sequential Agent Loop 与 Runtime reliability 的连续学习闭环；Admin Console 的真实 Observability Baseline 也已经建立。
 
-经过基于最新 `master` 的阶段讨论，下一正式 Agent 主线已经定案为 **Phase 7：Context Engineering**。Task 0 的正式 Issue #40 已创建；首轮 Clarification Gate 因 Draft / Ready PR 规则和 docs 状态漂移返回 `BLOCKED`，对应阻塞决策与流程文档已经同步。Task 0 在重新 Gate 为 `READY` 前仍保持 `Next`，因此当前没有 Active Agent Task。
+经过基于最新 `master` 的阶段讨论，下一正式 Agent 主线已经定案为 **Phase 7：Context Engineering**。Task 0 的正式 Issue #40 在阻塞决策同步后重新 Gate 为 `READY`，Context Boundary 与安全 Snapshot 已完成实现和本地验证，当前等待 Draft PR Review、GPT 技术验收与用户确认。
 
 当前状态：
 
 ```text
 阶段 1-6：Completed
-阶段 7：Context Engineering / Next
-当前 Agent 主线：无 Active Task
-下一正式 Task：Phase 7 Task 0 / Context Boundary & Snapshot / Next
+阶段 7：Context Engineering / Active
+当前 Agent 主线：Task 0 / Context Boundary & Snapshot / 已实现，待验收
 Issue：#40 已创建
-Gate：首轮 BLOCKED；阻塞决策已同步，等待重新 Gate
+Gate：首轮 BLOCKED；D-05 / D-06 同步后第二轮 READY
 Admin Observability：Task 0-3 Completed
 Admin Task 4：Planned
 ```
@@ -33,7 +32,7 @@ Admin Task 4：Planned
 | 阶段 4：Agent Runtime 基础 | Completed | `AgentRun` / `AgentStep` 与 Runtime Event |
 | 阶段 5：最小 Tool Calling | Completed | 单次 Tool Call、Observation 与第二轮 sampling |
 | [阶段 6：有界单 Agent Loop](./tasks/completed/phase-06-bounded-agent-loop.md) | **Completed** | 多轮顺序决策、执行预算、DeepSeek continuation、DB deadline 与终态可靠性 |
-| [阶段 7：Context Engineering](./tasks/phase-07-context-engineering/README.md) | **Next** | model-visible context 边界、model-aware budget、动态 History、Loop Context、Context Inspector |
+| [阶段 7：Context Engineering](./tasks/phase-07-context-engineering/README.md) | **Active** | model-visible context 边界、model-aware budget、动态 History、Loop Context、Context Inspector |
 
 ## 阶段 6 最终建立
 
@@ -84,7 +83,7 @@ Admin Task 4：Planned
 当前规划：
 
 ```text
-Task 0：Context Boundary & Snapshot                   Next / Issue #40 / 待重新 Gate
+Task 0：Context Boundary & Snapshot                   Active / 已实现，待验收
 Task 1：Model-aware Budget & Dynamic History          Planned
 Task 2：Loop-aware Context & Observation Governance   Planned
 Task 3：Context Inspector & Phase Baseline            Planned
@@ -95,7 +94,7 @@ Compaction：Gated Follow-up                           不自动启动
 
 先建立独立 Context boundary 和安全 Snapshot，保持当前 `historyLimit = 40`、Observation 上限、Chat / NDJSON 协议与数据库行为不变。目的只是把散落的 model input assembly 收敛成一个明确边界，并锁定 direct-final / Tool Loop 的 Context 不变量。
 
-Task 0 已创建正式 Issue #40。首轮 Gate 返回 `BLOCKED` 后，GPT 已明确两项决策：正式功能 PR 采用 Draft 生命周期；Task 0 在 Gate `READY` 前仍为 `Next`，不得因 Issue 已创建提前写成 Active。对应协作规范与 task / roadmap 状态已经同步，下一动作是重新执行 Gate。
+Task 0 已创建正式 Issue #40。首轮 Gate 的 D-05 / D-06 决策同步后，第二轮 Gate 为 `READY`；独立分支已完成 Context Boundary、安全 Snapshot 和 Provider-facing input 回归，当前状态为已实现、待验收。Task 1 不会因此自动启动。
 
 ### Task 1
 
@@ -177,4 +176,4 @@ Phase 7 Baseline 收口后，再基于最新 `master`、真实产品需求和学
 6. Multi-agent；
 7. 若 Context 证据充分，再决定 Minimal Compaction 是否需要单独收口。
 
-当前没有 Active Agent Task。下一正式动作是让 Codex 针对 Issue #40 重新执行 Clarification Gate；只有 Gate 为 `READY` 后，Task 0 才进入 Active。
+当前 Active Agent Task 是 Issue #40 / Task 0。下一正式动作是 Draft PR Review、GPT 技术验收与用户确认；未经明确授权，不转 Ready、不合并，也不启动 Task 1。

--- a/docs/tasks/README.md
+++ b/docs/tasks/README.md
@@ -6,8 +6,8 @@
 
 | 区域 | 状态 | 文档 | 说明 |
 | --- | --- | --- | --- |
-| Agent 主线 | **Phase 7 Next / 无 Active Task** | [roadmap.md](../roadmap.md) | 阶段 1-6 已完成；Phase 7 Context Engineering 已确认是下一主线 |
-| Phase 7：Context Engineering | **Next** | [phase-07-context-engineering/README.md](./phase-07-context-engineering/README.md) | Task 0 已创建 Issue #40；首轮 Gate BLOCKED，阻塞决策已同步，等待重新 Gate；Task 1-3 Planned；Compaction 为 Gated follow-up |
+| Agent 主线 | **Phase 7 Active / Task 0 待验收** | [roadmap.md](../roadmap.md) | 阶段 1-6 已完成；Task 0 Issue #40 已实现并通过本地验证 |
+| Phase 7：Context Engineering | **Active** | [phase-07-context-engineering/README.md](./phase-07-context-engineering/README.md) | Task 0 已实现、待验收；Task 1-3 Planned；Compaction 为 Gated follow-up |
 | 阶段 6：有界单 Agent Loop | Completed | [completed/phase-06-bounded-agent-loop.md](./completed/phase-06-bounded-agent-loop.md) | Task 0、横向配置治理、Task 1、Task 2 均已验收并合并 |
 | Admin Console Task 0-1 | Completed | [admin-console.md](./admin-console.md) | 基础壳与静态 Run UI 已完成 |
 | Admin Console Task 2 | **Completed** | [task-02-run-query-api.md](./admin-console/task-02-run-query-api.md) | Issue #33 / PR #34；merge `997d6b84` |
@@ -23,20 +23,19 @@
 
 ```text
 阶段 1-6：Completed
-阶段 7：Context Engineering / Next
-当前：无 Active Agent Task
-下一正式 Task：Phase 7 Task 0 / Context Boundary & Snapshot / Next
+阶段 7：Context Engineering / Active
+当前：Task 0 / Context Boundary & Snapshot / 已实现，待验收
 Issue：#40 已创建
-Gate：首轮 BLOCKED；阻塞决策已同步，等待重新 Gate
+Gate：首轮 BLOCKED；D-05 / D-06 同步后第二轮 READY
 ```
 
-Phase 7 已经完成阶段级与 Task 级规划，Task 0 的正式 Issue #40 已创建。首轮 Clarification Gate 因 Draft / Ready PR 规则和 docs 状态漂移返回 `BLOCKED`；对应流程规则与状态事实已由 GPT 同步到 `master`。在 Codex 重新 Gate 为 `READY` 前，Task 0 仍保持 `Next`，当前仍没有 Active Agent Task。
+Task 0 的第二轮 Clarification Gate 已为 `READY`，独立分支中的 Context Boundary、Snapshot 与回归测试已经实现并通过本地验证。当前正式状态为“实施状态：已实现 / 验收状态：待验收”；Phase 7 保持 Active，不推进 Task 1。
 
 ## Phase 7 当前任务
 
 | Task | 状态 | 核心边界 |
 | --- | --- | --- |
-| Task 0：Context Boundary & Snapshot | **Next / Issue #40 / 待重新 Gate** | 收敛 model input assembly；建立安全 Context Snapshot；不改变 40 条 History 与现有 Observation 行为 |
+| Task 0：Context Boundary & Snapshot | **Active / Issue #40 / 已实现，待验收** | 收敛 model input assembly；建立安全 Context Snapshot；不改变 40 条 History 与现有 Observation 行为 |
 | Task 1：Model-aware Budget & Dynamic History | Planned | 让 `contextWindowTokens` 进入真实预算；History 从固定条数升级为 token-budget 驱动 |
 | Task 2：Loop-aware Context & Observation Governance | Planned | 多轮 Tool Loop 的 Context Budget、Tool Call / Result pairing 与 Observation 最终裁剪 |
 | Task 3：Context Inspector & Phase Baseline | Planned | 安全 Context summary + Admin Inspector + 阶段回归 |
@@ -44,7 +43,7 @@ Phase 7 已经完成阶段级与 Task 级规划，Task 0 的正式 Issue #40 已
 
 阶段完整规格见 [`phase-07-context-engineering/README.md`](./phase-07-context-engineering/README.md)。
 
-下一动作是让 Codex 重新读取 Issue #40、最新 `master` 和协作规范，重新执行 Clarification Gate。只有 Gate 结论为 `READY` 后，Task 0 才进入 `Active` 并创建独立实现分支。
+下一动作是让 Issue #40 的 Draft PR 接受 Codex Review 和 GPT 技术验收。只有 GPT 验收通过且用户明确确认、授权后，才允许收口状态、转 Ready 或合并。
 
 ## Admin Console 当前状态
 

--- a/docs/tasks/phase-07-context-engineering/README.md
+++ b/docs/tasks/phase-07-context-engineering/README.md
@@ -1,8 +1,8 @@
 # Phase 7：Context Engineering
 
-状态：**Next / Task 0 Issue #40 已创建 / 待重新 Gate**。
+状态：**Active / Task 0 Issue #40 已实现，待验收**。
 
-本阶段已经由 GPT 与用户确认作为 Phase 6 之后的下一条 Agent 主线。Task 0 已创建正式 Issue #40；首轮 Clarification Gate 因 Draft / Ready PR 规则与 docs 状态漂移返回 `BLOCKED`。GPT 已按最新协作规范完成决策与 docs 同步；在 Codex 重新 Gate 为 `READY` 前，Phase 7 仍没有 Active Task。
+本阶段已经由 GPT 与用户确认作为 Phase 6 之后的下一条 Agent 主线。Task 0 已创建正式 Issue #40；首轮 Clarification Gate 的阻塞决策同步后，第二轮 Gate 为 `READY`。Task 0 已完成实现和本地验证，当前等待 Draft PR Review、GPT 技术验收与用户确认；Task 1-3 未启动。
 
 ## 1. 阶段目标
 
@@ -93,7 +93,7 @@ Phase 7 Baseline 不把自动 Summary / Compaction 作为必做项。先完成 C
 
 | Task | 状态 | 目标 |
 | --- | --- | --- |
-| Task 0：Context Boundary & Snapshot | **Next / Issue #40 / 待重新 Gate** | 把当前 model input 组装收敛到独立 Context 边界，并建立不改变现有行为的 Context Snapshot |
+| Task 0：Context Boundary & Snapshot | **Active / Issue #40 / 已实现，待验收** | 把当前 model input 组装收敛到独立 Context 边界，并建立不改变现有行为的 Context Snapshot |
 | Task 1：Model-aware Budget & Dynamic History | Planned | 让模型 Context Window 参与预算，历史选择从固定条数升级为 token-budget 驱动 |
 | Task 2：Loop-aware Context & Observation Governance | Planned | 统一管理后续 sampling 的 Tool Exchange、剩余 Context Budget 与 Observation 裁剪 |
 | Task 3：Context Inspector & Phase Baseline | Planned | 将 Context 决策做成安全可观察的 Runtime / Admin Inspector，并完成阶段回归 |
@@ -105,7 +105,10 @@ Phase 7 Baseline 不把自动 Summary / Compaction 作为必做项。先完成 C
 
 # Task 0：Context Boundary & Snapshot
 
-状态：**Next / Issue #40 已创建 / 首轮 Gate BLOCKED，阻塞决策已同步，待重新 Gate**。
+状态：**Active / Issue #40 / 已实现，待验收**。
+
+- 实施状态：已实现
+- 验收状态：待验收
 
 ## 目标
 
@@ -139,34 +142,48 @@ Task 0 是结构基线，不负责优化 History 数量，也不实现 token-bud
 
 ## Red：先定义失败用例
 
-- [ ] 当前 model input assembly 没有单一 Context 边界，测试应能暴露初始 History 与 Tool Exchange 分散拼装；
-- [ ] direct-final、一次 Tool、两次 Tool 的 Provider-facing items 没有统一 Snapshot；
-- [ ] Tool Call / Result pairing、当前用户消息恰好一次、UI Message 不含 Tool Exchange 等不变量必须先锁定。
+- [x] 当前 model input assembly 没有单一 Context 边界，测试应能暴露初始 History 与 Tool Exchange 分散拼装；
+- [x] direct-final、一次 Tool、两次 Tool 的 Provider-facing items 没有统一 Snapshot；
+- [x] Tool Call / Result pairing、当前用户消息恰好一次、UI Message 不含 Tool Exchange 等不变量必须先锁定。
 
 ## Green：最小实现
 
-- [ ] 建立内部 Context assembly / state 边界；
-- [ ] 让初始 Context 与后续 Tool Exchange 通过同一边界维护；
-- [ ] 输出只含安全元数据的 Context Snapshot；
-- [ ] 保持当前 Context 选择和请求行为不变。
+- [x] 建立内部 Context assembly / state 边界；
+- [x] 让初始 Context 与后续 Tool Exchange 通过同一边界维护；
+- [x] 输出只含安全元数据的 Context Snapshot；
+- [x] 保持当前 Context 选择和请求行为不变。
 
 ## 验收标准
 
-- [ ] direct final、一次 Tool、两次顺序 Tool 的最终 Provider input 与现有语义一致；
-- [ ] 当前用户输入在初始 model context 中恰好一次；
-- [ ] Tool Call / Result 按 callId 配对且顺序稳定；
-- [ ] Context Snapshot 不包含 reasoning、完整 Prompt、raw arguments 或 ToolResult.data；
-- [ ] 外部 Chat / NDJSON、Prisma schema、Admin Contract 无行为变更；
-- [ ] 现有 Phase 6 关键回归继续通过。
+- [x] direct final、一次 Tool、两次顺序 Tool 的最终 Provider input 与现有语义一致；
+- [x] 当前用户输入在初始 model context 中恰好一次；
+- [x] Tool Call / Result 按 callId 配对且顺序稳定；
+- [x] Context Snapshot 不包含 reasoning、完整 Prompt、raw arguments 或 ToolResult.data；
+- [x] 外部 Chat / NDJSON、Prisma schema、Admin Contract 无行为变更；
+- [x] 现有 Phase 6 关键回归继续通过。
 
 ## GitHub 交付状态
 
 - Issue：#40 `[Phase 7][Task 0] 建立 Context Boundary 与安全 Context Snapshot`
-- Clarification Gate：首轮 `BLOCKED`
-- 阻塞决策：已由 GPT 按最新协作规范定案并同步到 `master`
-- 当前状态：`Next`，等待 Codex 重新 Gate
-- Active 条件：重新 Gate 结论为 `READY`
-- PR：未创建
+- Clarification Gate：首轮 `BLOCKED`；D-05 / D-06 同步后第二轮 `READY`
+- 当前状态：`Active / 已实现，待验收`
+- 分支：`codex/issue-40-context-boundary`
+- PR：[Draft PR #41](https://github.com/mufeiyu-ayu/agent/pull/41)
+
+## 实现与验证证据
+
+- 新增单次 Run 内存 `ModelContext`，统一初始 model input assembly、Tool Exchange 成对追加与 sampling Snapshot；
+- Snapshot 只投影 source、category、item / Tool Exchange 数量和字符规模，不包含任何原始 Context；
+- Runtime 继续拥有 History 查询、Observation 上限、Tool 执行、Abort、deadline 与 terminalization；
+- direct-final、一次 Tool、两次顺序 Tool 的完整 `ModelInputItem[]` 已加入回归断言。
+
+| 命令 | 结果 |
+| --- | --- |
+| `pnpm --filter @agent/api test:tool-loop` | 通过，41 tests |
+| `pnpm --filter @agent/api test:model-stream` | 通过，56 tests |
+| `pnpm --filter @agent/api typecheck` | 通过 |
+| `pnpm --filter @agent/api lint` | 通过 |
+| `pnpm typecheck` | 通过，4 个 workspace project |
 
 ---
 
@@ -344,12 +361,12 @@ Minimal Compaction 不属于默认完成条件；是否加入 Phase 7 收口范�
 
 ## 7. 当前 GitHub 交付状态
 
-- Phase 7：Next
-- Task 0：Next / Issue #40 / 首轮 Gate BLOCKED / 阻塞决策已同步 / 待重新 Gate
+- Phase 7：Active
+- Task 0：Active / Issue #40 / 已实现，待验收
 - Task 1：Planned
 - Task 2：Planned
 - Task 3：Planned
 - Minimal Compaction：Gated
-- Active Agent Task：无
+- Active Agent Task：Task 0 / Issue #40
 
-下一正式动作：让 Codex 重新读取 Issue #40、最新 `master` 与协作规范并重新执行 Clarification Gate；只有 Gate 为 `READY` 后，Task 0 才进入 Active。
+下一正式动作：Draft PR #41 接受 Codex Review 与 GPT 技术验收；未经用户明确授权，不转 Ready、不合并、不清理分支，也不启动 Task 1。

--- a/docs/work-log.md
+++ b/docs/work-log.md
@@ -6,9 +6,9 @@
 
 | 类型 | 当前记录 | 下一步 |
 | --- | --- | --- |
-| Agent 主线 | 阶段 1-6 Completed；Phase 7 Context Engineering 已确认 Next；当前无 Active Agent Task | 为 Phase 7 Task 0 建立 Issue 级规格并创建正式 Issue |
+| Agent 主线 | 阶段 1-6 Completed；Phase 7 Context Engineering Active；Task 0 已实现、待验收 | Issue #40 Draft PR Review、GPT 技术验收与用户确认 |
 | Phase 6 | 已完成并归档 | 见 `docs/tasks/completed/phase-06-bounded-agent-loop.md` |
-| Phase 7 | Context Engineering；Task 0 Next，Task 1-3 Planned，Compaction Gated | 先做 Context Boundary & Snapshot，不直接启动完整 Budget / Compaction |
+| Phase 7 | Context Engineering；Task 0 Active / 已实现、待验收；Task 1-3 Planned；Compaction Gated | 验收 Task 0，不提前启动 Budget / Compaction |
 | Admin Console | Task 0-3 Completed；Observability Baseline 已建立；Task 4 Planned | Phase 7 Task 3 再按需增量增加 Context Inspector |
 | Web Chat | 会话滚动跟随与响应式 UI follow-up 已完成 | 后续仅在出现真实 UX 问题时继续迭代 |
 | 文档结构 | `roadmap`、`tasks`、`research`、`work-log` 为主入口 | 不维护第二套阶段状态 |
@@ -17,6 +17,7 @@
 
 | 日期 | 事项 | 结果 |
 | --- | --- | --- |
+| 2026-08-10 | Issue #40 / Phase 7 Task 0 实现 | 第二轮 Clarification Gate 为 READY；新增单次 Run 内存 Context Boundary 与 whitelist 安全 Snapshot，锁定 direct-final、一次 Tool、两次顺序 Tool 的 Provider-facing input；Issue 指定测试、API lint/typecheck 与 workspace typecheck 全部通过；Draft PR #41 已创建；当前已实现、待验收 |
 | 2026-08-10 | Phase 7 Context Engineering 路线定案 | 基于 Phase 6 Runtime 与现有 Context 限制，确认 Context Engineering 为下一 Agent 主线；Task 0 Context Boundary & Snapshot 为 Next；Task 1-3 Planned；Minimal Compaction 仅作为有证据才启动的 Gated follow-up；当前仍无 Active Task |
 | 2026-08-10 | PR #38 / Issue #37 收口 | Web Chat 会话滚动跟随、原生 viewport、scroll memory 与响应式布局 follow-up 合入 `master`；merge commit `415d740507a29ee4bd9b6a4aa26d9c4fbb9668c1`；Issue #37 Closed |
 | 2026-08-10 | PR #36 / Issue #35 收口 | Admin Console Task 3 合入 `master`；merge commit `4c689c4c8a8d3975192d13eb3f5a1c24463fcd7b`；真实 Run Trace UI、Computer Use 验收与截图证据完成；Issue #35 Closed |
@@ -38,13 +39,13 @@ Phase 6 已完成，不再继续向该阶段追加新 Agent 能力。
 Phase 7 当前状态：
 
 ```text
-Phase 7：Context Engineering          Next
-Task 0：Context Boundary & Snapshot   Next / Issue 未创建
+Phase 7：Context Engineering          Active
+Task 0：Context Boundary & Snapshot   Active / Issue #40 / 已实现，待验收
 Task 1：Model-aware Budget            Planned
 Task 2：Loop-aware Context            Planned
 Task 3：Context Inspector             Planned
 Compaction                            Gated
-Active Agent Task                     无
+Active Agent Task                     Task 0 / Issue #40
 ```
 
 Phase 7 的核心目标是让 model-visible context 从“固定 History 条数 + 各 Tool 局部字符限制”升级为统一 Context boundary、model-aware budget、动态 History Selection、多轮 Loop Context Governance 和安全 Inspector。


### PR DESCRIPTION
Closes #40

## Gate 结论

- 第二轮 Clarification Gate：`READY`
- 目标基线：`origin/master@06ca6221510d3fda22f15fcfd75555b2e5598e8c`
- D-05：正式功能 PR 使用 Draft 生命周期
- D-06：Issue 已创建且 Gate=READY 后，Task 0 才进入 Active
- 新阻塞项：无

## 关键实现

- 新增单次 Run 内存 `ModelContext`，统一：
  - 已选 History 经业务 prompt builder 转为 `ModelInputItem[]`
  - Tool Call / Tool Result 同 callId 成对追加
  - 每次 sampling 的安全 Context Snapshot
- Snapshot 采用 whitelist，只包含：
  - sampling index
  - item / Tool Exchange 数量
  - source / category
  - Unicode code point 字符规模
- `AgentRuntimeService` 不再直接维护 `ModelInputItem[]` 或私有 append helper；History 查询、Observation normalization、Abort、deadline、terminalization 仍由原层负责。
- 测试锁定 direct-final、一次 Tool、两次顺序 Tool 的完整 Provider-facing items，并验证当前 user input 恰好一次、Snapshot 不泄露敏感字段。

## 假设与决策

- A-01：Context 是每个 Run 独立的纯内存对象，不新增 NestJS provider。
- A-02：History 查询和 `Message -> ChatMessage` 留在 Runtime，固定 40 条选择语义不变。
- A-03：Snapshot 仅为内部安全结构元数据，本 Task 不持久化、不投影到 Admin。
- A-04：Observation 继续复用 `normalizeToolObservation`；Context 只追加规范化后的低信任 tool content。
- A-05：Context 不负责 token budget、selection、裁剪、生命周期或终态。

## AC-01 ～ AC-09 验收追踪

| AC | 状态 | 实现 / 证据 |
| --- | --- | --- |
| AC-01 | 通过 | direct-final 完整 `ModelInputItem[]` 回归断言 |
| AC-02 | 通过 | sampling #2 同 callId call/result 完整断言 |
| AC-03 | 通过 | sampling #3 保持 call1/result1/call2/result2 顺序 |
| AC-04 | 通过 | 最近 40 条 COMPLETED History 中本轮 user 恰好一次 |
| AC-05 | 通过 | Runtime persistence 回归继续证明 Message 不含 Tool Exchange / reasoning |
| AC-06 | 通过 | Snapshot 顶层和 item 字段 whitelist；敏感 fixture 负向断言 |
| AC-07 | 通过 | 未修改 runtime policy / Tool Observation；tool-loop 回归通过 |
| AC-08 | 通过 | 未修改 Chat/NDJSON、Prisma、shared contracts 或 Admin |
| AC-09 | 通过 | direct-final、Tool Loop、Abort、deadline、Tool failure 全套 Runtime 回归通过 |

## 验证

| 命令 | 真实结果 |
| --- | --- |
| `pnpm --filter @agent/api test:tool-loop` | 通过：41 tests，0 failed |
| `pnpm --filter @agent/api test:model-stream` | 通过：56 tests，0 failed |
| `pnpm --filter @agent/api typecheck` | 通过 |
| `pnpm --filter @agent/api lint` | 通过 |
| `pnpm typecheck` | 通过：contracts / api / web / admin |

Red 证据：加入 Context 测试后，首次 `test:tool-loop` 因 `model-context.js` 尚不存在而按预期失败；Green 后上述全部命令通过。

## 已知风险

- Snapshot 的 `characterCount` 是安全 size metadata，不是 token 估算；token budget 明确留给 Task 1。
- Snapshot 当前不持久化，因此没有 Admin 可视化；Inspector 明确留给 Task 3。
- 未执行浏览器/E2E：本 Task 只重构 API 内部 model context，外部 Chat/NDJSON 行为由现有自动测试保护。

## 非目标

未实现 tokenizer、token estimator、动态 History、`contextWindowTokens` budget、Summary/Compaction、RAG/Embedding/Memory、Admin Context Inspector、Prisma migration、外部协议变化、Observation 新预算策略、Permission/Approval/HITL，也未启动 Task 1。

## 建议阅读顺序

1. `apps/api/src/agent-runtime/model-context.ts`
2. `apps/api/src/agent-runtime/agent-runtime.service.ts`
3. `apps/api/src/agent-runtime/agent-runtime.service.test.ts`
4. `docs/tasks/phase-07-context-engineering/README.md`

## 当前状态

- 实施状态：已实现
- 验收状态：待验收
- PR 状态：Draft
