### PR TITLE
fix(retrieval): quality-v2 standalone lexical 与 hybrid 内部实现对齐

### DIFF
--- a/apps/api/src/retrieval/evaluation/article-retrieval-quality-v2.cli.ts
+++ b/apps/api/src/retrieval/evaluation/article-retrieval-quality-v2.cli.ts
@@ -17,7 +17,6 @@ import { resolveEmbeddingRuntimeConfig } from '../../embeddings/embedding-provid
 import { GeminiEmbeddingProvider } from '../../embeddings/gemini-embedding.provider.js'
 import {
   DatabaseOperationDeadlineExceededError,
-  PrismaService,
 } from '../../prisma/prisma.service.js'
 import { HybridArticleRetriever } from '../hybrid-article-retriever.js'
 import { LexicalArticleRetriever } from '../lexical-article-retriever.js'
@@ -25,7 +24,6 @@ import {
   createArticleRetrievalPool,
   PostgresArticleRetrievalRepository,
 } from '../postgres-article-retrieval.repository.js'
-import { PrismaArticleRetriever } from '../prisma-article-retriever.js'
 import { VectorArticleRetriever } from '../vector-article-retriever.js'
 import { evaluateArticleRetrievalQualityV2 } from './article-retrieval-quality-v2.js'
 
@@ -123,26 +121,15 @@ async function createProductionRuntime(): Promise<RetrievalQualityRuntime> {
     )
   }
 
-  process.env.DATABASE_URL = connectionString
   const provider = new GeminiEmbeddingProvider(
     resolveEmbeddingRuntimeConfig(process.env),
   )
-  const prisma = new PrismaService()
   const pool = createArticleRetrievalPool(connectionString)
-
-  try {
-    await prisma.$connect()
-  }
-  catch (error) {
-    await Promise.all([
-      prisma.$disconnect().catch(() => {}),
-      pool.end().catch(() => {}),
-    ])
-    throw error
-  }
-
   const repository = new PostgresArticleRetrievalRepository(pool)
-  const lexicalRetriever = new PrismaArticleRetriever(prisma)
+  // standalone lexical 基线必须与 hybrid 内部 lexical 通道同一实现
+  // （postgres_lexical_ranked@1）：对照实验的基线与对照组组件不同源时，
+  // hybrid 的增益无法归因（旧报告用 prisma_lexical@1，口径不可直接对比）。
+  const lexicalRetriever = new LexicalArticleRetriever(repository)
 
   return {
     strategies: {
@@ -177,10 +164,7 @@ async function createProductionRuntime(): Promise<RetrievalQualityRuntime> {
       ),
     },
     close: async () => {
-      await Promise.all([
-        prisma.$disconnect(),
-        pool.end(),
-      ])
+      await pool.end()
     },
   }
 }


### PR DESCRIPTION
Closes #75

## 改动概述

修复审计发现 C7（评测方法论陷阱）：quality-v2 的 standalone lexical 基线此前用 `PrismaArticleRetriever`（`prisma_lexical@1`，按 `updatedAt desc` 排序），而 hybrid 内部用 `LexicalArticleRetriever`（`postgres_lexical_ranked@1`，相关性分级排序）——"hybrid 比 lexical 好 X"的部分增益实际来自更强的 lexical 排序而非向量融合。

现在 standalone 基线与 hybrid 内部同源（`LexicalArticleRetriever` + 同一 repository）。报告中的 strategy 标识自动跟随为 `postgres_lexical_ranked@1`，新旧报告口径不可直接对比（注释注明）。

## /code-review findings 处理（medium 级）

| Finding | 处理 |
| --- | --- |
| PrismaService 在该 CLI 中失去全部消费者（CONFIRMED cleanup） | ✅ 已修：移除实例化、$connect/$disconnect 与 DATABASE_URL 改写 |

其余候选（import 正确性、报告标识、生产路径引用、基线可比性）均被 REFUTED。

## 验证

```
test:retrieval   41 pass / 0 fail
typecheck / lint PASS
真实评测 run 需隔离库 + GEMINI key（本地未配置隔离评测库，未执行冒烟；
strategy 名由 retriever 自身返回并有既有测试覆盖）
```

实施状态：已实现 / 验收状态：待验收

🤖 Generated with [Claude Code](https://claude.com/claude-code)