### PR TITLE
fix(grounding): finalization 将模型不服从纳入 correction 路径

### DIFF
--- a/apps/api/src/admin-runs/admin-retrieval-inspector.projector.ts
+++ b/apps/api/src/admin-runs/admin-retrieval-inspector.projector.ts
@@ -119,6 +119,7 @@ const REJECTION_CODES: AdminGroundedAnswerRejectionCode[] = [
   'malformed_json',
   'outcome_not_allowed_for_availability',
   'schema_invalid',
+  'submission_missing',
   'unknown_citation_key',
 ]
 const SAMPLING_FAILURES: AdminGroundedFinalizationSamplingFailure[] = [

--- a/apps/api/src/agent-runtime/grounding/grounded-answer.contract.ts
+++ b/apps/api/src/agent-runtime/grounding/grounded-answer.contract.ts
@@ -79,6 +79,8 @@ export type GroundedAnswerRejectionCode
     | 'malformed_json'
     | 'outcome_not_allowed_for_availability'
     | 'schema_invalid'
+    // 模型以纯文本正常 stop 结束、未调用提交工具：模型不服从，消耗 correction。
+    | 'submission_missing'
     | 'unknown_citation_key'
 
 export class GroundedAnswerRejectedError extends Error {

--- a/apps/api/src/agent-runtime/grounding/grounded-answer.finalizer.test.ts
+++ b/apps/api/src/agent-runtime/grounding/grounded-answer.finalizer.test.ts
@@ -7,6 +7,7 @@ import assert from 'node:assert/strict'
 import { describe, it } from 'node:test'
 
 import {
+  GroundedFinalizationFailedError,
   GroundedFinalizationSamplingError,
   runGroundedFinalization,
 } from './grounded-answer.finalizer.js'
@@ -211,5 +212,121 @@ describe('runGroundedFinalization post-sampling 可用性复核', () => {
     assert.equal(attempts.length, 1)
     assert.equal(attempts[0]?.ok, true)
     assert.equal(attempts[0]?.submittedCitationKeyCount, 1)
+  })
+})
+
+describe('runGroundedFinalization 模型不服从（正常 stop、未调用提交工具）', () => {
+  function plainTextStream(): ModelStreamEvent[] {
+    return [
+      { type: 'text_delta', delta: '我直接用普通文本回答了。' },
+      { type: 'usage', usage: { inputTokens: 5, outputTokens: 3, totalTokens: 8 } },
+      { type: 'response_completed', finishReason: 'stop' },
+    ]
+  }
+
+  it('首次不服从消耗 correction，第二次成功提交则正常返回', async () => {
+    const registry = createRegistry()
+    const citationKey = registry.list()[0]!.citationKey
+    const attempts: GroundedFinalizationAttemptSummary[] = []
+    const systemPrompts: string[] = []
+    let sampleCount = 0
+
+    const result = await runGroundedFinalization({
+      draft: '草稿',
+      registry,
+      assertAvailable: () => {},
+      onAttempt: summary => attempts.push(summary),
+      sample: (items) => {
+        sampleCount += 1
+        systemPrompts.push((items[0] as { content: string }).content)
+
+        return sampleCount === 1
+          ? toModelStream(plainTextStream())
+          : toModelStream(submissionStream([citationKey]))
+      },
+    })
+
+    assert.equal(result.validated.grounding.outcome, 'answered')
+    assert.equal(sampleCount, 2)
+    assert.equal(attempts.length, 2)
+    // 不服从是「模型说错了」：记 rejectionCode，不是 samplingFailure。
+    assert.equal(attempts[0]?.ok, false)
+    assert.equal(attempts[0]?.rejectionCode, 'submission_missing')
+    assert.equal(attempts[0]?.samplingFailure, undefined)
+    // 真实发生的调用用量不丢。
+    assert.deepEqual(attempts[0]?.usage, {
+      inputTokens: 5,
+      outputTokens: 3,
+      totalTokens: 8,
+    })
+    assert.equal(attempts[1]?.ok, true)
+    // correction prompt 必须点名「没有调用提交工具」而不是泛化的校验失败。
+    assert.match(systemPrompts[1] ?? '', /没有调用提交工具/)
+  })
+
+  it('correction 后仍不服从时按校验失败收口，保留两条 attempt', async () => {
+    const registry = createRegistry()
+    const attempts: GroundedFinalizationAttemptSummary[] = []
+    let sampleCount = 0
+
+    await assert.rejects(
+      runGroundedFinalization({
+        draft: '草稿',
+        registry,
+        assertAvailable: () => {},
+        onAttempt: summary => attempts.push(summary),
+        sample: () => {
+          sampleCount += 1
+          return toModelStream(plainTextStream())
+        },
+      }),
+      (error: unknown) => {
+        assert.ok(error instanceof GroundedFinalizationFailedError)
+        assert.equal(error.rejectionCode, 'submission_missing')
+        assert.equal(error.attempts.length, 2)
+        return true
+      },
+    )
+
+    assert.equal(sampleCount, 2)
+    assert.deepEqual(
+      attempts.map(attempt => attempt.rejectionCode),
+      ['submission_missing', 'submission_missing'],
+    )
+  })
+
+  it('stop 但存在提交调用时仍按采样故障收口，不消耗 correction', async () => {
+    const registry = createRegistry()
+    const citationKey = registry.list()[0]!.citationKey
+    const attempts: GroundedFinalizationAttemptSummary[] = []
+    let sampleCount = 0
+
+    await assert.rejects(
+      runGroundedFinalization({
+        draft: '草稿',
+        registry,
+        assertAvailable: () => {},
+        onAttempt: summary => attempts.push(summary),
+        sample: () => {
+          sampleCount += 1
+
+          const events = submissionStream([citationKey]).map(event => (
+            event.type === 'response_completed'
+              ? { ...event, finishReason: 'stop' as const }
+              : event
+          ))
+
+          return toModelStream(events)
+        },
+      }),
+      (error: unknown) => {
+        assert.ok(error instanceof GroundedFinalizationSamplingError)
+        assert.equal(error.failure, 'unexpected_finish_reason')
+        return true
+      },
+    )
+
+    assert.equal(sampleCount, 1)
+    assert.equal(attempts[0]?.samplingFailure, 'unexpected_finish_reason')
   })
 })

