### PR TITLE
fix(api): 拒绝纯空白 SEO Chat 消息并阻断下游 Agent Run

### DIFF
--- a/apps/api/src/seo/dto/seo-chat.dto.test.ts
+++ b/apps/api/src/seo/dto/seo-chat.dto.test.ts
@@ -1,10 +1,42 @@
+/* eslint-disable perfectionist/sort-imports */
+import 'reflect-metadata'
+
+import type { ArgumentMetadata } from '@nestjs/common'
 import assert from 'node:assert/strict'
 // eslint-disable-next-line test/no-import-node-test
 import { describe, it } from 'node:test'
 import { SEO_CHAT_MESSAGE_MAX_CHARS } from '@agent/contracts'
+import { BadRequestException } from '@nestjs/common'
 import { validate } from 'class-validator'
 
+import { createAppValidationPipe } from '../../common/pipes/app-validation.pipe.js'
 import { SeoChatDto } from './seo-chat.dto.js'
+
+/** 只由常规空白构成的消息，必须在 DTO / 全局 Pipe 边界被拒绝。 */
+const BLANK_MESSAGES = [
+  '',
+  '   ',
+  '\t\n\r',
+  '\u00A0',
+  '\u3000',
+  ' \t\n\u00A0\u3000 ',
+]
+
+/** 至少含一个 `\S` 字符的消息，必须继续通过。 */
+const MEANINGFUL_MESSAGES = [
+  ' \n hi \t ',
+  '0',
+  '中',
+]
+
+/** 用于验证错误响应没有回显失败字段原始值的哨兵值。 */
+const CONVERSATION_SENTINEL = 'conversation-sentinel-1'
+
+const BODY_METADATA: ArgumentMetadata = {
+  type: 'body',
+  metatype: SeoChatDto,
+  data: undefined,
+}
 
 describe('SeoChatDto', () => {
   it('接受共享上限内的用户消息', async () => {
@@ -23,12 +55,150 @@ describe('SeoChatDto', () => {
       true,
     )
   })
+
+  it('拒绝只包含空白字符的用户消息', async () => {
+    for (const message of BLANK_MESSAGES) {
+      const errors = await validate(createDto(message))
+
+      assert.equal(
+        errors.some(error => error.property === 'message'),
+        true,
+        `未拒绝空白消息：${JSON.stringify(message)}`,
+      )
+    }
+  })
+
+  it('接受含非空白字符的用户消息', async () => {
+    for (const message of MEANINGFUL_MESSAGES) {
+      const errors = await validate(createDto(message))
+
+      assert.equal(
+        errors.some(error => error.property === 'message'),
+        false,
+        `误拒绝有效消息：${JSON.stringify(message)}`,
+      )
+    }
+  })
+
+  it('MaxLength 仍在 trim 前生效，前导空白计入长度', async () => {
+    const errors = await validate(createDto(
+      `${' '.repeat(10)}${'a'.repeat(SEO_CHAT_MESSAGE_MAX_CHARS)}`,
+    ))
+
+    assert.equal(
+      errors.some(error => error.property === 'message'),
+      true,
+    )
+  })
+
+  it('拒绝不在白名单内的 model', async () => {
+    const errors = await validate(createDto('hi', 'gpt-4o'))
+
+    assert.equal(
+      errors.some(error => error.property === 'model'),
+      true,
+    )
+  })
 })
 
-function createDto(message: string): SeoChatDto {
+describe('SeoChatDto 在 App ValidationPipe 边界的行为', () => {
+  it('纯空白 body 抛出 400 且不进入下游处理', async () => {
+    const pipe = createAppValidationPipe({ expectedType: SeoChatDto })
+
+    for (const message of BLANK_MESSAGES) {
+      let downstreamCalled = false
+
+      try {
+        const transformed: unknown = await pipe.transform(
+          createPayload(message),
+          BODY_METADATA,
+        )
+
+        downstreamCalled = true
+        void transformed
+      }
+      catch (error) {
+        assert.ok(error instanceof BadRequestException)
+        assert.equal(error.getStatus(), 400)
+
+        const response = error.getResponse() as {
+          message: string
+          details: string[]
+        }
+
+        assert.equal(response.message, '请求参数校验失败')
+        assert.equal(
+          response.details.some(detail => detail.startsWith('message:')),
+          true,
+        )
+
+        // 错误响应不得回显请求正文。直接比对未序列化的 details，
+        // 避免 JSON 转义把 \t \n \r 变成两字符序列后断言恒真。
+        if (message !== '') {
+          assert.equal(
+            response.details.join('\n').includes(message),
+            false,
+          )
+        }
+      }
+
+      assert.equal(
+        downstreamCalled,
+        false,
+        `空白消息越过了 Pipe：${JSON.stringify(message)}`,
+      )
+    }
+  })
+
+  it('校验失败字段的原始值不会被回显到错误详情', async () => {
+    const pipe = createAppValidationPipe({ expectedType: SeoChatDto })
+    const payload = {
+      ...createPayload('hi'),
+      // 超过 conversationId 的 128 字符上限，让该字段本身成为失败字段，
+      // 这样「不回显原始值」才是一个真正可能失败的断言。
+      conversationId: CONVERSATION_SENTINEL.repeat(20),
+    }
+
+    await assert.rejects(
+      () => pipe.transform(payload, BODY_METADATA),
+      (error: unknown) => {
+        assert.ok(error instanceof BadRequestException)
+
+        const response = error.getResponse() as { details: string[] }
+        const detailText = response.details.join('\n')
+
+        assert.equal(detailText.includes('conversationId:'), true)
+        assert.equal(detailText.includes(CONVERSATION_SENTINEL), false)
+
+        return true
+      },
+    )
+  })
+
+  it('含非空白字符的 body 通过校验且保留原始空白', async () => {
+    const pipe = createAppValidationPipe({ expectedType: SeoChatDto })
+    const transformed: unknown = await pipe.transform(
+      createPayload(' hi '),
+      BODY_METADATA,
+    )
+
+    assert.ok(transformed instanceof SeoChatDto)
+    assert.equal(transformed.message, ' hi ')
+  })
+})
+
+function createDto(message: string, model = 'deepseek-v4-flash'): SeoChatDto {
   return Object.assign(new SeoChatDto(), {
     conversationId: 'conversation-1',
     message,
-    model: 'deepseek-v4-flash',
+    model,
   })
+}
+
+function createPayload(message: string) {
+  return {
+    conversationId: 'conversation-1',
+    message,
+    model: 'deepseek-v4-flash',
+  }
 }

--- a/apps/api/src/seo/dto/seo-chat.dto.ts
+++ b/apps/api/src/seo/dto/seo-chat.dto.ts
@@ -5,6 +5,7 @@ import {
   IsNotEmpty,
   IsOptional,
   IsString,
+  Matches,
   MaxLength,
 } from 'class-validator'
 
@@ -18,6 +19,11 @@ export class SeoChatDto implements SeoChatRequest {
 
   @IsString()
   @IsNotEmpty()
+  // 只校验「至少包含一个非空白字符」，不做 trim：
+  // trim 与持久化规范化仍由 AgentRuntime 负责，MaxLength 也保持在 trim 前生效。
+  @Matches(/\S/u, {
+    message: 'message 不能只包含空白字符',
+  })
   @MaxLength(SEO_CHAT_MESSAGE_MAX_CHARS)
   message!: string
 


### PR DESCRIPTION
Closes #65

## 1. Gate 结论

- Clarification Gate：`READY`，无阻塞性歧义。
- 实际 base SHA：`ababbf7f1c71331c50b290cdf6dc6229ae868e56`（Issue 正文记录的 `9eb9e2f` 已不是最新 `master`；`ababbf7` 只改动 `.claude/skills/**` 与 `CLAUDE.md`，与本修复无关）。
- 已确认 base 包含 Issue #64 / PR #69 的合并与 `docs: 记录 Issue #64 维护修复收口`。
- 已确认最新 `master` 尚未修复该缺陷：`SeoChatDto.message` 此前只有 `@IsString()`、`@IsNotEmpty()`、`@MaxLength()`。
- 非阻塞内部假设：
  - 测试文件新增 `import 'reflect-metadata'`，与 `admin-runs.controller.test.ts` 同风格；`ValidationPipe` 内部经 `class-transformer.plainToInstance`，需要 `Reflect.getMetadata` 存在。
  - 空字符串会同时触发 `IsNotEmpty` 与 `Matches`，测试统一用 `errors.some(error => error.property === 'message')`，不断言 constraint 数量或顺序。
  - DTO 层 `model` 白名单此前无测试覆盖，在同一测试文件补了一条最小回归，未改动白名单本身。

## 2. 根因

```text
IsNotEmpty 只拒绝空字符串
纯空白字符串仍能通过 DTO
Runtime trim 后得到空字符串，但当前仍继续持久化并创建 Agent Run
```

具体路径（`apps/api/src/agent-runtime/agent-runtime.service.ts`）：

- `:150` `const normalizedMessage = input.userContent.trim()`；
- `:151` 继续 `createMessageAndTouchConversation()` 写入空内容 User Message 并 touch Conversation；
- `:157` 继续 `createRun()`；
- `:173` 继续 `startStep()`，随后进入 Context / LLM 链路。

不是 Runtime trim 失败，不是数据库允许空字符串，不是 Web 按钮没禁用，也不是模型返回异常。

## 3. 校验位置

修复放在共享 `SeoChatDto`：

```text
HTTP Request
  → Global ValidationPipe（registerAppGlobals -> createAppValidationPipe）
  → SeoChatDto validation
       ├─ invalid：BadRequestException(400)，停止
       └─ valid：进入 Controller
  → SeoController
  → SeoService
  → AgentRuntime
```

- `SeoController.chat()`（`seo.controller.ts:29`）与 `SeoController.chatStream()`（`seo.controller.ts:36`）的 `@Body()` 均为 `SeoChatDto`，同步与流式入口共用同一规则。
- 校验发生在 `seo.controller.ts:47-51` 的 `response.status()` / `setHeader()` / `flushHeaders()` 之前，因此无效请求可以稳定返回普通 HTTP 400，而不会污染已经开始的 NDJSON 流。
- Controller 方法根本不会执行，下游持久化和 Agent 执行不会发生。

## 4. 最小实现

`apps/api/src/seo/dto/seo-chat.dto.ts`（+6 行）：

- 从 `class-validator` 增加 `Matches` import（既有依赖，未新增任何依赖）；
- 在 `message` 上增加 `@Matches(/\S/u, { message: 'message 不能只包含空白字符' })`；
- 正则语义：只要包含至少一个 `\S` 字符即通过，与 `String.prototype.trim()` 的 ECMAScript 常规空白定义一致；
- 保留 `@IsString()`、`@IsNotEmpty()`、`@MaxLength(SEO_CHAT_MESSAGE_MAX_CHARS)` 的既有语义与顺序（`MaxLength` 仍在 trim 前生效）；
- DTO 不做 trim、不做任何内容变换；
- `AgentRuntimeService`、`SeoService`、`SeoController`、`createAppValidationPipe()`、`AllExceptionsFilter`、`packages/contracts` 均未修改。

## 5. 测试证据

`apps/api/src/seo/dto/seo-chat.dto.test.ts`：

- 覆盖的纯空白样例：`''`、`'   '`、`'\t\n\r'`、`'\u00A0'`（non-breaking space）、`'\u3000'`（全角空格）、`' \t\n\u00A0\u3000 '`（混合）。
- DTO ValidationError：用 `class-validator.validate()` 断言 `errors.some(error => error.property === 'message')`，不依赖 constraint 数量，避免 `IsNotEmpty` 与 `Matches` 同时命中时不稳定。
- 真实 App ValidationPipe：用 `createAppValidationPipe({ expectedType: SeoChatDto })` 的 `transform(payload, { type: 'body', metatype: SeoChatDto, data: undefined })`，断言抛出 `BadRequestException` 且 `error.getStatus() === 400`。
- details 指向 `message`：断言响应顶层 `message` 为 `请求参数校验失败`，且 `details.some(detail => detail.startsWith('message:'))`。
- 不回显原始正文：对未序列化的 `response.details` 断言不含原始 `message` 字符串（不用 `JSON.stringify`，避免 `\t` / `\n` / `\r` 被转义后断言恒真）；另有一条独立用例让 `conversationId` 自身超长成为失败字段，断言 details 出现 `conversationId:` 但不含该字段的原始值——这是一个真正可能失败的反回显断言。
- downstream sentinel：`downstreamCalled` 只有在 `transform()` 成功返回后才置为 `true`，循环末尾断言其为 `false`，证明 Pipe 拒绝后业务处理没有执行。
- `" hi "` 保留原字符串：同一个真实 Pipe 对合法 body `transform()` 成功，断言返回值 `instanceof SeoChatDto` 且 `message === ' hi '`，证明 DTO / Pipe 没有 trim。
- 合法样例回归：`' \n hi \t '`、`'0'`、`'中'` 均不产生 `message` 校验错误。
- 既有行为不回归：保留最大长度上下界两条既有测试；补充一条「前导空白计入长度」用例锁定 `MaxLength` 的 trim 前语义；补充一条 DTO 层非法 model（`'gpt-4o'`）被 `@IsIn` 拒绝的最小回归。
- 反向验证（非提交内容）：临时还原未修复的 `seo-chat.dto.ts` 后，`test:seo-service` 出现 `# fail 2`（`拒绝只包含空白字符的用户消息`、`纯空白 body 抛出 400 且不进入下游处理`），确认新增测试不是空跑。
- 编译产物复跑（非提交内容）：`test:seo-service` 经 `tsx`（esbuild）运行，不产生 `emitDecoratorMetadata`。为确认断言不依赖这一差异，另在 `tsc` 编译产物上跑了同一测试文件：`node --test apps/api/dist/seo/dto/seo-chat.dto.test.js` → 9 tests / 9 pass。

## 6. commit 前 `/code-review` 结论与处理

对暂存区 diff 运行了 Claude Code 内置 `/code-review`（1 轮），共 14 条 finding。已修 3 条，其余按 Issue #65 已确认决策与任务边界不修并说明理由。

### 已修（本次提交内）

| Finding | 处理 |
| --- | --- |
| `JSON.stringify(response).includes(message)` 对含控制字符的样例恒真，反回显断言空跑 | 改为比对未序列化的 `response.details`，`'\t\n\r'` 与混合样例现在是真断言 |
| `CONVERSATION_SENTINEL` 放在始终校验通过的 `conversationId` 上，永远不会失败 | 新增独立用例，让 `conversationId` 超长成为失败字段后再断言其原始值未被回显 |
| 注释声明的「`MaxLength` 保持 trim 前生效」不变量没有测试覆盖 | 新增用例：`' '.repeat(10) + 'a'.repeat(SEO_CHAT_MESSAGE_MAX_CHARS)` 必须被拒绝 |

### 不修（与已确认规格冲突或超出 #65 范围）

| Finding | 不修理由 |
| --- | --- |
| `/\S/u` 不覆盖零宽字符（`\u200B` / `\u200C` / `\u200D` / `\u2060`） | Issue D-03 明确排除零宽格式字符与更广泛文本安全治理，要求与 `trim()` / ECMAScript whitespace 保持一致。**已在编译产物上复现确认该行为真实存在**，记为后续候选（见第 9 节） |
| `enableImplicitConversion: true` 会把 `{"message":{}}` 强转成 `"[object Object]"` 从而绕过校验 | 真实且已在编译产物上复现，但这是 `createAppValidationPipe()` 的既有行为，本 PR 未引入。Issue 明确「不修改 `createAppValidationPipe()`」「非字符串输入继续由既有 DTO 规则处理」。记为后续候选（见第 9 节） |
| `test:seo-service` 走 `tsx`，与生产 `emitDecoratorMetadata` 管线不一致 | 改 `apps/api/package.json` 的测试脚本超出本 Issue 允许改动范围。已改为在 `tsc` 编译产物上额外复跑同一测试文件（9/9 pass）作为等价证据 |
| 应抽出共享 `@IsNotBlank()` 装饰器，与 `conversation.dto.ts` 的 `@Transform` + `IsNotEmpty` 统一 | 与 Issue D-01 / D-02 冲突（DTO 不得 trim），且本任务明确要求「不新增通用 validator 文件」「不为两行校验创建新的 module / service / abstraction」 |
| `CreateConversationDto.title` 有同类空白缺陷，应一并修 | 超出 #65 范围（不修改其他 DTO 字段）。记为后续候选（见第 9 节） |
| `@IsNotEmpty()` 被 `@Matches` 完全覆盖，属冗余 | Issue 明确要求「保留现有 `@IsString()`、`@IsNotEmpty()` 与 `@MaxLength()`」 |
| 应改用 `assert.rejects` 替代手写 try/catch + sentinel | Issue 与任务要求显式规定用 downstream sentinel 证明「Pipe 失败时业务处理未执行」，`assert.rejects` 表达不了这层意图。已保留 sentinel，反回显断言的空跑问题按上表单独修掉 |
| 测试硬编码 `'deepseek-v4-flash'`，应从 `SUPPORTED_DEEPSEEK_MODELS` 取 | 该字面量是既有测试写法，属推测性防御（模型改名才会触发），不影响任何 AC，不做无关改写 |
| 测试用 `expectedType`，生产不传，属配置分叉 | Issue 与任务明确要求用 `createAppValidationPipe({ expectedType: SeoChatDto })` |
| 中文约束文案与 class-validator 英文默认文案混排 | Issue 明确建议该中文文案；错误响应格式调整在「不在本任务范围」内 |
| 应在 `docs/tasks/**` 补任务记录 | Issue 明确「`docs/tasks/**` 无需为该维护修复新增 Task 状态」，任务边界也禁止修改 `docs/tasks/**` |

## 7. 验收追踪

| 验收项 | 实现位置 | 测试或证据 | 结果 |
| --- | --- | --- | --- |
| AC-01 | `seo-chat.dto.ts` | whitespace DTO tests（6 个样例） | PASS |
| AC-02 | App ValidationPipe | 400 / details / 反回显 tests | PASS |
| AC-03 | Pipe boundary | downstream sentinel | PASS |
| AC-04 | DTO / Pipe | `" hi "` 原字符串保留断言 | PASS |
| AC-05 | existing SEO tests + MaxLength / model 回归 | `test:seo-service` | PASS |
| AC-06 | API workspace | typecheck / lint / build / `git diff --check` | PASS |

## 8. 验证命令与真实结果

```text
pnpm --filter @agent/api test:seo-service
  退出码：0
  tests 31 / pass 31 / fail 0 / skipped 0 / todo 0 / cancelled 0（suites 5）
  其中 SeoChatDto 6 条、SeoChatDto 在 App ValidationPipe 边界的行为 3 条，全部 ok
  有输出：测试 TAP 报告

pnpm --filter @agent/api typecheck
  退出码：0
  无诊断输出（仅 pnpm / tsc 命令回显）

pnpm --filter @agent/api lint
  退出码：0
  无 eslint 输出（仅 pnpm / eslint 命令回显）

pnpm --filter @agent/api build
  退出码：0
  无编译错误输出（先构建 @agent/contracts，再 tsc 构建 @agent/api）
  说明：test:seo-service 自身会先执行 pnpm --filter @agent/contracts build，
        因此 contracts 构建被重复执行了一次；此处仍按要求独立运行并记录 API build。

node --test apps/api/dist/seo/dto/seo-chat.dto.test.js
  退出码：0
  tests 9 / pass 9 / fail 0
  用途：在真实 emitDecoratorMetadata 编译产物上复跑，确认断言不依赖 tsx 差异
  有输出：测试 TAP 报告

git diff --check
  退出码：0
  无输出

git status --short
  提交前仅两个文件：
    M apps/api/src/seo/dto/seo-chat.dto.ts
    M apps/api/src/seo/dto/seo-chat.dto.test.ts
  无生成产物、无 lockfile 改动、无依赖变化、无 docs 状态变化
```

## 9. 风险与非目标

本 PR 未修改：

- `AgentRuntimeService`、Runtime event、Runtime `failureReason`、Runtime trim 行为；
- `SeoService`、`SeoController`；
- `createAppValidationPipe()`、`AllExceptionsFilter` 与全局异常格式；
- `packages/contracts`（`SeoChatRequest.message` 仍是 `string`；TS interface 无法表达「至少一个非空白字符」，必须靠运行时校验）；
- Web UI / Admin UI；
- 数据库、Prisma schema / migration、既有数据；
- 依赖、lockfile、环境变量、部署配置；
- Phase 8 状态、`docs/tasks/**`、`docs/roadmap.md`、`docs/work-log.md`；
- Issue #66 与其他开放 Issue。

明确的非目标：

- 本 Task 不阻止零宽格式字符（`\u200B` 等）；
- 本 Task 不做 Prompt Injection 防护、内容审核或通用文本净化；
- `/\S/u` 只覆盖 Issue 定义的常规空白语义（与 `String.prototype.trim()` 一致，含 `\u00A0`、`\u3000` 等）。

### 已确认存在、但本 PR 按边界不处理的后续候选

以下两条来自 commit 前 `/code-review`，已在 `tsc` 编译产物上实测复现，建议另立 Issue：

1. **零宽字符仍可通过**：`{"message":"\u200B"}` 在编译产物上返回 `ACCEPT`，`trim()` 后长度仍为 1，因此仍会创建 Message / Run 并触发一次真实模型调用。属 D-03 明确划出的后续 Task。
2. **`enableImplicitConversion` 绕过 `@IsString()`**：`{"message":{}}` → `"[object Object]"`、`{"message":12345}` → `"12345"`、`{"message":true}` → `"true"` 均被 `ACCEPT`。属 `createAppValidationPipe()` 的既有全局行为，本 PR 未引入也未加剧，修复需要单独评估对全部 DTO 的影响。
3. **`CreateConversationDto.title` 同类空白缺陷**：`POST /api/conversations {"title":"   "}` 仍可创建纯空白标题，而 `UpdateConversationDto.title` 会拒绝，两者策略不一致。

## 10. 建议阅读顺序

1. `apps/api/src/seo/dto/seo-chat.dto.ts`（生产改动，6 行）
2. `apps/api/src/common/pipes/app-validation.pipe.ts`（未改动，理解 400 与 details 协议）
3. `apps/api/src/seo/seo.controller.ts:27-51`（未改动，理解流式 headers 与校验时序）
4. `apps/api/src/agent-runtime/agent-runtime.service.ts:148-184`（未改动，理解被阻断的下游链路）
5. `apps/api/src/seo/dto/seo-chat.dto.test.ts`（测试改动）

## 11. 状态

```text
实施状态：已实现
验收状态：待验收
```
