### PR TITLE
chore: 低危卫生批量修复

### DIFF
--- a/apps/admin/src/features/runs/run.utils.ts
+++ b/apps/admin/src/features/runs/run.utils.ts
@@ -1,5 +1,3 @@
-import type { RunFilters } from './run.model'
-
 const dateTimeOptions: Intl.DateTimeFormatOptions = {
   timeZone: 'Asia/Shanghai',
   year: 'numeric',
@@ -45,13 +43,6 @@ export const knownTimelineInspectorKeys = {
   receive_user_message: 'timeline.inspectors.receiveUserMessage',
   tool_execution: 'timeline.inspectors.toolExecution',
 } as const
-
-export const defaultRunFilters: RunFilters = {
-  query: '',
-  status: undefined,
-  dateFrom: '',
-  dateTo: '',
-}
 
 export function formatRequestedModel(model: string | null, fallback = 'Default request'): string {
   return model ?? fallback

--- a/apps/api/src/agent-runtime/agent-runtime.service.ts
+++ b/apps/api/src/agent-runtime/agent-runtime.service.ts
@@ -421,7 +421,6 @@ export class AgentRuntimeService {
         const toolDefinition = toolDefinitions.find(
           definition => definition.name === samplingDecision.call.toolName,
         )
-        // add toolstep runing
         const toolStep = await this.agentRunRecorderService.startStep({
           runId: currentAgentRunId,
           type: AGENT_STEP_TYPES.toolExecution,

--- a/apps/api/src/agent-runtime/grounding/grounded-answer.finalizer.ts
+++ b/apps/api/src/agent-runtime/grounding/grounded-answer.finalizer.ts
@@ -11,6 +11,7 @@ import type {
 import type { ValidatedGroundedAnswer } from './grounded-answer.validator.js'
 import type { RunEvidenceRegistry } from './run-evidence-registry.js'
 
+import { mergeModelUsage } from '../../llm/model-stream.types.js'
 import {
   GroundedAnswerRejectedError,
   parseSubmitGroundedAnswerInput,
@@ -347,7 +348,7 @@ async function consumeFinalizationSampling(
           break
 
         case 'usage':
-          usage = mergeUsage(usage, event.usage)
+          usage = mergeModelUsage(usage, event.usage)
           break
 
         case 'response_completed':
@@ -378,18 +379,4 @@ async function consumeFinalizationSampling(
     return failed('missing_submission')
 
   return { ok: true, rawArgumentsJson, usage }
-}
-
-function mergeUsage(
-  current: ModelUsage | null,
-  next: ModelUsage,
-): ModelUsage | null {
-  const merged: ModelUsage = {
-    ...(current ?? {}),
-    ...(next.inputTokens === undefined ? {} : { inputTokens: next.inputTokens }),
-    ...(next.outputTokens === undefined ? {} : { outputTokens: next.outputTokens }),
-    ...(next.totalTokens === undefined ? {} : { totalTokens: next.totalTokens }),
-  }
-
-  return Object.keys(merged).length > 0 ? merged : null
 }

--- a/apps/api/src/agent-runtime/model-sampling-decision.ts
+++ b/apps/api/src/agent-runtime/model-sampling-decision.ts
@@ -6,6 +6,7 @@ import type {
 } from '../llm/model-stream.types.js'
 import type { UnvalidatedToolCallEnvelope } from '../tools/core/tool.types.js'
 
+import { mergeModelUsage } from '../llm/model-stream.types.js'
 import { ModelSamplingIncompleteError } from './agent-runtime.errors.js'
 
 export interface ModelSamplingSummary {
@@ -176,20 +177,6 @@ export async function* streamModelSampling(
     type: 'final_answer',
     summary: buildSummary(),
   }
-}
-
-function mergeModelUsage(
-  current: ModelUsage | null,
-  next: ModelUsage,
-): ModelUsage | null {
-  const merged: ModelUsage = {
-    ...(current ?? {}),
-    ...(next.inputTokens === undefined ? {} : { inputTokens: next.inputTokens }),
-    ...(next.outputTokens === undefined ? {} : { outputTokens: next.outputTokens }),
-    ...(next.totalTokens === undefined ? {} : { totalTokens: next.totalTokens }),
-  }
-
-  return Object.keys(merged).length > 0 ? merged : null
 }
 
 function toToolCallEnvelope(

--- a/apps/api/src/llm/model-stream.types.ts
+++ b/apps/api/src/llm/model-stream.types.ts
@@ -47,3 +47,18 @@ export type ModelStreamEvent
     type: 'response_completed'
     finishReason: ModelFinishReason
   }
+
+/** 合并流式 usage 分片；没有任何已知字段时保持 null，绝不补零。 */
+export function mergeModelUsage(
+  current: ModelUsage | null,
+  next: ModelUsage,
+): ModelUsage | null {
+  const merged: ModelUsage = {
+    ...(current ?? {}),
+    ...(next.inputTokens === undefined ? {} : { inputTokens: next.inputTokens }),
+    ...(next.outputTokens === undefined ? {} : { outputTokens: next.outputTokens }),
+    ...(next.totalTokens === undefined ? {} : { totalTokens: next.totalTokens }),
+  }
+
+  return Object.keys(merged).length > 0 ? merged : null
+}

--- a/apps/api/src/retrieval/postgres-article-retrieval.repository.ts
+++ b/apps/api/src/retrieval/postgres-article-retrieval.repository.ts
@@ -148,7 +148,7 @@ const LEXICAL_CANDIDATES_SQL = String.raw`
       ELSE 4
     END ASC,
     article."sourceId" ASC
-  LIMIT 10
+  LIMIT ${LEXICAL_ARTICLE_CANDIDATE_LIMIT}
 `
 
 const VECTOR_CANDIDATES_SQL = `
@@ -211,7 +211,7 @@ const VECTOR_CANDIDATES_SQL = `
     source_id ASC,
     ordinal ASC,
     chunk_id ASC
-  LIMIT 40
+  LIMIT ${VECTOR_CHUNK_CANDIDATE_LIMIT}
 `
 
 const SET_LOCAL_TIMEOUTS_SQL = `

--- a/apps/web/src/api/http.ts
+++ b/apps/web/src/api/http.ts
@@ -20,6 +20,7 @@ function isApiSuccessResponse<T>(value: unknown): value is ApiSuccessResponseCon
     typeof value === 'object'
     && value !== null
     && 'success' in value
+    && value.success === true
     && 'code' in value
     && 'data' in value
   )

--- a/apps/web/src/api/seo.ts
+++ b/apps/web/src/api/seo.ts
@@ -110,7 +110,7 @@ export function parseChatStreamEventLine(line: string): ChatStreamEvent | null {
  * href 必须为 null、citationId 唯一，两侧结论完全一致。
  *
  * 与服务端的唯一区别是失败处理：这里只丢弃这个可选字段，不让 UI / 审计元数据
- * 拖垮整条回答流。本 Task 不渲染来源卡片。
+ * 拖垮整条回答流；来源卡片由 UI 层按 done.grounding 渲染。
  */
 function sanitizeChatStreamEvent(event: ChatStreamEvent): ChatStreamEvent {
   if (event.type !== 'done' || event.grounding === undefined)

--- a/apps/web/src/components/agent/AgentMarkdownContent.vue
+++ b/apps/web/src/components/agent/AgentMarkdownContent.vue
@@ -1,13 +1,10 @@
-<script setup lang="ts">
+<script lang="ts">
 import type Token from 'markdown-it/lib/token.mjs'
 
 import MarkdownIt from 'markdown-it'
 import { computed } from 'vue'
 
-const props = defineProps<{
-  text: string
-}>()
-
+// 解析器配置是纯静态的，放模块级共享一个实例，避免每条回复各建一个。
 const markdown = new MarkdownIt({
   breaks: true,
   html: false,
@@ -34,8 +31,6 @@ markdown.renderer.rules.link_open = (tokens, index, options, env, self) => {
   return self.renderToken(tokens, index, options)
 }
 
-const renderedContent = computed(() => markdown.render(props.text.trim()))
-
 function setTokenAttr(token: Token, name: string, value: string) {
   const attrIndex = token.attrIndex(name)
 
@@ -49,6 +44,14 @@ function setTokenAttr(token: Token, name: string, value: string) {
 
   token.attrs[attrIndex][1] = value
 }
+</script>
+
+<script setup lang="ts">
+const props = defineProps<{
+  text: string
+}>()
+
+const renderedContent = computed(() => markdown.render(props.text.trim()))
 </script>
 
 <template>


### PR DESCRIPTION
Closes #77

## 改动概述

审计低危清单中零行为风险的 7 项批量收口（净删 17 行）：

1. `postgres-article-retrieval.repository.ts`：SQL `LIMIT 10/40` 改由 `LEXICAL_ARTICLE_CANDIDATE_LIMIT` / `VECTOR_CHUNK_CANDIDATE_LIMIT` 常量插值（生成 SQL 逐字节一致，常量已被 retriever 消费，闭合漂移风险）；
2. `mergeModelUsage` / `mergeUsage` 逐字节相同的双实现收敛到 `llm/model-stream.types.ts` 单一导出；
3. `AgentMarkdownContent.vue`：MarkdownIt 实例与渲染规则提升到普通 `<script>` 模块级，不再每条回复各建解析器；
4. `web/api/http.ts`：`isApiSuccessResponse` 补 `success === true`（对齐 admin 侧实现）；
5. 删除 admin 无引用的 `defaultRunFilters`（与 store 的 `createDefaultFilters()` 重复）及其类型导入；
6. `web/api/seo.ts` 过时注释（"本 Task 不渲染来源卡片"）更新；
7. 删除 runtime 的无信息量注释。

## /code-review findings

medium 级自审：**0 findings**（6 类候选全部 REFUTED，含 dual-script SFC 语义、String.raw 插值、拆除代码的引用面核查）。

## 验证

```
workspace typecheck                 PASS（0 错误）
test:model-stream / grounding / retrieval   67 / 168 / 41 pass
web test / build                    43 pass / build ✓
api / web / admin lint              PASS
```

实施状态：已实现 / 验收状态：待验收

🤖 Generated with [Claude Code](https://claude.com/claude-code)