### PR TITLE
fix(retrieval): 修复 connectWithAbort 连接获取阶段的 double-release 竞态

### DIFF
--- a/apps/api/src/retrieval/postgres-article-retrieval.repository.test.ts
+++ b/apps/api/src/retrieval/postgres-article-retrieval.repository.test.ts
@@ -123,6 +123,125 @@ describe('PostgresArticleRetrievalRepository', () => {
     assert.equal(client.releaseArguments[0]?.name, 'AbortError')
   })
 
+  describe('连接获取阶段的 client 所有权', () => {
+    it('connection 已 fulfilled 但成功 reaction 执行前 Abort 时只 release 一次', async () => {
+      const client = new FakePoolClient()
+      const connection = Promise.resolve<ArticleRetrievalPoolClient>(client)
+      const pool = new FakePool(connection)
+      const abortController = new AbortController()
+      // 在 helper 注册 connection reaction 之前排入一条 microtask，
+      // 让 Abort 精确落在“connection 已 fulfilled、成功回调尚未执行”的窗口里。
+      void connection.then(() => abortController.abort())
+
+      await expectNoUnhandledRejection(async () => {
+        await assert.rejects(
+          new PostgresArticleRetrievalRepository(pool).findLexicalCandidates(
+            { query: 'connection race', limit: 10 },
+            createContext(abortController.signal),
+          ),
+          { name: 'AbortError' },
+        )
+      })
+
+      assert.equal(client.releaseArguments.length, 1)
+      assert.equal(client.releaseArguments[0]?.name, 'AbortError')
+      assert.deepEqual(pool.cancelledProcessIds, [])
+    })
+
+    it('pending connect 期间 Abort 后，迟到 client 用同一个 abort error release 一次', async () => {
+      const client = new FakePoolClient()
+      const connection = createDeferredConnection()
+      const pool = new FakePool(connection.promise)
+      const abortController = new AbortController()
+
+      const pending = new PostgresArticleRetrievalRepository(pool).findLexicalCandidates(
+        { query: 'abort while connecting', limit: 10 },
+        createContext(abortController.signal),
+      )
+      abortController.abort()
+      connection.resolve(client)
+
+      const abortError = await pending.then(
+        () => assert.fail('连接被 Abort 时调用不应成功'),
+        (error: unknown) => error,
+      )
+      assert.equal((abortError as Error).name, 'AbortError')
+      assert.equal(client.releaseArguments.length, 1)
+      assert.strictEqual(client.releaseArguments[0], abortError)
+      assert.deepEqual(pool.cancelledProcessIds, [])
+    })
+
+    it('连接正常移交后 helper 不 release，late Abort 也不改变释放结果', async () => {
+      const client = new FakePoolClient()
+      const pool = new FakePool(client)
+      const abortController = new AbortController()
+
+      await new PostgresArticleRetrievalRepository(pool).findLexicalCandidates(
+        { query: 'owned transfer', limit: 10 },
+        createContext(abortController.signal),
+      )
+
+      abortController.abort()
+      await nextMacrotask()
+      // helper release 0 次，唯一一次无错误 release 来自 runOwnedReadQuery 的成功收尾。
+      assert.deepEqual(client.releaseArguments, [undefined])
+      assert.equal(pool.connectCalls, 1)
+    })
+
+    it('connection 先失败时保留原始连接错误，late Abort 不改变结果', async () => {
+      const connection = createDeferredConnection()
+      const pool = new FakePool(connection.promise)
+      const abortController = new AbortController()
+
+      const pending = new PostgresArticleRetrievalRepository(pool).findLexicalCandidates(
+        { query: 'connect failure', limit: 10 },
+        createContext(abortController.signal),
+      )
+      connection.reject(new Error('pool connect failed'))
+
+      await assert.rejects(pending, /pool connect failed/)
+      // listener 已在失败分支移除：迟到的 Abort 不会再产生任何释放或取消动作。
+      abortController.abort()
+      await nextMacrotask()
+      assert.deepEqual(pool.cancelledProcessIds, [])
+    })
+
+    it('Abort 先赢时迟到的 connection rejection 被安全观察且不产生 release', async () => {
+      const connection = createDeferredConnection()
+      const pool = new FakePool(connection.promise)
+      const abortController = new AbortController()
+
+      await expectNoUnhandledRejection(async () => {
+        const pending = new PostgresArticleRetrievalRepository(pool).findLexicalCandidates(
+          { query: 'abort then connect failure', limit: 10 },
+          createContext(abortController.signal),
+        )
+        abortController.abort()
+        connection.reject(new Error('pool connect failed after abort'))
+
+        await assert.rejects(pending, { name: 'AbortError' })
+      })
+
+      assert.deepEqual(pool.cancelledProcessIds, [])
+    })
+
+    it('signal 在调用前已 Abort 时不调用 pool.connect', async () => {
+      const pool = new FakePool(new FakePoolClient())
+      const abortController = new AbortController()
+      abortController.abort()
+
+      await assert.rejects(
+        new PostgresArticleRetrievalRepository(pool).findLexicalCandidates(
+          { query: 'pre aborted', limit: 10 },
+          createContext(abortController.signal),
+        ),
+        { name: 'AbortError' },
+      )
+
+      assert.equal(pool.connectCalls, 0)
+    })
+  })
+
   it('拒绝维度错误、非有限数值和零向量', async () => {
     const repository = new PostgresArticleRetrievalRepository(
       new FakePool(new FakePoolClient()),
@@ -185,16 +304,26 @@ class FakePoolClient implements ArticleRetrievalPoolClient {
 
   release(error?: Error): void {
     this.releaseArguments.push(error)
+    // 复刻 pg-pool `_releaseOnce()` 的一次性语义，double-release 必须在测试里立刻暴露。
+    if (this.releaseArguments.length > 1)
+      throw new Error('Release called on client which has already been released to the pool.')
   }
 }
 
 class FakePool implements ArticleRetrievalPool {
   readonly cancelledProcessIds: number[] = []
+  connectCalls = 0
 
-  constructor(private readonly client: ArticleRetrievalPoolClient) {}
+  constructor(
+    private readonly connection:
+      | ArticleRetrievalPoolClient
+      | Promise<ArticleRetrievalPoolClient>,
+  ) {}
 
-  async connect(): Promise<ArticleRetrievalPoolClient> {
-    return this.client
+  connect(): Promise<ArticleRetrievalPoolClient> {
+    this.connectCalls += 1
+    // Promise.resolve 对原生 Promise 返回同一实例，保留“connection 已 fulfilled”这一竞态前提。
+    return Promise.resolve(this.connection)
   }
 
   async cancel(processId: number): Promise<boolean> {
@@ -217,6 +346,40 @@ function createContext(signal = new AbortController().signal) {
       signal,
       createTimeoutError: () => new Error('test retrieval deadline exceeded'),
     },
+  }
+}
+
+function createDeferredConnection(): {
+  promise: Promise<ArticleRetrievalPoolClient>
+  resolve: (client: ArticleRetrievalPoolClient) => void
+  reject: (error: Error) => void
+} {
+  let resolve!: (client: ArticleRetrievalPoolClient) => void
+  let reject!: (error: Error) => void
+  const promise = new Promise<ArticleRetrievalPoolClient>((resolveFn, rejectFn) => {
+    resolve = resolveFn
+    reject = rejectFn
+  })
+  return { promise, resolve, reject }
+}
+
+// unhandledRejection 在当前 turn 结束后才派发，需要跨一次 macrotask 才能观察到。
+async function nextMacrotask(): Promise<void> {
+  await new Promise<void>(resolve => setImmediate(resolve))
+}
+
+async function expectNoUnhandledRejection(run: () => Promise<void>): Promise<void> {
+  const unhandledReasons: unknown[] = []
+  const onUnhandledRejection = (reason: unknown): number => unhandledReasons.push(reason)
+  process.on('unhandledRejection', onUnhandledRejection)
+
+  try {
+    await run()
+    await nextMacrotask()
+    assert.deepEqual(unhandledReasons, [])
+  }
+  finally {
+    process.off('unhandledRejection', onUnhandledRejection)
   }
 }
 

--- a/apps/api/src/retrieval/postgres-article-retrieval.repository.ts
+++ b/apps/api/src/retrieval/postgres-article-retrieval.repository.ts
@@ -479,35 +479,31 @@ async function connectWithAbort(
   const connection = pool.connect()
 
   return await new Promise<ArticleRetrievalPoolClient>((resolve, reject) => {
-    let settled = false
+    // client 所有权只由下面这一条 connection reaction 仲裁，不允许出现第二条 release 路径：
+    // abortError 为空表示所有权移交调用方，由 runOwnedReadQuery 负责最终 release；
+    // abortError 已存在表示 Abort 先决定了结果，迟到的 client 仍归本函数，在这里 release 恰好一次。
+    let abortError: Error | undefined
     const handleAbort = (): void => {
-      if (settled)
-        return
-      settled = true
-      const error = abortReason(signal)
-      void connection.then(
-        client => client.release(error),
-        () => {},
-      )
-      reject(error)
+      abortError = abortReason(signal)
+      reject(abortError)
     }
     signal.addEventListener('abort', handleAbort, { once: true })
 
     void connection.then(
       (client) => {
-        if (settled) {
-          client.release(abortReason(signal))
+        // reaction 一旦执行，Abort 就不可能再改变所有权归属。
+        signal.removeEventListener('abort', handleAbort)
+        if (abortError) {
+          client.release(abortError)
           return
         }
-        settled = true
-        signal.removeEventListener('abort', handleAbort)
         resolve(client)
       },
       (error) => {
-        if (settled)
-          return
-        settled = true
         signal.removeEventListener('abort', handleAbort)
+        // Abort 已经是最终结果时，这里只负责安全观察迟到的连接失败。
+        if (abortError)
+          return
         reject(error)
       },
     )


### PR DESCRIPTION
Closes #67

## Gate 结论

`READY`。Issue #67 正文（updatedAt 2026-08-16T13:37:23Z，0 条评论）的 D-01 / D-02 澄清决策与真实代码、现有测试、项目规范一致，无阻塞性歧义。基线为 `origin/master` @ `46f08f3`。

Gate 期已用只读脚本确认真实缺陷（连跑 5 次结果完全一致）：

| 场景 | 修复前 |
| --- | --- |
| connection 已 fulfilled + 成功 reaction 前 Abort | release **2 次** |
| pending connect 期间 Abort，connection 随后成功 | release **2 次** |
| 正常移交 | release 1 次、参数 `undefined`（正确） |
| Abort 先赢 + connection 随后 reject | 无未处理 rejection（正确） |
| connection 先失败 | 保留原错误（正确） |
| 调用前已 Abort | `pool.connect()` 0 次（正确） |

补充事实：`pg-pool` 的 `_releaseOnce()` 在第二次 release 时 `throwOnDoubleRelease()` 抛 `Release called on client which has already been released to the pool.`；该同步 throw 发生在 promise reaction 内且被 `void connection.then(...)` 丢弃，因此真实环境下 double-release 还会额外产生未处理的异步 rejection。

## ownership / release 修复方式

修复前 `connectWithAbort()` 有两条独立的 client 释放路径：

1. `handleAbort()` 内注册的 `connection.then(client => client.release(error))`；
2. 主 `connection.then()` success 分支中 `settled === true` 时的 `client.release(abortReason(signal))`。

两条 reaction 都会在 client 到达时执行，`settled` 只决定了「谁先决定 Promise 结果」，并不约束「谁拥有 client」。

修复后只保留**一条** connection reaction 作为唯一仲裁点，用 `abortError` 表达所有权归属：

- `abortError === undefined` → 所有权移交调用方，helper 自身 **release 0 次**，由 `runOwnedReadQuery()` 既有生命周期最终 release 1 次；
- `abortError !== undefined` → Abort 已先决定结果，迟到的 client 仍归 helper，在这里用**与 rejection 相同的 Error 实例** release **恰好 1 次**；
- 成功与失败两条分支都在首行同步 `removeEventListener`，reaction 执行后 `handleAbort` 不可能再触发（abort dispatch 是同步的，不与 microtask 交错），因此不再需要 `settled` 守卫；
- 失败分支在 `abortError` 已存在时仅 `return`，迟到的 connection rejection 仍被该 handler 观察，不产生未处理 rejection。

这是真正的 ownership transfer，不是靠吞掉第二次 release 异常掩盖问题——删除的正是那条多余的释放路径。

## 验收追踪矩阵

| 验收项 | 预期行为 | 实现位置 | 验证结果 |
| --- | --- | --- | --- |
| AC-01 | 已 fulfilled connection + reaction 前 Abort 只 release 一次，无未处理 rejection | `connectWithAbort()` / `.test.ts` | PASS |
| AC-02 | pending connect Abort 后迟到 client 用同一 abort error release 一次 | 同上 | PASS（`strictEqual` 断言与 rejection 同一实例） |
| AC-03 | 正常移交 helper release 0 次；late Abort 不改变 `[undefined]` | 同上 | PASS |
| AC-04 | connection reject 保留原错误且不 release；Abort 先赢时迟到 rejection 被安全观察 | 同上 | PASS（含 `unhandledRejection` 监听） |
| AC-05 | 调用前 Abort 不调用 `pool.connect` | 同上 | PASS（`connectCalls === 0`） |
| AC-06 | Retrieval 行为无回归 | Retrieval tests | PASS 41/41，另 DB 集成 9/9 |
| AC-07 | 类型与 lint 通过 | API workspace | PASS |

## 新增竞态测试如何确定性复现

不使用随机调度、循环碰撞或时间延迟，只用已 fulfilled Promise、deferred 和显式同步点：

- **AC-01**：`FakePool` 的 `connect()` 用 `Promise.resolve(connection)` 返回**同一个**原生 Promise 实例，保留「connection 已 fulfilled」前提；测试在调用 helper **之前**先 `void connection.then(() => abortController.abort())`，把 Abort 排进一条早于 helper reaction 的 microtask，从而精确命中「connection 已 fulfilled、成功回调尚未执行」的窗口。
- **AC-02 / AC-04**：用 `createDeferredConnection()` 手工控制 connection 的 resolve / reject 时机，先 `abort()` 再 settle。
- **AC-03 / AC-05**：同步调用 + `setImmediate` 单次 macrotask 跨越（用于观察 late Abort 与 `unhandledRejection` 派发，不是靠时长赌调度）。
- `FakePoolClient.release()` 复刻 `pg-pool` 的一次性语义：第二次 release 抛 `Release called on client which has already been released to the pool.`，让 double-release 在整个 Retrieval 套件里都会立刻暴露。

**对修复前实现的实测结果**（还原源码后运行同一套新测试）：

```
not ok 1 - connection 已 fulfilled 但成功 reaction 执行前 Abort 时只 release 一次
  error: 'Release called on client which has already been released to the pool.'
not ok 2 - pending connect 期间 Abort 后，迟到 client 用同一个 abort error release 一次
  expected: 1
  actual: 2
  operator: 'strictEqual'
# Error: ... generated asynchronous activity after the test ended. This activity created the error
  "Error: Release called on client which has already been released to the pool." and would have caused
  the test to fail, but instead triggered an unhandledRejection event.
# tests 10 / pass 8 / fail 2
```

修复后同一套测试全绿。

## 验证命令与真实结果

| 命令 | 结果 |
| --- | --- |
| `pnpm --filter @agent/api test:retrieval` | PASS — tests 41 / suites 9 / pass 41 / fail 0 |
| `pnpm --filter @agent/api typecheck` | PASS — 无输出 |
| `pnpm --filter @agent/api lint` | PASS — 无输出 |
| `pnpm --filter @agent/api test:retrieval-db` | PASS — tests 9 / suites 2 / pass 9 / fail 0（真实 PostgreSQL + pgvector） |

补充 scoped 回归说明：`connectWithAbort()` / `runOwnedReadQuery()` 在 `apps/api/src` 内无其他调用方，`PostgresArticleRetrievalRepository` 的其余消费方均为 DB 集成测试，因此额外跑了 `test:retrieval-db`，用真实 pg client 覆盖连接释放与 pool 复用路径。

## 已知风险与非目标

风险：

- `handleAbort` 去掉 `settled` 守卫依赖「abort dispatch 同步、不与 microtask 交错」这一语义；若未来 `pool.connect()` 被替换为会同步执行 reaction 的自定义 thenable，需要重新评估。当前生产路径返回原生 Promise。
- `abortError` 捕获自 `abortReason(signal)`：当 `signal.reason` 不是 Error 时，`abortReason()` 每次都会新建 DOMException，因此改为捕获一次并复用，保证 reject 与 release 携带同一实例。

非目标（本 PR 未触碰）：

- `queryWithAbort()`、PostgreSQL backend cancellation；
- Retrieval SQL、ranking、evaluation；
- statement / lock timeout、pg pool 配置；
- Embedding、Tool、Agent Runtime、API、公共 contract；
- Prisma schema / migration、依赖版本；
- `runOwnedReadQuery()` 外层 release 与错误映射逻辑；
- `docs/tasks/**`、`docs/roadmap.md`、`docs/work-log.md` 状态收口。

Gate 期发现但不属于 #67 的问题：无。

---

实施状态：已实现
验收状态：待验收
