### PR TITLE
feat(retrieval): 向量通道静默排除可观测性告警

### DIFF
--- a/apps/api/src/retrieval/postgres-article-retrieval.repository.test.ts
+++ b/apps/api/src/retrieval/postgres-article-retrieval.repository.test.ts
@@ -138,6 +138,9 @@ describe('PostgresArticleRetrievalRepository', () => {
     assert.deepEqual(staleQueryValues[0], [
       'article-html-cl100k-v1',
       ACTIVE_EMBEDDING_PROFILE.version,
+      ACTIVE_EMBEDDING_PROFILE.provider,
+      ACTIVE_EMBEDDING_PROFILE.model,
+      ACTIVE_EMBEDDING_PROFILE.dimensions,
     ])
     assert.equal(warnings.length, 1)
     assert.match(warnings[0]!, /2 篇已索引文章.*不可被向量检索/)

--- a/apps/api/src/retrieval/postgres-article-retrieval.repository.test.ts
+++ b/apps/api/src/retrieval/postgres-article-retrieval.repository.test.ts
@@ -101,6 +101,64 @@ describe('PostgresArticleRetrievalRepository', () => {
     assert.equal((query.values[0] as string).split(',').length, 1536)
   })
 
+  it('存在 stale 排除时经节流告警，无 stale 时静默', async () => {
+    const staleQueryValues: unknown[][] = []
+    let staleCount = 2
+    // owned 查询每次 connect 需要全新 client（release 是一次性的）；
+    // stale observability 走 pool.query 直查，不经过连接所有权机器。
+    const pool: ArticleRetrievalPool = {
+      connect: async () => new FakePoolClient({ vectorRows: [] }),
+      cancel: async () => true,
+      query: async () => ({ rows: [] }),
+      auxiliaryQuery: (async (text: string, values: unknown[] = []) => {
+        assert.match(text, /stale_article_count/)
+        staleQueryValues.push(values)
+        return { rows: [{ stale_article_count: staleCount }] }
+      }) as ArticleRetrievalPool['auxiliaryQuery'],
+      end: async () => {},
+    }
+
+    const repository = new PostgresArticleRetrievalRepository(pool)
+    const warnings: string[] = []
+
+    ;(repository as unknown as {
+      logger: { warn: (message: string) => void }
+    }).logger = { warn: message => warnings.push(message) }
+
+    const retrieve = async () => repository.findVectorChunkCandidates(
+      createVector(0.5),
+      { query: 'stale check', limit: 5 },
+      createContext(),
+    )
+
+    await retrieve()
+    await nextMacrotask()
+
+    assert.equal(staleQueryValues.length, 1)
+    assert.deepEqual(staleQueryValues[0], [
+      'article-html-cl100k-v1',
+      ACTIVE_EMBEDDING_PROFILE.version,
+    ])
+    assert.equal(warnings.length, 1)
+    assert.match(warnings[0]!, /2 篇已索引文章.*不可被向量检索/)
+
+    // 节流窗口内的第二次检索不再触发 observability 查询。
+    staleCount = 0
+    await retrieve()
+    await nextMacrotask()
+
+    assert.equal(staleQueryValues.length, 1)
+    assert.equal(warnings.length, 1)
+
+    // 无 stale 时不产生任何告警。
+    ;(repository as unknown as { lastStaleCheckAt: number }).lastStaleCheckAt = 0
+    await retrieve()
+    await nextMacrotask()
+
+    assert.equal(staleQueryValues.length, 2)
+    assert.equal(warnings.length, 1)
+  })
+
   it('Abort 时用 error release owned client 且不返回迟到查询结果', async () => {
     const client = new FakePoolClient({ hangVectorQuery: true })
     const pool = new FakePool(client)
@@ -332,6 +390,10 @@ class FakePool implements ArticleRetrievalPool {
   }
 
   async query<Row>(): Promise<{ rows: Row[] }> {
+    return { rows: [] }
+  }
+
+  async auxiliaryQuery<Row>(): Promise<{ rows: Row[] }> {
     return { rows: [] }
   }
 

--- a/apps/api/src/retrieval/postgres-article-retrieval.repository.ts
+++ b/apps/api/src/retrieval/postgres-article-retrieval.repository.ts
@@ -15,10 +15,11 @@ export const LEXICAL_ARTICLE_CANDIDATE_LIMIT = 10
 export const VECTOR_CHUNK_CANDIDATE_LIMIT = 40
 
 /** stale 排除告警的节流间隔；observability 查询不允许放大检索 QPS。 */
-export const STALE_EXCLUSION_CHECK_INTERVAL_MS = 60_000
+const STALE_EXCLUSION_CHECK_INTERVAL_MS = 60_000
 
 const PG_POOL_ACQUISITION_TIMEOUT_MS = 2_000
 const PG_CANCEL_TIMEOUT_MS = 2_000
+const PG_AUXILIARY_TIMEOUT_MS = 2_000
 const PG_STATEMENT_TIMEOUT_LEAD_MS = 50
 const PG_LOCK_TIMEOUT_LEAD_MS = 25
 const require = createRequire(import.meta.url)
@@ -227,9 +228,10 @@ const VECTOR_CANDIDATES_SQL = `
   LIMIT 40
 `
 
-// 统计「已索引但在当前 active profile 下不可被向量检索」的文章：
-// sourceUpdatedAt 过期、chunker / embedding 版本不匹配都属于同一类
-// 静默排除；chunkCount = 0 的空文章是合法状态，不计入。
+// 统计「已索引但在当前 active profile 下不可被向量检索」的文章，
+// 排除条件与 VECTOR_CANDIDATES_SQL 的守门谓词逐条对齐：state 级版本 /
+// 时间戳过期，以及 chunk 级一致性与完整性（数量不符或存在不兼容 chunk
+// 的半写 / 损坏索引同样不可达）；chunkCount = 0 的空文章是合法状态不计入。
 const STALE_ARTICLE_COUNT_SQL = `
   SELECT COUNT(*)::int AS stale_article_count
   FROM "ArticleIndexState" AS state
@@ -240,6 +242,22 @@ const STALE_ARTICLE_COUNT_SQL = `
       state."chunkerVersion" <> $1::text
       OR state."embeddingVersion" <> $2::text
       OR state."sourceUpdatedAt" <> article."updatedAt"
+      OR state."chunkCount"::bigint <> (
+        SELECT COUNT(*)
+        FROM "ArticleChunk" AS chunk
+        WHERE chunk."articleId" = state."articleId"
+      )
+      OR state."chunkCount"::bigint <> (
+        SELECT COUNT(*)
+        FROM "ArticleChunk" AS chunk
+        WHERE chunk."articleId" = state."articleId"
+          AND chunk."chunkerVersion" = $1::text
+          AND chunk."embeddingVersion" = $2::text
+          AND chunk."embeddingProvider" = $3::text
+          AND chunk."embeddingModel" = $4::text
+          AND chunk."embeddingDimensions" = $5::integer
+          AND chunk."languageCode" = article."languageCode"
+      )
     )
 `
 
@@ -342,6 +360,9 @@ export class PostgresArticleRetrievalRepository implements ArticleRetrievalRepos
       .auxiliaryQuery<{ stale_article_count: number }>(STALE_ARTICLE_COUNT_SQL, [
         ARTICLE_CHUNKER_PROFILE.version,
         ACTIVE_EMBEDDING_PROFILE.version,
+        ACTIVE_EMBEDDING_PROFILE.provider,
+        ACTIVE_EMBEDDING_PROFILE.model,
+        ACTIVE_EMBEDDING_PROFILE.dimensions,
       ])
       .then(({ rows }) => {
         const staleCount = Number(rows[0]?.stale_article_count ?? 0)
@@ -375,6 +396,15 @@ export function createArticleRetrievalPool(
     query_timeout: PG_CANCEL_TIMEOUT_MS,
     statement_timeout: PG_CANCEL_TIMEOUT_MS,
   })
+  // observability 专用小池：不与检索主 pool 抢连接，也不占用取消旁路
+  // （pg_cancel_backend 是 abort 语义的关键路径，不能被观测查询排队阻塞）。
+  const auxiliaryPool = new PgPool({
+    connectionString,
+    max: 1,
+    connectionTimeoutMillis: PG_POOL_ACQUISITION_TIMEOUT_MS,
+    query_timeout: PG_AUXILIARY_TIMEOUT_MS,
+    statement_timeout: PG_AUXILIARY_TIMEOUT_MS,
+  })
 
   return {
     connect: async () => await queryPool.connect(),
@@ -388,15 +418,14 @@ export function createArticleRetrievalPool(
     query: async <Row>(text: string, values?: unknown[]) => (
       await queryPool.query<Row>(text, values)
     ),
-    // cancellationPool 自带 2s query/statement timeout 且 max=1，
-    // 是现成的有界旁路，observability 查询不会拖垮检索主 pool。
     auxiliaryQuery: async <Row>(text: string, values?: unknown[]) => (
-      await cancellationPool.query<Row>(text, values)
+      await auxiliaryPool.query<Row>(text, values)
     ),
     end: async () => {
       await Promise.all([
         queryPool.end(),
         cancellationPool.end(),
+        auxiliaryPool.end(),
       ])
     },
   }

--- a/apps/api/src/retrieval/postgres-article-retrieval.repository.ts
+++ b/apps/api/src/retrieval/postgres-article-retrieval.repository.ts
@@ -6,11 +6,16 @@ import type {
 import { createRequire } from 'node:module'
 import { performance } from 'node:perf_hooks'
 
+import { Logger } from '@nestjs/common'
+
 import { ARTICLE_CHUNKER_PROFILE } from '../article-indexing/article-chunking.js'
 import { ACTIVE_EMBEDDING_PROFILE } from '../embeddings/embedding-provider.js'
 
 export const LEXICAL_ARTICLE_CANDIDATE_LIMIT = 10
 export const VECTOR_CHUNK_CANDIDATE_LIMIT = 40
+
+/** stale 排除告警的节流间隔；observability 查询不允许放大检索 QPS。 */
+export const STALE_EXCLUSION_CHECK_INTERVAL_MS = 60_000
 
 const PG_POOL_ACQUISITION_TIMEOUT_MS = 2_000
 const PG_CANCEL_TIMEOUT_MS = 2_000
@@ -68,6 +73,14 @@ export interface ArticleRetrievalPool {
   connect: () => Promise<ArticleRetrievalPoolClient>
   cancel: (processId: number) => Promise<boolean>
   query: <Row = Record<string, unknown>>(
+    text: string,
+    values?: unknown[],
+  ) => Promise<PgQueryResult<Row>>
+  /**
+   * 有界旁路查询：走独立小连接池并带 2s query/statement timeout，
+   * 供 observability 等非关键查询使用，绝不与检索主 pool 抢连接。
+   */
+  auxiliaryQuery: <Row = Record<string, unknown>>(
     text: string,
     values?: unknown[],
   ) => Promise<PgQueryResult<Row>>
@@ -214,6 +227,22 @@ const VECTOR_CANDIDATES_SQL = `
   LIMIT 40
 `
 
+// 统计「已索引但在当前 active profile 下不可被向量检索」的文章：
+// sourceUpdatedAt 过期、chunker / embedding 版本不匹配都属于同一类
+// 静默排除；chunkCount = 0 的空文章是合法状态，不计入。
+const STALE_ARTICLE_COUNT_SQL = `
+  SELECT COUNT(*)::int AS stale_article_count
+  FROM "ArticleIndexState" AS state
+  INNER JOIN "Article" AS article
+    ON article."id" = state."articleId"
+  WHERE state."chunkCount" > 0
+    AND (
+      state."chunkerVersion" <> $1::text
+      OR state."embeddingVersion" <> $2::text
+      OR state."sourceUpdatedAt" <> article."updatedAt"
+    )
+`
+
 const SET_LOCAL_TIMEOUTS_SQL = `
   SELECT
     set_config('statement_timeout', $1::text, true),
@@ -221,6 +250,9 @@ const SET_LOCAL_TIMEOUTS_SQL = `
 `
 
 export class PostgresArticleRetrievalRepository implements ArticleRetrievalRepositoryContract {
+  private readonly logger = new Logger(PostgresArticleRetrievalRepository.name)
+  private lastStaleCheckAt = 0
+
   constructor(private readonly pool: ArticleRetrievalPool) {}
 
   async findLexicalCandidates(
@@ -269,6 +301,8 @@ export class PostgresArticleRetrievalRepository implements ArticleRetrievalRepos
       onSqlLatencyMs,
     )
 
+    this.maybeWarnStaleExcludedArticles()
+
     return rows.map((row) => {
       const cosineDistance = Number(row.cosine_distance)
       if (!Number.isFinite(cosineDistance))
@@ -288,6 +322,41 @@ export class PostgresArticleRetrievalRepository implements ArticleRetrievalRepos
         cosineDistance,
       }
     })
+  }
+
+  /**
+   * freshness gate（sourceUpdatedAt = article.updatedAt）是 fail-closed 设计，
+   * 保持不变；这里只补上「静默」的另一半：存在被排除的已索引文章时告警。
+   *
+   * fire-and-forget + 节流：可观测性查询不增加检索主路径延迟，也不放大
+   * QPS；查询失败只吞掉，绝不影响检索结果。
+   */
+  private maybeWarnStaleExcludedArticles(): void {
+    const now = Date.now()
+
+    if (now - this.lastStaleCheckAt < STALE_EXCLUSION_CHECK_INTERVAL_MS)
+      return
+
+    this.lastStaleCheckAt = now
+    void this.pool
+      .auxiliaryQuery<{ stale_article_count: number }>(STALE_ARTICLE_COUNT_SQL, [
+        ARTICLE_CHUNKER_PROFILE.version,
+        ACTIVE_EMBEDDING_PROFILE.version,
+      ])
+      .then(({ rows }) => {
+        const staleCount = Number(rows[0]?.stale_article_count ?? 0)
+
+        if (staleCount > 0) {
+          this.logger.warn(
+            `${staleCount} 篇已索引文章在当前 profile 下不可被向量检索`
+            + '（版本不匹配或 sourceUpdatedAt 过期），hybrid 对它们退化为'
+            + '纯 lexical；请执行 pnpm index:articles 刷新索引。',
+          )
+        }
+      })
+      .catch(() => {
+        // 可观测性查询失败不影响检索主路径。
+      })
   }
 }
 
@@ -318,6 +387,11 @@ export function createArticleRetrievalPool(
     },
     query: async <Row>(text: string, values?: unknown[]) => (
       await queryPool.query<Row>(text, values)
+    ),
+    // cancellationPool 自带 2s query/statement timeout 且 max=1，
+    // 是现成的有界旁路，observability 查询不会拖垮检索主 pool。
+    auxiliaryQuery: async <Row>(text: string, values?: unknown[]) => (
+      await cancellationPool.query<Row>(text, values)
     ),
     end: async () => {
       await Promise.all([

--- a/apps/api/src/retrieval/retrieval.db.test.ts
+++ b/apps/api/src/retrieval/retrieval.db.test.ts
@@ -534,6 +534,13 @@ class TrackingPool implements ArticleRetrievalPool {
     return await this.pool.query<Row>(text, values)
   }
 
+  async auxiliaryQuery<Row>(
+    text: string,
+    values?: unknown[],
+  ): Promise<QueryResult<Row>> {
+    return await this.pool.auxiliaryQuery<Row>(text, values)
+  }
+
   async end(): Promise<void> {
     await this.pool.end()
   }


### PR DESCRIPTION
Closes #76

## 改动概述

修复审计发现 C8 的"静默"一半（fail-closed 行为保持不变）：

1. 向量查询后异步检查"已索引但当前 active profile 下不可被向量检索"的文章数——覆盖 `sourceUpdatedAt` 过期 **和** chunker/embedding 版本不匹配两类同源静默排除（`chunkCount=0` 的合法空文章不计入）；存在时打 warning（含数量与修复指引）。
2. 观测查询 fire-and-forget + 60s 节流：不增加检索主路径延迟、不放大 QPS、失败只吞掉。
3. 新增 `ArticleRetrievalPool.auxiliaryQuery`：观测查询走已有的 cancellationPool（自带 2s query/statement timeout、max=1），与检索主 pool（max=2）完全隔离。
4. 索引 CLI 侧确认：`ArticleIndexSummary.stale` 已有 CAS 冲突计数，本场景（忘跑索引）只能由查询侧覆盖，不重复实现。

## /code-review findings 处理（medium 级）

| Finding | 处理 |
| --- | --- |
| 观测查询占用 max-2 主 pool 且无超时，可能饿死检索（PLAUSIBLE） | ✅ 已修：改走 auxiliaryQuery（独立池 + 2s timeout） |
| 版本不匹配的同类静默排除不被告警覆盖（PLAUSIBLE） | ✅ 已修：SQL 扩展为版本不匹配 OR 时间戳过期 |

其余候选（节流竞态、pool.end 后触发、多实例重复告警等）均被 REFUTED。

## 验证

```
test:retrieval   42 pass / 0 fail（+1 新测试：告警/节流/静默三段断言）
typecheck / lint PASS
retrieval.db.test.ts 需隔离库（本地未配置未执行；TrackingPool 已同步接口）
```

实施状态：已实现 / 验收状态：待验收

🤖 Generated with [Claude Code](https://claude.com/claude-code)