### PR TITLE
fix(admin): Run 列表查询补齐 groundedFinalization Step

### DIFF
--- a/apps/api/src/admin-runs/admin-runs.service.test.ts
+++ b/apps/api/src/admin-runs/admin-runs.service.test.ts
@@ -904,6 +904,58 @@ describe('AdminRunsService', () => {
     )
   })
 
+  it('列表查询只请求统计所需的三类 Step，且保留 output 字段', async () => {
+    const harness = createServiceHarness()
+
+    await harness.service.list({})
+
+    const steps = (harness.calls.findMany[0]?.select as {
+      steps?: {
+        where?: { type?: { in?: string[] } }
+        select?: Record<string, boolean>
+      }
+    }).steps
+
+    // 排序后精确比对：既证明三类必需 Step 都在，也证明没有夹带无关 Step。
+    assert.deepEqual([...(steps?.where?.type?.in ?? [])].sort(), [
+      'grounded_finalization',
+      'model_sampling',
+      'tool_execution',
+    ])
+    assert.equal(steps?.select?.output, true)
+  })
+
+  it('列表统计包含 grounded finalization 的采样次数与 Token', async () => {
+    const harness = createServiceHarness({ list: createGroundedListRecord() })
+
+    const response = await harness.service.list({})
+    const item = response.items[0]
+
+    // 3 次 action sampling + 1 次 finalization attempt。
+    assert.equal(item?.samplingCount, 4)
+    assert.equal(item?.inputTokens, 60 + 4)
+    assert.equal(item?.outputTokens, 23 + 1)
+    assert.equal(item?.totalTokens, 83 + 5)
+  })
+
+  it('finalization metadata 损坏时列表路径继续 fail closed', async () => {
+    const listRecord = createRunRecord()
+    listRecord.steps = [
+      ...listRecord.steps,
+      step(10, 'grounded_finalization', { output: null }),
+    ]
+
+    const response = await createServiceHarness({ list: listRecord })
+      .service
+      .list({})
+    const item = response.items[0]
+
+    assert.equal(item?.samplingCount, 4)
+    assert.equal(item?.inputTokens, null)
+    assert.equal(item?.outputTokens, null)
+    assert.equal(item?.totalTokens, null)
+  })
+
   it('拒绝反向日期范围', async () => {
     const harness = createServiceHarness()
 
@@ -1269,17 +1321,28 @@ function safeContextPlan(
   }
 }
 
-function createServiceHarness(options: { detail?: ReturnType<typeof createRunRecord> | null } = {}) {
+function createServiceHarness(options: {
+  detail?: ReturnType<typeof createRunRecord> | null
+  list?: ReturnType<typeof createRunRecord>
+} = {}) {
   const calls = {
     findMany: [] as Array<Record<string, unknown>>,
     groupBy: [] as Array<Record<string, unknown>>,
   }
   const record = createRunRecord()
+  const listRecord = options.list ?? record
   const prisma = {
     agentRun: {
       async findMany(args: Record<string, unknown>) {
         calls.findMany.push(args)
-        return [record]
+        // 模拟 Prisma 真实行为：只返回 list select allowlist 内的 Step。
+        // 否则 mock 会把生产查询压根不会读到的 Step 喂给 projector，
+        // 让查询—投影接缝缺陷在测试里变成假阳性。
+        const allowedTypes = readListStepTypes(args)
+        return [{
+          ...listRecord,
+          steps: listRecord.steps.filter(step => allowedTypes.includes(step.type)),
+        }]
       },
       async groupBy(args: Record<string, unknown>) {
         calls.groupBy.push(args)
@@ -1297,4 +1360,29 @@ function createServiceHarness(options: { detail?: ReturnType<typeof createRunRec
     calls,
     service: new AdminRunsService(prisma),
   }
+}
+
+function readListStepTypes(args: Record<string, unknown>): string[] {
+  const select = args.select as {
+    steps?: { where?: { type?: { in?: string[] } } }
+  } | undefined
+
+  return select?.steps?.where?.type?.in ?? []
+}
+
+/** 列表 Run 记录：追加一次成功的 finalization attempt。 */
+function createGroundedListRecord() {
+  const record = createRunRecord()
+
+  record.steps = [
+    ...record.steps,
+    step(10, 'grounded_finalization', {
+      input: groundedFinalizationInput(),
+      output: groundedFinalizationOutput([
+        { ok: true, usage: { inputTokens: 4, outputTokens: 1, totalTokens: 5 } },
+      ]),
+    }),
+  ]
+
+  return record
 }

--- a/apps/api/src/admin-runs/admin-runs.service.ts
+++ b/apps/api/src/admin-runs/admin-runs.service.ts
@@ -37,9 +37,12 @@ const ADMIN_RUN_LIST_SELECT = {
   steps: {
     where: {
       type: {
+        // grounded finalization 也是真实模型调用，必须喂给 projector，
+        // 否则 Grounded Run 在列表页会系统性少算采样次数与 Token。
         in: [
           AGENT_STEP_TYPES.modelSampling,
           AGENT_STEP_TYPES.toolExecution,
+          AGENT_STEP_TYPES.groundedFinalization,
         ],
       },
     },


### PR DESCRIPTION
Closes #64

## 1. Gate 结论

- Gate：`READY`
- 基线 SHA：`41c197f795d1d5b112c939952c2e1371dac8ea8a`（远程 `master`，位于 Issue 要求的 PR #68 merge `51793f03` 之后）
- 阻塞性歧义：无
- 非阻塞假设：
  - A-01 `grounded_finalization` 是唯一持久化值，无别名（`agent-run-recorder.service.ts:17-24`）
  - A-02 现有列表 Step select 字段已够 finalization 聚合使用，不扩大字段
  - A-03 `AdminRunListItem` 已能表达正确结果，不改 `packages/contracts`
  - A-04 / A-05 测试组织方式（在既有测试文件内新增 `it()`、最小扩展 `createServiceHarness()`）为内部选择

## 2. 根因

```text
projector 已支持 grounded finalization
但 ADMIN_RUN_LIST_SELECT 没有查询该 Step
因此生产列表路径无法把 finalization 喂给 projector
```

`projectAdminRunListItem()` 早已调用 `aggregateGroundedFinalization(run.steps)`，
并把 attempt 次数计入 `samplingCount`、把 attempt usage 并入 Token 汇总。
问题不在 projector 的计算，而在查询层：`ADMIN_RUN_LIST_SELECT.steps.where.type.in`
只允许 `model_sampling` 与 `tool_execution`，Prisma 根本不会返回
`grounded_finalization` Step，projector 拿到的是一份缺失数据的输入。

后果：使用 Grounded Answer 的 Run 在列表页系统性少算 1～2 次真实模型调用及其 Token；
详情查询没有同类 type filter，因此同一个 Run 的列表与详情统计口径不一致。

## 3. 最小修复

- `ADMIN_RUN_LIST_SELECT.steps.where.type.in` 增加 `AGENT_STEP_TYPES.groundedFinalization`（allowlist 仍为 3 项）
- Step select 字段不变：`sequence / type / status / input / output`
- `projectAdminRunListItem()` 不变
- `aggregateGroundedFinalization()` 不变
- `packages/contracts` 不变
- Admin UI 不变
- 详情查询不变

生产代码 diff 为 3 行（含 2 行注释）。

## 4. 查询—投影接缝测试

原缺陷正好落在「projector 支持」与「查询真的把数据喂给它」之间，因此测试不再只调用 projector：

1. **查询参数断言（AC-01）**：`列表查询只请求统计所需的三类 Step，且保留 output 字段`
   直接读取 mock 记录的 `harness.calls.findMany[0].select.steps.where.type.in`，
   排序后 `deepEqual` 精确比对 `['grounded_finalization', 'model_sampling', 'tool_execution']`——
   同时证明三类必需 Step 都在、数组长度为 3、没有夹带其他 Step 类型；并断言 `steps.select.output === true`。

2. **harness 现在真实执行 select 过滤**：`createServiceHarness()` 的 mock `findMany`
   改为按 `args.select.steps.where.type.in` 过滤 Step 后再返回。
   此前 mock 无条件返回 fixture 的全部 Step（含 `future_retrieval`、`assistant_output`、
   `receive_user_message` 等生产查询根本读不到的类型），任何 Service 层断言都可能是假阳性。

3. **Service 路径行为断言（AC-02 / AC-03）**：`列表统计包含 grounded finalization 的采样次数与 Token`
   调用 `AdminRunsService.list()`，harness 返回带一次成功 finalization attempt 的列表 Run，
   断言响应 `items[0]` 的 `samplingCount = 4`（3 次 action sampling + 1 次 attempt）、
   `inputTokens = 64`、`outputTokens = 24`、`totalTokens = 88`。
   由于第 2 点，这些数字只有在生产 allowlist 真的包含 `groundedFinalization` 时才成立。

4. **列表路径 fail-closed 回归（AC-04）**：`finalization metadata 损坏时列表路径继续 fail closed`
   finalization Step 的 `output` 为 `null` 时，`samplingCount` 仍为 4（不静默少算成 0），
   三项 Token 全部为 `null`（不输出只含 action sampling 的偏低总数）。
   这条覆盖的是本次改动引入的新生产行为：finalization Step 现在会真的进入列表投影。

**反向验证**：临时把 `groundedFinalization` 从 allowlist 移除后重跑，
上述 3 个新增测试全部失败（`# pass 136 # fail 3`），证明测试确实锁住查询—投影接缝，
而不是只验证手工调用 projector。恢复修复后重新全绿。

既有 projector 测试（含 6 组 malformed output、FAILED / ABORTED、usage 缺失）全部保留未改。

## 5. 验收追踪

| 需求 / 验收项 | 实现位置 | 测试或证据 | 结果 |
| --- | --- | --- | --- |
| AC-01 | `admin-runs.service.ts` | Service select 断言（排序后 `deepEqual` 三类 + `select.output`） | PASS |
| AC-02 | Service list | 行为测试 `samplingCount = 4` | PASS |
| AC-03 | Service list + projector | Token 断言 `64 / 24 / 88` | PASS |
| AC-04 | 既有 fail-closed tests + 新增列表路径回归 | `test:admin-runs` | PASS |
| AC-05 | 既有 Service / detail tests | `test:admin-runs`（139 passed，含分页、过滤、排序、summary、404、详情投影） | PASS |
| AC-06 | API workspace | test / typecheck / lint | PASS |

## 6. 验证命令与真实结果

```text
命令：pnpm --filter @agent/api test:admin-runs   （脚本自带 pnpm build）
退出码：0
测试数量：139
失败数量：0
skip 数量：0
suites：14 / cancelled 0 / todo 0
```

```text
命令：pnpm --filter @agent/api typecheck
退出码：0
（tsc --noEmit，无输出）
```

```text
命令：pnpm --filter @agent/api lint
退出码：0
（eslint src scripts，无输出）
```

```text
命令：git diff --check
退出码：0
```

反向验证（临时移除修复，仅用于证明测试有效，未提交）：

```text
命令：pnpm --filter @agent/api test:admin-runs
退出码：1
测试数量：139
失败数量：3
skip 数量：0
```

## 7. 风险与非目标

本 PR **没有修改**：

- `projectAdminRunListItem()` / `aggregateGroundedFinalization()` / finalization parser
- `packages/contracts`（`AdminRunListItem` 已能表达正确结果）
- Admin UI
- 详情查询 `ADMIN_RUN_DETAIL_SELECT`
- Agent Runtime / Grounding
- Retrieval / Embedding / Tool
- Prisma schema / migration
- Admin Auth / RBAC、Admin Task 4
- Issue #65 / #66 或其他开放 Issue
- `docs/tasks/**`、`docs/roadmap.md`、`docs/work-log.md`、Phase 8 与 Admin Task 3C 状态

已知行为变化（预期内）：修复后，带损坏 finalization metadata 的 Grounded Run 在列表页
Token 会由「原先看似精确但实际偏低的数字」变为 `null`。这正是既有 fail-closed 语义的正确表现——
observability 数字宁可明确不可用，也不给系统性偏低的假精确值。

未新增依赖、环境变量或数据库集成测试。

---

实施状态：已实现
验收状态：待验收

🤖 Generated with [Claude Code](https://claude.com/claude-code)
