### PR TITLE
fix(agent-runtime): 终态收口兜底与终态化失败流通知

### DIFF
--- a/apps/api/src/agent-runtime/agent-runtime.service.test.ts
+++ b/apps/api/src/agent-runtime/agent-runtime.service.test.ts
@@ -1801,6 +1801,13 @@ describe('AgentRuntimeService model stream', () => {
     assistantMessage.status = MessageStatus.ABORTED
     assistantMessage.content = '已停止'
 
+    // 终态化失败在抛出前会先 best-effort 通知流消费者，再拒绝。
+    const failureEvent = await stream.next()
+
+    assert.equal(
+      (failureEvent.value as AgentRuntimeEvent | undefined)?.type,
+      'run_failed',
+    )
     await assert.rejects(
       stream.next(),
       AgentRunTerminalizationError,
@@ -1858,6 +1865,33 @@ describe('AgentRuntimeService model stream', () => {
     assert.equal(harness.assistantMessage()?.status, MessageStatus.ABORTED)
     assert.deepEqual(harness.recorder.abortedRunIds, ['run-1'])
     assert.deepEqual(harness.recorder.failedRunIds, [])
+    assertNoUnfinishedSteps(harness)
+  })
+
+  it('消费者在 delta 后提前 return() 时兜底收口为 ABORTED', async () => {
+    const harness = createHarness(() => toModelStream([
+      { type: 'text_delta', delta: '部' },
+      { type: 'text_delta', delta: '分' },
+      { type: 'response_completed', finishReason: 'stop' },
+    ]))
+    const generator = harness.run()
+
+    const first = await generator.next()
+    assert.equal((first.value as AgentRuntimeEvent | undefined)?.type, 'run_started')
+    const second = await generator.next()
+    assert.equal((second.value as AgentRuntimeEvent | undefined)?.type, 'assistant_delta')
+
+    // for-await break 语义：触发 generator.return()，yield 点以 return
+    // 语义恢复，catch 不执行，只有 finally 兜底有机会收口。
+    await generator.return(undefined)
+
+    assert.equal(harness.assistantMessage()?.status, MessageStatus.ABORTED)
+    assert.equal(harness.assistantMessage()?.content, '部')
+    assert.deepEqual(harness.recorder.abortedRunIds, ['run-1'])
+    assert.deepEqual(harness.recorder.completedRunIds, [])
+    assert.deepEqual(harness.recorder.failedRunIds, [])
+    // 兜底收口必须同时取消在途模型请求，否则 provider 流会继续生成计费 token。
+    assert.equal(harness.llmCalls[0]?.options?.signal?.aborted, true)
     assertNoUnfinishedSteps(harness)
   })
 
@@ -2151,6 +2185,37 @@ describe('AgentRuntimeService model stream', () => {
     assert.deepEqual(harness.recorder.failedRunIds, [])
     assert.deepEqual(harness.recorder.abortedRunIds, [])
     assert.equal(findStep(harness, 'assistant_output')?.status, AgentStepStatus.RUNNING)
+  })
+
+  it('completion commit 结果未知时抛出前 best-effort 通知流消费者', async () => {
+    const outcomeUnknown = new DatabaseCommitOutcomeUnknownError()
+    const harness = createHarness(() => toModelStream([
+      { type: 'text_delta', delta: '结果未知' },
+      { type: 'response_completed', finishReason: 'stop' },
+    ]))
+    harness.recorder.completeRunCommitError = outcomeUnknown
+
+    const events: AgentRuntimeEvent[] = []
+    let caught: unknown
+
+    try {
+      for await (const event of harness.run())
+        events.push(event)
+    }
+    catch (error) {
+      caught = error
+    }
+
+    assert.ok(caught instanceof AgentRunTerminalizationError)
+    assert.equal(events.at(-1)?.type, 'run_failed')
+    assert.match(
+      (events.at(-1) as { message: string }).message,
+      /收口结果未知/,
+    )
+    // DB 终态仍不被伪造：Message 保持 STREAMING，无任何 cleanup。
+    assert.equal(harness.assistantMessage()?.status, MessageStatus.STREAMING)
+    assert.deepEqual(harness.recorder.abortedRunIds, [])
+    assert.deepEqual(harness.recorder.failedRunIds, [])
   })
 })
 

--- a/apps/api/src/agent-runtime/agent-runtime.service.ts
+++ b/apps/api/src/agent-runtime/agent-runtime.service.ts
@@ -20,7 +20,7 @@ import type {
 } from './model-sampling-decision.js'
 import type { SamplingContextPlanSummary } from './sampling-context-planner.js'
 
-import { Inject, Injectable, NotFoundException } from '@nestjs/common'
+import { Inject, Injectable, Logger, NotFoundException } from '@nestjs/common'
 import { MessageRole, MessageStatus } from '../generated/prisma/client.js'
 import { LLMService } from '../llm/llm.service.js'
 import { getModelProfile } from '../llm/model-profiles.js'
@@ -107,6 +107,8 @@ interface TerminalStepMetadata {
 
 @Injectable()
 export class AgentRuntimeService {
+  private readonly logger = new Logger(AgentRuntimeService.name)
+
   constructor(
     @Inject(LLMService)
     private readonly llmService: LLMService,
@@ -139,6 +141,10 @@ export class AgentRuntimeService {
     let content = ''
     let runCancellation: RunCancellation | undefined
     let terminalStepFailure: TerminalStepFailure | undefined
+    // 终态收口是否已由正常完成或 catch 接管。消费者提前 return()（如
+    // for-await break）会让 yield 点以 return 语义恢复、跳过 catch，
+    // 此时只有 finally 有机会兜底收口。
+    let terminalizationHandled = false
     // finalization Step 的最新已知安全 output。一旦模型调用发生过，
     // 无论 replay Abort、Step 启动失败还是终态事务回滚，都用它收口，
     // 已经产生的 attempt 与 usage 不会从审计里消失。
@@ -672,6 +678,7 @@ export class AgentRuntimeService {
         runCancellation.claimCompletion,
       )
       runCancellation.claimCompleted()
+      terminalizationHandled = true
       runCancellation.dispose()
 
       yield {
@@ -685,11 +692,23 @@ export class AgentRuntimeService {
       }
     }
     catch (error) {
+      // catch 一旦接管，终态收口（成功或失败）都由本块负责；finally 的
+      // 兜底只针对 catch 未执行的 return() 路径。约定：本块每条分支都必须
+      // 以「写入 DB 终态」或「向消费者交付终态事件」结束；新增早退 rethrow
+      // 分支会静默失去 finally 兜底，必须自行保证收口。
+      terminalizationHandled = true
+
       if (
         runCancellation?.source === 'completing'
         && error instanceof DatabaseCommitOutcomeUnknownError
       ) {
-        throw new AgentRunTerminalizationError(error, error)
+        yield* this.emitTerminalizationFailure({
+          conversationId: input.conversationId,
+          agentRunId,
+          assistantMessage,
+          runCause: error,
+          terminalizationCause: error,
+        })
       }
 
       if (runCancellation) {
@@ -711,21 +730,22 @@ export class AgentRuntimeService {
             await this.agentRunRecorderService.abortRun(
               agentRunId,
               createTerminalizationDeadline(),
-              assistantMessage
-                ? {
-                    id: assistantMessage.id,
-                    conversationId: input.conversationId,
-                    content,
-                  }
-                : undefined,
+              this.toAssistantMessageSnapshot(
+                assistantMessage,
+                input.conversationId,
+                content,
+              ),
               finalizationClose,
             )
           }
           catch (terminalizationCause) {
-            throw new AgentRunTerminalizationError(
+            yield* this.emitTerminalizationFailure({
+              conversationId: input.conversationId,
+              agentRunId,
+              assistantMessage,
               runCause,
               terminalizationCause,
-            )
+            })
           }
         }
 
@@ -750,22 +770,23 @@ export class AgentRuntimeService {
             agentRunId,
             errorMessage,
             createTerminalizationDeadline(),
-            assistantMessage
-              ? {
-                  id: assistantMessage.id,
-                  conversationId: input.conversationId,
-                  content: content || errorMessage,
-                }
-              : undefined,
+            this.toAssistantMessageSnapshot(
+              assistantMessage,
+              input.conversationId,
+              content || errorMessage,
+            ),
             terminalStepFailure,
             finalizationClose,
           )
         }
         catch (terminalizationCause) {
-          throw new AgentRunTerminalizationError(
+          yield* this.emitTerminalizationFailure({
+            conversationId: input.conversationId,
+            agentRunId,
+            assistantMessage,
             runCause,
             terminalizationCause,
-          )
+          })
         }
       }
 
@@ -781,8 +802,90 @@ export class AgentRuntimeService {
       }
     }
     finally {
+      // 兜底收口：只覆盖消费者提前 return() 的路径（catch 未执行）。
+      // 此时不存在进行中的数据库事务（return 只能发生在 yield 点），
+      // 按用户中断语义收口为 ABORTED，避免 Run / Message 永久 RUNNING / STREAMING。
+      if (!terminalizationHandled && agentRunId) {
+        // 先取消在途模型请求：return() 路径不经过 claimRunTermination，
+        // 不 abort 内部信号的话 provider 流会继续生成 token 直到自然结束。
+        runCancellation?.claimFailure(new Error('流消费者提前终止了本次 Run'))
+
+        try {
+          await this.agentRunRecorderService.abortRun(
+            agentRunId,
+            createTerminalizationDeadline(),
+            this.toAssistantMessageSnapshot(
+              assistantMessage,
+              input.conversationId,
+              content,
+            ),
+            finalizationClose,
+          )
+        }
+        catch (terminalizationCause) {
+          // return 路径上没有消费者能接收异常；从 finally 抛出只会
+          // 变成 return() 调用点的意外拒绝，这里记录后放弃。
+          this.logger.error(
+            `Agent Run ${agentRunId} 兜底收口失败`,
+            terminalizationCause instanceof Error
+              ? terminalizationCause.stack
+              : String(terminalizationCause),
+          )
+        }
+      }
       runCancellation?.dispose()
     }
+  }
+
+  /**
+   * 终态收口失败（含 COMMIT 结果未知）的统一出口：先记服务端日志，再
+   * best-effort 通知流消费者，最后抛出。日志必须在 yield 之前落：消费者
+   * 收到 run_failed 后可能停止拉流（触发 return()），后面的 throw 就永远
+   * 不会执行，这起最需要告警的事故不能只依赖异常传播才可见。
+   */
+  private async* emitTerminalizationFailure(input: {
+    conversationId: string
+    agentRunId: string | undefined
+    assistantMessage: Message | undefined
+    runCause: unknown
+    terminalizationCause: unknown
+  }): AsyncGenerator<AgentRuntimeEvent, never> {
+    this.logger.error(
+      `Agent Run ${input.agentRunId ?? '(未创建)'} 终态收口失败，DB 状态可能停留在非终态`,
+      input.terminalizationCause instanceof Error
+        ? input.terminalizationCause.stack
+        : String(input.terminalizationCause),
+    )
+
+    yield {
+      type: 'run_failed',
+      ...(input.agentRunId ? { runId: input.agentRunId } : {}),
+      conversationId: input.conversationId,
+      ...(input.assistantMessage
+        ? { assistantMessageId: input.assistantMessage.id }
+        : {}),
+      failureReason: 'terminalization_unknown',
+      message: '本轮回答的收口结果未知，请刷新会话查看最终状态。',
+    }
+
+    throw new AgentRunTerminalizationError(
+      input.runCause,
+      input.terminalizationCause,
+    )
+  }
+
+  private toAssistantMessageSnapshot(
+    assistantMessage: Message | undefined,
+    conversationId: string,
+    content: string,
+  ): { id: string, conversationId: string, content: string } | undefined {
+    return assistantMessage
+      ? {
+          id: assistantMessage.id,
+          conversationId,
+          content,
+        }
+      : undefined
   }
 
   private async listRecentChatMessageCandidates(

--- a/apps/api/src/agent-runtime/agent-runtime.types.ts
+++ b/apps/api/src/agent-runtime/agent-runtime.types.ts
@@ -40,7 +40,11 @@ export interface AgentRuntimeRunFailedEvent {
   runId?: string
   conversationId: string
   assistantMessageId?: string
-  failureReason?: 'conversation_not_found'
+  /**
+   * terminalization_unknown：终态收口失败或 COMMIT 结果未知，run 可能实际
+   * 已成功提交；消费者应引导「刷新确认」而不是「重试」，避免重复发送计费。
+   */
+  failureReason?: 'conversation_not_found' | 'terminalization_unknown'
   message: string
 }
 

--- a/apps/api/src/seo/seo.controller.ts
+++ b/apps/api/src/seo/seo.controller.ts
@@ -1,5 +1,5 @@
 import type { ChatStreamEvent } from '@agent/contracts'
-import { Body, Controller, HttpStatus, Inject, Post, Res } from '@nestjs/common'
+import { Body, Controller, HttpStatus, Inject, Logger, Post, Res } from '@nestjs/common'
 
 // DTO classes are required at runtime for Nest decorator metadata.
 // eslint-disable-next-line ts/consistent-type-imports
@@ -19,6 +19,8 @@ interface StreamResponse {
 
 @Controller('seo')
 export class SeoController {
+  private readonly logger = new Logger(SeoController.name)
+
   constructor(
     @Inject(SeoService)
     private readonly seoService: SeoService,
@@ -54,16 +56,27 @@ export class SeoController {
       for await (const event of this.seoService.chatStream(body, {
         signal: abortController.signal,
       })) {
-        if (response.destroyed) {
-          abortController.abort()
-          break
+        // 断连后不能 break：break 会触发 generator.return()，让 runtime 的
+        // yield 点以 return 语义恢复、跳过 catch 收口路径。abort 信号由
+        // 'close' 监听统一触发；这里继续 drain（不再写出），让 runtime 走
+        // 正常 ABORTED 收口并产出 run_aborted 审计事件。runtime 的 finally
+        // 兜底只保障其他消费者 return() 时的 DB 终态，不能替代 drain。
+        if (!response.destroyed) {
+          writeNdjsonEvent(response, event)
         }
-
-        writeNdjsonEvent(response, event)
       }
     }
+    catch (error) {
+      // NDJSON 流已开始写出，异常不能再交给全局异常过滤器（会对已结束的
+      // response 再写 JSON）；runtime 在抛出终态化异常前已 best-effort
+      // 向流写入 error 事件，这里只记录。
+      this.logger.error(
+        'SEO chat 流式收口异常',
+        error instanceof Error ? error.stack : String(error),
+      )
+    }
     finally {
-      if (!response.destroyed) {
+      if (!response.destroyed && !response.writableEnded) {
         response.end()
       }
     }

--- a/apps/api/src/seo/seo.service.ts
+++ b/apps/api/src/seo/seo.service.ts
@@ -46,6 +46,12 @@ export class SeoService {
             throw new NotFoundException('会话不存在或已被删除')
           }
 
+          if (event.failureReason === 'terminalization_unknown') {
+            // 收口结果未知：run 可能实际已成功提交，不能引导用户重试，
+            // 否则会造成重复提问与重复计费。
+            throw new ServiceUnavailableException(event.message)
+          }
+
           throw new ServiceUnavailableException(
             '模型服务暂时没有返回结果，请稍后重试。',
           )


### PR DESCRIPTION
Closes #72

## 改动概述

修复源码审计发现的两个终态一致性缺陷（C1 高危 + C9 中危）：

1. **C1 根因修复（runtime finally 兜底）**：消费者提前 `return()`（如 for-await break）会让 yield 点以 return 语义恢复、跳过 catch，`abortRun` 永不执行。现在 finally 检测"未终态化即退出"，先 abort 内部信号取消在途模型请求（防 provider token 泄漏），再 best-effort 收口为 ABORTED。
2. **Controller 断连改为 drain**：不再 break，让 runtime 走正常 ABORTED 收口并产出 `run_aborted` 审计事件；runtime 兜底只保障其他消费者的 DB 终态。
3. **C9 终态化失败不再静默截断流**：统一经 `emitTerminalizationFailure`——先落服务端 error 日志（消费者可能收到事件后停止拉流，throw 不可依赖），再向流写入带 `failureReason: 'terminalization_unknown'` 的 `run_failed` 事件，最后抛出；controller 捕获流开始后的异常，防止全局异常过滤器 write-after-end。
4. **outcome-unknown 不引导重试**：非流式 `chat()` 对 `terminalization_unknown` 返回"请刷新会话查看最终状态"，避免 run 可能已 COMPLETED 时引导用户重复提问、重复计费。

## /code-review findings 处理（high 级审查，24 候选 → 13 有效 → 2 REFUTED）

| Finding | 严重度 | 处理 |
| --- | --- | --- |
| yield 后 throw 依赖消费者继续拉流，终态化事故可能零日志 | high | ✅ 已修：日志先于 yield 落地（emitTerminalizationFailure） |
| COMMIT 结果未知被伪装成普通失败，chat() 引导重试 → 重复计费 | high | ✅ 已修：新增 terminalization_unknown failureReason + chat() 分支 |
| finally 兜底记 ABORTED 但不取消在途模型请求（token 泄漏） | high | ✅ 已修：兜底先 claimFailure abort 内部信号；测试断言 signal.aborted |
| drain 使断连 handler 等待 abortRun 完成（DB 降级时堆积） | medium | 📝 已知代价：受 TERMINALIZATION_DEADLINE_MS=5s 上限约束，接受 |
| abortRun 无 reason 元数据，consumer-return 与用户取消审计不可区分 | medium-low | 📝 不修：需改 recorder schema，超出本 Issue 范围，记录待议 |
| 兜底 abortRun 与 catch 路径逐字重复、快照三份拷贝 | cleanup | ✅ 已修：抽取 emitTerminalizationFailure / toAssistantMessageSnapshot |
| controller 循环内 abort 与 close 监听职责重复 | cleanup | ✅ 已修：abort 单点归 close 监听，循环体收敛为写出守卫单行 |
| 注释与两层机制分工矛盾 | cleanup | ✅ 已修：注释明确 drain（审计事件）与兜底（DB 终态）分工 |
| terminalizationHandled 双语义依赖隐式契约 | cleanup | ✅ 已修：catch 顶部注释显式声明分支收口契约 |

## 验证

```
test:model-stream   69 pass / 0 fail（含 2 个新增回归测试 + 1 个既有测试按新契约更新）
test:tool-loop      56 pass / 0 fail
test:seo-service    31 pass / 0 fail
test:grounding     168 pass / 0 fail
typecheck / lint    PASS
```

实施状态：已实现 / 验收状态：待验收

🤖 Generated with [Claude Code](https://claude.com/claude-code)