### PR TITLE
fix(web): 流消费边界修复——出错中止后端、stale 快照防护与卸载清理

### DIFF
--- a/apps/web/src/api/seo.stream.test.ts
+++ b/apps/web/src/api/seo.stream.test.ts
@@ -331,6 +331,66 @@ describe('streamChatWithSeoAgent', () => {
     }
   })
 
+  it('解析失败或消费者提前退出时取消底层流（关闭 HTTP 连接）', async () => {
+    const originalFetch = globalThis.fetch
+    let cancelCount = 0
+    const createOpenResponse = (lines: string[]): Response => {
+      const bytes = new TextEncoder().encode(`${lines.join('\n')}\n`)
+      const body = new ReadableStream<Uint8Array>({
+        start(controller) {
+          controller.enqueue(bytes)
+          // 刻意不 close：模拟仍在进行中的流，只有 cancel 能关闭连接。
+          // 若实现只 releaseLock 不 cancel，后端会继续采样计费。
+        },
+        cancel() {
+          cancelCount += 1
+        },
+      })
+
+      return new Response(body, {
+        status: 200,
+        headers: { 'Content-Type': 'application/x-ndjson' },
+      })
+    }
+
+    try {
+      // 场景一：某行 JSON 损坏 → 抛错，且底层流必须被 cancel。
+      globalThis.fetch = (async () => createOpenResponse([
+        JSON.stringify(LEGACY_EVENTS[0]),
+        '{ broken',
+      ])) as typeof globalThis.fetch
+
+      await assert.rejects(
+        collect(streamChatWithSeoAgent({
+          conversationId: 'conversation-1',
+          message: '问题',
+        })),
+        /JSON 解析失败/,
+      )
+      assert.equal(cancelCount, 1)
+
+      // 场景二：消费者提前 break（触发 generator.return()）→ 同样 cancel。
+      globalThis.fetch = (async () => createOpenResponse([
+        JSON.stringify(LEGACY_EVENTS[0]),
+        JSON.stringify(LEGACY_EVENTS[1]),
+      ])) as typeof globalThis.fetch
+
+      const stream = streamChatWithSeoAgent({
+        conversationId: 'conversation-1',
+        message: '问题',
+      })
+      const first = await stream.next()
+
+      assert.equal((first.value as ChatStreamEvent | undefined)?.type, 'start')
+      // for-await break 的等价语义：显式触发 generator.return()。
+      await stream.return(undefined)
+      assert.equal(cancelCount, 2)
+    }
+    finally {
+      globalThis.fetch = originalFetch
+    }
+  })
+
   it('HTTP 失败时抛出后端提供的安全错误消息', async () => {
     const restoreFetch = stubFetch('', {
       status: 503,

--- a/apps/web/src/api/seo.ts
+++ b/apps/web/src/api/seo.ts
@@ -74,7 +74,18 @@ async function* parseChatStreamEvents(
     }
   }
   finally {
-    reader.releaseLock()
+    // 解析异常或消费者提前退出时必须 cancel：只 releaseLock 不会关闭底层
+    // HTTP 连接，后端会继续采样、计费并把消息持久化为 COMPLETED，与 UI
+    // 的失败状态背离。流已正常读完时 cancel 是 no-op。
+    try {
+      await reader.cancel()
+    }
+    catch {
+      // 连接可能已被 abort；取消失败无需处理。
+    }
+    finally {
+      reader.releaseLock()
+    }
   }
 }
 

--- a/apps/web/src/hooks/useSeoWorkspace.ts
+++ b/apps/web/src/hooks/useSeoWorkspace.ts
@@ -13,7 +13,7 @@ import type {
 } from '../types/seo'
 
 import { isAxiosError } from 'axios'
-import { computed, onMounted, ref } from 'vue'
+import { computed, onMounted, onUnmounted, ref } from 'vue'
 import { useI18n } from 'vue-i18n'
 
 import {
@@ -71,7 +71,19 @@ export function useSeoWorkspace() {
   let activeStreamRequestId: string | null = null
   let activeStreamConversationId: string | null = null
   let activeStreamAssistantMessageId: string | null = null
+  let isUnmounted = false
+  // start 事件前 abort 的占位消息：同一次请求只允许创建一条（stopGeneration
+  // 与 catch 的 abort 分支会先后进入 markGenerationAborted）；若排队中的
+  // start 事件随后到达，真实助手消息会取代它，占位必须移除。
+  let abortedPlaceholder: {
+    requestId: string | null
+    conversationId: string
+    messageId: string
+  } | null = null
   const conversationMessagesCache = new Map<string, ConversationMessage[]>()
+  // 每次本地消息变更（流事件、乐观更新）都会推进版本号；消息加载用它
+  // 识别「fetch 期间本地已被流终态更新」的过期快照。
+  const conversationMessagesVersion = new Map<string, number>()
 
   const messageCharacterCount = computed(() => message.value.length)
 
@@ -103,6 +115,17 @@ export function useSeoWorkspace() {
 
   onMounted(() => {
     void initializeWorkspace()
+  })
+
+  onUnmounted(() => {
+    // 与 stopGeneration 语义一致：离开工作区即中止进行中的流，
+    // 不做跨页面恢复；同时清理提示消息定时器。isUnmounted 阻止
+    // abort 之后才落地的异步续体再更新状态或重建定时器。
+    isUnmounted = true
+    activeAbortController?.abort()
+
+    if (messageTimer !== undefined)
+      window.clearTimeout(messageTimer)
   })
 
   async function initializeWorkspace() {
@@ -149,6 +172,7 @@ export function useSeoWorkspace() {
 
       await deleteConversation(conversationId)
       conversationMessagesCache.delete(conversationId)
+      conversationMessagesVersion.delete(conversationId)
 
       const nextConversations = conversations.value.filter(item => item.id !== conversationId)
 
@@ -245,6 +269,9 @@ export function useSeoWorkspace() {
         if (event.type === 'start') {
           assistantMessageId = event.assistantMessageId
           activeStreamAssistantMessageId = event.assistantMessageId
+          // stop 先于排队中的 start 到达时会先建 ABORTED 占位；真实助手
+          // 消息从这里开始接管，移除占位避免出现两条中止气泡。
+          removeAbortedPlaceholderForRequest(streamRequestId)
           handleStreamStartEvent(event, pendingMessage)
           message.value = ''
           status.value = 'generating'
@@ -292,6 +319,15 @@ export function useSeoWorkspace() {
       }
     }
     catch (error) {
+      // 组件已卸载：不再更新任何状态，也不发无人消费的刷新请求。
+      if (isUnmounted)
+        return
+
+      // done/error/aborted 已处理完终态：EOF 前的尾部异常（连接重置、
+      // 结尾残行解析失败）不能把已完成的回答翻成 FAILED。
+      if (hasFinalStreamEvent)
+        return
+
       if (isAbortError(error)) {
         markGenerationAborted(targetConversationId, assistantMessageId, streamRequestId)
         await refreshConversationList()
@@ -408,6 +444,7 @@ export function useSeoWorkspace() {
 
   async function loadMessagesForConversation(conversationId: string) {
     const runId = ++messageLoadRunId
+    const versionBeforeLoad = conversationMessagesVersion.get(conversationId) ?? 0
 
     try {
       isLoadingMessages.value = true
@@ -418,7 +455,13 @@ export function useSeoWorkspace() {
       if (runId !== messageLoadRunId || conversationId !== activeConversationId.value)
         return
 
-      if (activeStreamConversationId === conversationId) {
+      // 两种情况都保留本地事实、丢弃服务端快照：该会话仍在流式中，或
+      // fetch 期间本地消息已被流事件更新过（典型：切走再切回后 done 先到，
+      // 服务端快照是流终态之前的旧数据）。
+      const versionChanged
+        = (conversationMessagesVersion.get(conversationId) ?? 0) !== versionBeforeLoad
+
+      if (activeStreamConversationId === conversationId || versionChanged) {
         const cachedMessages = conversationMessagesCache.get(conversationId)
 
         if (cachedMessages)
@@ -560,8 +603,15 @@ export function useSeoWorkspace() {
     if (assistantMessageId) {
       markAssistantMessageAborted(conversationId, assistantMessageId)
     }
-    else {
-      upsertMessageInConversation(createAbortedAssistantMessage(conversationId))
+    else if (abortedPlaceholder?.requestId !== streamRequestId) {
+      const placeholder = createAbortedAssistantMessage(conversationId)
+
+      abortedPlaceholder = {
+        requestId: streamRequestId,
+        conversationId,
+        messageId: placeholder.id,
+      }
+      upsertMessageInConversation(placeholder)
     }
 
     if (shouldUpdateWorkspaceStatus) {
@@ -569,6 +619,19 @@ export function useSeoWorkspace() {
       setStatusAfterStreamCompletion(conversationId, 'aborted')
       clearActiveStreamState(streamRequestId)
     }
+  }
+
+  function removeAbortedPlaceholderForRequest(streamRequestId: string) {
+    if (!abortedPlaceholder || abortedPlaceholder.requestId !== streamRequestId)
+      return
+
+    const { conversationId, messageId } = abortedPlaceholder
+
+    abortedPlaceholder = null
+    setMessagesForConversation(
+      conversationId,
+      getMessagesForConversation(conversationId).filter(item => item.id !== messageId),
+    )
   }
 
   function markAssistantMessageAborted(
@@ -689,6 +752,10 @@ export function useSeoWorkspace() {
   ) {
     const sortedMessages = [...nextMessages].sort(compareMessagesByCreatedAt)
 
+    conversationMessagesVersion.set(
+      conversationId,
+      (conversationMessagesVersion.get(conversationId) ?? 0) + 1,
+    )
     cacheMessagesForConversation(conversationId, sortedMessages)
 
     if (conversationId === activeConversationId.value)
@@ -935,6 +1002,10 @@ export function useSeoWorkspace() {
   }
 
   function showMessage(text: string, type: AppMessageType = 'info') {
+    // 卸载后不再重建定时器：清理钩子已经跑过，新建的 timer 无人回收。
+    if (isUnmounted)
+      return
+
     if (messageTimer !== undefined) {
       window.clearTimeout(messageTimer)
     }


### PR DESCRIPTION
Closes #73

## 改动概述

修复源码审计在 web 流消费层发现的 4 个边界缺陷（C2 / C3 / 双 ABORTED 占位 / 无卸载清理）：

1. **C2 出错不中止后端**：`parseChatStreamEvents` 的 finally 现在 `reader.cancel()`（正常读完为 no-op）——任何解析异常或消费者提前退出都会关闭底层 HTTP 连接，后端感知断连立即 abort，不再空跑采样并把消息持久化成与 UI 背离的 COMPLETED。
2. **C3 stale-read race**：为每个会话维护本地消息版本号，`loadMessagesForConversation` 在 fetch 返回后发现版本已被流事件推进则丢弃过期服务端快照，修复"流式中切走再切回 → 永久 generating"。
3. **双 ABORTED 占位**：start 前 abort 的占位消息按 streamRequestId 幂等；排队中的 start 事件随后到达时移除占位，由真实助手消息接管（避免两条中止气泡）。
4. **卸载清理**：新增 `onUnmounted`——中止进行中的流、清理提示定时器；`isUnmounted` 阻断卸载后才落地的异步续体（刷新请求、重建 timer）。

## /code-review findings 处理（high 级，8 候选 → 5 有效 3 REFUTED）

| Finding | 处理 |
| --- | --- |
| done 后的尾部异常把 COMPLETED 翻成 FAILED（PLAUSIBLE） | ✅ 已修：catch 增加 hasFinalStreamEvent 守卫 |
| 排队 start 与 stop 竞态留下孤儿占位气泡（PLAUSIBLE） | ✅ 已修：start 到达时移除本请求的占位 |
| 卸载后异步续体发无效请求并重建 timer（CONFIRMED） | ✅ 已修：isUnmounted 守卫 catch 与 showMessage |
| catch 内 abort() 与 api 层 cancel 职责重复（CONFIRMED cleanup） | ✅ 已修：移除冗余 abort，连接终止单点归 api 层 |
| 两段 stale-restore 代码逐字重复（CONFIRMED cleanup） | ✅ 已修：合并为单一守卫分支 |

## 验证

```
web test（含 seo.stream.test.ts）  43 pass / 0 fail
typecheck / lint / build           PASS
```

实施状态：已实现 / 验收状态：待验收

🤖 Generated with [Claude Code](https://claude.com/claude-code)