--- a/apps/api/src/agent-runtime/grounding/grounded-answer.finalizer.ts
+++ b/apps/api/src/agent-runtime/grounding/grounded-answer.finalizer.ts
@@ -61,7 +61,11 @@ export class GroundedFinalizationFailedError extends Error {
     readonly rejectionCode: GroundedAnswerRejectionCode,
     readonly attempts: GroundedFinalizationAttemptSummary[] = [],
   ) {
-    super('本轮回答未能通过引用校验，已安全放弃。')
+    // submission_missing 时并没有跑过引用校验（模型根本没提交），
+    // 用户可见文案不能声称「未通过校验」。
+    super(rejectionCode === 'submission_missing'
+      ? '本轮回答未能完成结构化提交，已安全放弃。'
+      : '本轮回答未能通过引用校验，已安全放弃。')
     this.name = 'GroundedFinalizationFailedError'
   }
 }
@@ -118,9 +122,10 @@ export interface RunGroundedFinalizationInput {
 /**
  * 执行 finalization sampling，直到得到通过校验的终态输出或用尽 attempt 预算。
  *
- * 只有结构 / 引用校验失败才会消耗 correction 机会；Provider 流不完整、错误的
- * finish reason、连接异常、超时和外部中断直接向上抛出，避免把「服务故障」
- * 伪装成「模型说错了」或「知识库无答案」。
+ * 消耗 correction 的只有两类「模型说错了」：结构 / 引用校验失败，以及模型
+ * 以纯文本正常 stop 结束而未调用提交工具（submission_missing）。Provider 流
+ * 不完整、异常 finish reason、连接异常、超时和外部中断直接向上抛出，避免把
+ * 「服务故障」伪装成「模型说错了」或「知识库无答案」。
  *
  * @throws GroundedFinalizationFailedError attempt 用尽后仍未通过校验。
  * @throws GroundedFinalizationSamplingError 终态 sampling 未能完整结束。
@@ -152,7 +157,7 @@ export async function runGroundedFinalization(
     // 从这一行起，一次真实模型调用已经发起：无论后面怎么失败，attempt 事实都必须留下。
     const sampling = await consumeFinalizationSampling(input.sample(items))
 
-    if (!sampling.ok) {
+    if (!sampling.ok && sampling.kind === 'sampling_failure') {
       recordAttempt({
         attempt,
         ok: false,
@@ -171,6 +176,13 @@ export async function runGroundedFinalization(
       // 这次复核必须留在 try 内：模型流已经完整结束、usage 也可能已经收到，
       // 若此刻 Abort 或 deadline 生效，仍然要先把 attempt 事实记下来再抛出。
       input.assertAvailable()
+
+      if (!sampling.ok) {
+        // 模型不服从（正常 stop、未调用提交工具）：复用「模型说错了」的
+        // rejection 路径消耗 correction，而不是把它伪装成服务故障。
+        throw new GroundedAnswerRejectedError('submission_missing')
+      }
+
       submitted = parseSubmitGroundedAnswerInput(sampling.rawArgumentsJson)
 
       const validated = validateGroundedAnswer(submitted, input.registry)
@@ -265,7 +277,9 @@ export function buildFinalizationInput(
       ? [
           '',
           '## 上一次提交结果',
-          `上一次提交未通过服务端校验，原因类别：${options.rejectionCode}。请修正后重新提交，这是最后一次机会。`,
+          options.rejectionCode === 'submission_missing'
+            ? `上一次你直接输出了普通文本，没有调用提交工具。必须调用 ${SUBMIT_GROUNDED_ANSWER_TOOL_NAME} 工具提交结果，不要输出任何普通文本，这是最后一次机会。`
+            : `上一次提交未通过服务端校验，原因类别：${options.rejectionCode}。请修正后重新提交，这是最后一次机会。`,
         ]
       : []),
   ].join('\n')
@@ -298,7 +312,15 @@ type FinalizationSamplingOutcome
   = | { ok: true, rawArgumentsJson: string, usage: ModelUsage | null }
     | {
       ok: false
+      kind: 'sampling_failure'
       failure: GroundedFinalizationSamplingFailure
+      usage: ModelUsage | null
+    }
+    // 流本身完整（正常 stop 结束），但模型没有调用提交工具：
+    // 这是「模型不服从」，不是 Provider 故障，按校验失败语义消耗 correction。
+    | {
+      ok: false
+      kind: 'model_noncompliance'
       usage: ModelUsage | null
     }
 
@@ -314,9 +336,10 @@ type FinalizationSamplingOutcome
  * - `finishReason === 'tool_calls'`；
  * - `response_completed` 之后没有额外事件。
  *
- * 任何一条不满足都返回 `{ ok: false, failure, usage }`：这是采样故障，不是模型
- * 内容错误，因此不消耗 correction 预算；但它仍然是一次真实模型调用，用量与
- * attempt 事实必须原样交回给调用方。
+ * 任何一条不满足都返回失败分支。其中「正常 stop 结束且无提交」单独归类为
+ * `model_noncompliance`（模型不服从，由调用方按 correction 语义处理）；其余
+ * 是采样故障，不消耗 correction 预算。两类都是真实模型调用，用量与 attempt
+ * 事实必须原样交回给调用方。
  */
 async function consumeFinalizationSampling(
   events: AsyncIterable<ModelStreamEvent>,
@@ -327,7 +350,12 @@ async function consumeFinalizationSampling(
   let completed = false
   const failed = (
     failure: GroundedFinalizationSamplingFailure,
-  ): FinalizationSamplingOutcome => ({ ok: false, failure, usage })
+  ): FinalizationSamplingOutcome => ({
+    ok: false,
+    kind: 'sampling_failure',
+    failure,
+    usage,
+  })
 
   try {
     for await (const event of events) {
@@ -370,6 +398,11 @@ async function consumeFinalizationSampling(
 
   if (!completed)
     return failed('missing_response_completed')
+
+  // 正常 stop 结束且没有任何提交：典型的模型不服从（直接输出了普通文本），
+  // 与 Provider 故障区分开，交给调用方按 correction 语义处理。
+  if (finishReason === 'stop' && rawArgumentsJson === undefined)
+    return { ok: false, kind: 'model_noncompliance', usage }
 
   if (finishReason !== 'tool_calls')
     return failed('unexpected_finish_reason')

--- a/apps/api/src/agent-runtime/grounding/grounded-answer.runtime.test.ts
+++ b/apps/api/src/agent-runtime/grounding/grounded-answer.runtime.test.ts
@@ -416,7 +416,7 @@ describe('Grounded finalization 路径', () => {
     assert.equal(output.rejectionCode, 'citation_required_for_answered')
   })
 
-  it('finalization 改输出自由文本时按采样故障收口，不伪装 zero-hit', async () => {
+  it('finalization 改输出自由文本时消耗 correction，重试仍不服从则失败收口', async () => {
     const plainText = () => toModelStream([
       { type: 'text_delta', delta: '模型改成了自由文本' },
       { type: 'response_completed', finishReason: 'stop' },
@@ -452,11 +452,14 @@ describe('Grounded finalization 路径', () => {
     )
     const output = step?.output as Record<string, unknown>
 
-    // 模型没有提交终态调用属于采样故障，不消耗 correction，也不会被记成 schema 问题。
-    assert.equal(output.failureReason, 'sampling_incomplete')
-    assert.equal(output.samplingFailure, 'unexpected_finish_reason')
-    assert.equal(output.rejectionCode, undefined)
-    assert.equal(harness.llmCalls.length, 3)
+    // 正常 stop 且没有提交调用是「模型不服从」：消耗 correction 重试一次；
+    // 两次都不服从时按校验失败收口，审计里是 rejectionCode 而非采样故障。
+    assert.equal(output.failureReason, 'validation_failed')
+    assert.equal(output.rejectionCode, 'submission_missing')
+    assert.equal(output.samplingFailure, undefined)
+    assert.equal(output.attemptCount, 2)
+    // action 2 次 + finalization 首次 + correction 1 次。
+    assert.equal(harness.llmCalls.length, 4)
   })
 
   it('eligible Tool 失败时进入 unavailable，并按 insufficient 收口', async () => {

--- a/packages/contracts/src/admin-run.ts
+++ b/packages/contracts/src/admin-run.ts
@@ -210,6 +210,8 @@ export type AdminGroundedAnswerRejectionCode
     | 'malformed_json'
     | 'outcome_not_allowed_for_availability'
     | 'schema_invalid'
+    // 模型以纯文本正常 stop 结束、未调用提交工具（模型不服从）。
+    | 'submission_missing'
     | 'unknown_citation_key'
 
 /** 终态采样流未完整结束的安全类别；与「模型说错了」是两类问题。 */


### PR DESCRIPTION
Closes #74

## 改动概述

修复审计发现 C4：finalization 阶段模型以纯文本正常 `stop` 结束（未调用 `submit_grounded_answer`）此前被归类为采样故障 `unexpected_finish_reason`，整轮直接 FAILED、correction 预算形同虚设。现在：

1. `consumeFinalizationSampling` 将「正常 stop 且无提交」单独归类为 `model_noncompliance`，与 Provider 故障分离；
2. 不服从复用既有 `GroundedAnswerRejectedError` rejection 路径（新 rejection code `submission_missing`），消耗 correction 重试一次；correction prompt 明确点名"没有调用提交工具"；
3. correction 后仍不服从 → `GroundedFinalizationFailedError('submission_missing')`，文案改为"未能完成结构化提交"（不再错误声称"未通过引用校验"）；
4. 契约同步：`GroundedAnswerRejectionCode` / `AdminGroundedAnswerRejectionCode` / projector 允许列表三处新增 `submission_missing`（编译期漂移守卫强制）。

带提交调用但 finishReason 异常、length/content_filter/unknown 等仍维持采样故障语义（Issue 澄清决策）。

## /code-review findings 处理（high 级）

| Finding | 处理 |
| --- | --- |
| 失败文案对 submission_missing 路径声称"未通过引用校验"（CONFIRMED） | ✅ 已修：按 rejectionCode 区分文案 |
| noncompliance 分支重复 recordAttempt 簿记（PLAUSIBLE cleanup） | ✅ 已修：改走既有 rejection catch 路径复用记录逻辑 |
| 非标准 provider finishReason 归一化为 unknown 时绕过 correction（PLAUSIBLE） | 📝 不修：与 Issue #74 澄清决策一致（非 stop 维持采样故障语义）；当前 active provider（DeepSeek）返回标准 stop；换 provider 时再议 |

## 验证

```
test:grounding    171 pass / 0 fail（+3 新单测：不服从→correction 成功 /
                  两次不服从→失败收口 / stop+有提交仍为采样故障）
test:admin-runs   139 pass / 0 fail
contracts build / api & admin typecheck / lint   PASS
```

实施状态：已实现 / 验收状态：待验收

🤖 Generated with [Claude Code](https://claude.com/claude-code)