### PR TITLE
fix(bootstrap): 主库镜像对齐 pgvector，README quickstart 补全自举步骤

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,19 +153,25 @@ Requirements:
 
 - Node.js `^20.19.0` or `>=22.12.0`
 - pnpm `10.32.1`
-- PostgreSQL
-- pgvector for Article Embedding Index migration / indexing
+- PostgreSQL **with the pgvector extension**（`docker compose up -d postgres` 使用的镜像已内置；自装 PostgreSQL 时必须额外安装 pgvector，否则 Embedding Index migration 会失败）
 - A DeepSeek or other OpenAI-compatible Chat Completions endpoint
 - A Google AI Studio Gemini API Key when running explicit Embedding smoke, indexing, or real vector retrieval
 
 ```bash
 corepack enable
 pnpm install
-cp .env.example .env
+cp .env.example .env                                    # 填入 LLM_API_KEY / GEMINI_API_KEY
+docker compose up -d postgres                           # 启动含 pgvector 的主库
 pnpm prisma:generate
-pnpm prisma:migrate
+pnpm prisma:migrate                                     # 应用全部 migration
+node --env-file=.env --import tsx apps/api/scripts/seed.ts   # 灌入 Demo 文章（幂等）
+pnpm --filter @agent/api index:articles -- --mode=incremental # 构建向量索引（调真实 Gemini）
 pnpm dev
 ```
+
+seed 与 index 两步是 Retrieval / Grounding 链路可用的前提：跳过它们时普通聊天仍可用，但 `retrieve_article_context` 会因缺少 active index 而 fail closed。
+
+> **从旧版 `postgres:16-alpine` 升级的开发机注意**：alpine（musl）初始化的数据卷在新镜像（glibc）下会有 collation 版本告警，文本索引可能失序。开发数据都可重建，建议直接重置主库卷后重走 migrate / seed / index：`docker compose rm -sf postgres && docker volume rm <项目前缀>_postgres-data && docker compose up -d postgres`。
 
 | Application | URL |
 | --- | --- |

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,11 @@
 services:
   postgres:
-    image: postgres:16-alpine
+    # 主库必须使用含 pgvector 的镜像：Article Embedding Index migration 会执行
+    # CREATE EXTENSION vector，普通 postgres:16-alpine 缺扩展会直接失败。
+    # 版本与下方 integration 测试库保持一致。
+    # 注意：从旧 alpine 镜像迁移的已有数据卷存在 musl→glibc collation 差异，
+    # 建议重置卷后重建（开发数据可由 seed / index 重建），见 README Getting started。
+    image: pgvector/pgvector:0.8.6-pg16-bookworm
     container_name: agent-ai-seo-postgres
     restart: unless-stopped
     environment:


### PR DESCRIPTION
Closes #84

## 改动概述

编写实机启动手册时发现的开发环境自举缺陷（详见 Issue）：

1. **compose 主库镜像换为 `pgvector/pgvector:0.8.6-pg16-bookworm`**（对齐 integration 库现值）。原 `postgres:16-alpine` 不含 pgvector，`prisma:migrate` 必然在 Embedding Index migration 中断——本开发机主库因此长期只应用了 8 个 migration 中的 6 个，web 前台 RAG 主链与 grounded 落库在 dev 主库上从未真正可用。
2. **README Getting started 补齐三处**：`docker compose up -d postgres` 起库入口、语料 seed 步骤（此前完全未提）、向量索引构建步骤；并注明跳过时的 fail-closed 行为与旧 alpine 数据卷的 collation 迁移注意。

## /code-review findings 处理（medium 级）

| Finding | 处理 |
| --- | --- |
| 旧 alpine 数据卷复用新镜像有 musl→glibc collation 失序风险（PLAUSIBLE） | ✅ 已修：README + compose 注释补迁移指引（重置卷重建） |
| README 硬编码计数（8 个 / 68 篇）会随演进漂移（cleanup） | ✅ 已修：去掉数字 |

其余事实核查（migration 目录数、fixture 篇数、CLI 参数、seed 幂等性、镜像 tag 一致性）全部通过。

## 实机验证（AC-1 / AC-2）

```
全新数据卷 + 新镜像:
  pnpm prisma:migrate            8/8 migration 应用成功，vector 扩展就位
  seed.ts                        已导入并验证 68 篇文章
  index:articles (incremental)   indexed=68 / chunksWritten=2044 / failed=0 / stale=0 / retryCount=0
docker compose config            PASS（integration 库配置未变，AC-4）
```

实施状态：已实现 / 验收状态：待验收

🤖 Generated with [Claude Code](https://claude.com/claude-code)