### PR TITLE
feat: debug 开关捕获模型采样原始请求/响应并在后台展示（#86）

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -83,6 +83,11 @@ AGENT_RUN_DEADLINE_MS=600000
 # Infinity 或超限值会使应用启动失败，
 # 不会被静默截断或回退。
 
+# debug 开关：捕获每轮模型采样的 provider 原始请求体和组装后的原始响应 JSON，
+# 落到 model_sampling AgentStep 并在后台请求检查器展示（1/true 开启；缺省关闭）。
+# 仅用于学习 / 调试观测；单侧序列化超过约 200KB 时截断为前缀预览。
+AGENT_DEBUG_CAPTURE_MODEL_IO=false
+
 # ─── 数据库配置（阶段 2 必填）──────────────────
 # PostgreSQL 连接字符串。
 # 本地示例：postgresql://postgres:postgres@localhost:5432/agent_ai_seo?schema=public

--- a/apps/admin/e2e/fixtures.ts
+++ b/apps/admin/e2e/fixtures.ts
@@ -605,6 +605,8 @@ function samplingStep(
     textChars: 40,
     intermediateTextChars: 0,
     recordedDurationMs: 300,
+    debugRequestBody: null,
+    debugRawResponse: null,
     contextInspector: {
       availability: 'unavailable',
       outcome: 'unavailable',

--- a/apps/admin/package.json
+++ b/apps/admin/package.json
@@ -20,6 +20,7 @@
     "pinia": "^3.0.4",
     "vue": "^3.5.25",
     "vue-i18n": "^11.4.6",
+    "vue-json-pretty": "^2.6.0",
     "vue-router": "^5.1.0"
   },
   "devDependencies": {

--- a/apps/admin/src/features/runs/run-data.check.ts
+++ b/apps/admin/src/features/runs/run-data.check.ts
@@ -973,6 +973,8 @@ function createTraceDetail(toolCount: 0 | 1 | 2): AdminRunDetail {
       textChars: finishReason === 'stop' ? 12 : 0,
       intermediateTextChars: 0,
       recordedDurationMs: 50,
+      debugRequestBody: null,
+      debugRawResponse: null,
       contextInspector: createContextInspector({
         estimatedInputTokens: index * 100,
         budgetUsageRatio: index * 100 / 262_144,
@@ -1158,6 +1160,8 @@ function createRunningDetail(): AdminRunDetail {
     textChars: null,
     intermediateTextChars: null,
     recordedDurationMs: null,
+    debugRequestBody: null,
+    debugRawResponse: null,
     contextInspector: createContextInspector({
       availability: 'partial',
       outcome: 'unavailable',

--- a/apps/admin/src/features/runs/trace/RunTraceWorkspace.vue
+++ b/apps/admin/src/features/runs/trace/RunTraceWorkspace.vue
@@ -2,6 +2,7 @@
 import type { RunDetail } from '../run.model'
 import type { TraceRecord, TraceRequestGroup } from './run-trace.model'
 import { computed, ref, watch } from 'vue'
+import { useI18n } from 'vue-i18n'
 
 import {
   createRunTraceProjection,
@@ -19,9 +20,34 @@ const props = defineProps<{
   run: RunDetail
 }>()
 
+const { t } = useI18n()
+
 const query = ref('')
 const collapsedRequestIds = ref<Set<string>>(new Set())
 const selectedId = ref<string>()
+
+// 检查器宽度拖拽调整；null 表示使用 CSS 默认宽度。
+const MIN_INSPECTOR_WIDTH = 300
+const MIN_LEDGER_WIDTH = 320
+const RESIZE_KEYBOARD_STEP = 16
+// CSS 默认宽度 clamp(320px, 28%, 440px) 的 28%，用作 aria 初始值。
+const DEFAULT_INSPECTOR_PERCENT = 28
+const bodyEl = ref<HTMLElement>()
+const inspectorEl = ref<HTMLElement>()
+const inspectorWidth = ref<number | null>(null)
+const resizerValuePercent = ref(DEFAULT_INSPECTOR_PERCENT)
+const resizing = ref(false)
+const activePointerId = ref<number | null>(null)
+const dragStartX = ref(0)
+const dragStartWidth = ref(0)
+
+// min() 让容器变窄时由 CSS 自动重新收紧，始终给左侧列表保留 MIN_LEDGER_WIDTH。
+const bodyStyle = computed(() => inspectorWidth.value === null
+  ? undefined
+  : {
+      gridTemplateColumns:
+        `minmax(0, 1fr) min(${inspectorWidth.value}px, calc(100% - ${MIN_LEDGER_WIDTH}px))`,
+    })
 
 const projection = computed(() => createRunTraceProjection(props.run))
 const visibleRecords = computed(() => getVisibleTraceRecords(
@@ -145,6 +171,82 @@ function collapseRequests() {
 function expandAll() {
   collapsedRequestIds.value = new Set()
 }
+
+function applyInspectorWidth(width: number) {
+  const rect = bodyEl.value?.getBoundingClientRect()
+  if (!rect)
+    return
+
+  const max = Math.max(MIN_INSPECTOR_WIDTH, rect.width - MIN_LEDGER_WIDTH)
+  const clamped = Math.min(Math.max(width, MIN_INSPECTOR_WIDTH), max)
+  inspectorWidth.value = clamped
+  resizerValuePercent.value = Math.round((clamped / rect.width) * 100)
+}
+
+function currentInspectorWidth(): number {
+  return inspectorWidth.value
+    ?? inspectorEl.value?.offsetWidth
+    ?? MIN_INSPECTOR_WIDTH
+}
+
+/** 聚焦时按真实布局同步 aria 值，修正默认 clamp 或窗口缩放造成的偏差。 */
+function syncResizerValue() {
+  const rect = bodyEl.value?.getBoundingClientRect()
+  if (!rect || rect.width === 0)
+    return
+
+  resizerValuePercent.value = Math.round(
+    (currentInspectorWidth() / rect.width) * 100,
+  )
+}
+
+function onResizerPointerDown(event: PointerEvent) {
+  // 只认第一个按下的 pointer，避免触屏第二根手指打断拖拽
+  if (activePointerId.value !== null)
+    return
+
+  event.preventDefault()
+  ;(event.currentTarget as HTMLElement).setPointerCapture(event.pointerId)
+  activePointerId.value = event.pointerId
+  dragStartX.value = event.clientX
+  dragStartWidth.value = currentInspectorWidth()
+  resizing.value = true
+}
+
+function onResizerPointerMove(event: PointerEvent) {
+  if (!resizing.value || event.pointerId !== activePointerId.value)
+    return
+
+  // 基于按下时的宽度做相对位移，起手不跳变
+  applyInspectorWidth(
+    dragStartWidth.value + (dragStartX.value - event.clientX),
+  )
+}
+
+function onResizerPointerUp(event: PointerEvent) {
+  if (event.pointerId !== activePointerId.value)
+    return
+
+  resizing.value = false
+  activePointerId.value = null
+  ;(event.currentTarget as HTMLElement).releasePointerCapture(event.pointerId)
+}
+
+function onResizerKeydown(event: KeyboardEvent) {
+  if (event.key !== 'ArrowLeft' && event.key !== 'ArrowRight')
+    return
+
+  event.preventDefault()
+  const delta = event.key === 'ArrowLeft'
+    ? RESIZE_KEYBOARD_STEP
+    : -RESIZE_KEYBOARD_STEP
+  applyInspectorWidth(currentInspectorWidth() + delta)
+}
+
+function resetInspectorWidth() {
+  inspectorWidth.value = null
+  resizerValuePercent.value = DEFAULT_INSPECTOR_PERCENT
+}
 </script>
 
 <template>
@@ -177,7 +279,7 @@ function expandAll() {
         @select="selectRecord"
       />
 
-      <div class="run-trace-workspace__body">
+      <div ref="bodyEl" class="run-trace-workspace__body" :style="bodyStyle">
         <RunTraceLedger
           :records="visibleRecords"
           :request-groups="projection.requestGroups"
@@ -188,7 +290,23 @@ function expandAll() {
           @toggle-request="toggleRequest"
         />
 
-        <div class="run-trace-workspace__inspector">
+        <div ref="inspectorEl" class="run-trace-workspace__inspector">
+          <div
+            class="run-trace-workspace__resizer"
+            :class="{ 'run-trace-workspace__resizer--active': resizing }"
+            role="separator"
+            aria-orientation="vertical"
+            :aria-label="t('runTrace.inspector.resizerLabel')"
+            :aria-valuenow="resizerValuePercent"
+            tabindex="0"
+            @pointerdown="onResizerPointerDown"
+            @pointermove="onResizerPointerMove"
+            @pointerup="onResizerPointerUp"
+            @pointercancel="onResizerPointerUp"
+            @keydown="onResizerKeydown"
+            @focus="syncResizerValue"
+            @dblclick="resetInspectorWidth"
+          />
           <RunTraceInspector
             :record="selectedRecord"
             :request-group="selectedRequestGroup"
@@ -230,10 +348,31 @@ function expandAll() {
 }
 
 .run-trace-workspace__inspector {
+  position: relative;
   min-width: 0;
   min-height: 0;
   overflow: hidden;
   border-left: 1px solid var(--admin-border-strong);
+}
+
+.run-trace-workspace__resizer {
+  position: absolute;
+  z-index: 1;
+  top: 0;
+  bottom: 0;
+
+  /* 检查器容器 overflow:hidden 会裁掉负偏移部分，把手必须完全落在容器内 */
+  left: 0;
+  width: 6px;
+  cursor: col-resize;
+  touch-action: none;
+}
+
+.run-trace-workspace__resizer:hover,
+.run-trace-workspace__resizer:focus-visible,
+.run-trace-workspace__resizer--active {
+  background: color-mix(in srgb, var(--trace-model) 35%, transparent);
+  outline: none;
 }
 
 @container run-trace (max-width: 900px) {
@@ -243,13 +382,18 @@ function expandAll() {
   }
 
   .run-trace-workspace__body {
-    grid-template-columns: 1fr;
+    /* 覆盖拖拽宽度的行内样式，堆叠布局下宽度调整无意义 */
+    grid-template-columns: 1fr !important;
     grid-template-rows: minmax(270px, 0.9fr) minmax(340px, 1.1fr);
   }
 
   .run-trace-workspace__inspector {
     border-top: 1px solid var(--admin-border-strong);
     border-left: 0;
+  }
+
+  .run-trace-workspace__resizer {
+    display: none;
   }
 }
 </style>

--- a/apps/admin/src/features/runs/trace/inspectors/DebugJsonPane.vue
+++ b/apps/admin/src/features/runs/trace/inspectors/DebugJsonPane.vue
@@ -1,0 +1,122 @@
+<script setup lang="ts">
+import type { AdminDebugModelIOCapture } from '@agent/contracts'
+import { Alert, Button, message } from 'ant-design-vue'
+import { computed } from 'vue'
+import { useI18n } from 'vue-i18n'
+import VueJsonPretty from 'vue-json-pretty'
+
+import 'vue-json-pretty/lib/styles.css'
+
+// vue-json-pretty 的 data prop 类型；捕获值来自后端 JSON 列，运行时必然满足。
+type JsonDataType
+  = | string
+    | number
+    | boolean
+    | unknown[]
+    | Record<string, unknown>
+    | null
+
+// 旧 API 构建返回的 run 数据没有 debug 字段（undefined 而非 null），一并按未捕获处理。
+const props = defineProps<{
+  capture?: AdminDebugModelIOCapture | null
+}>()
+
+const { t } = useI18n()
+
+const jsonData = computed<JsonDataType>(() => (
+  props.capture && !props.capture.truncated ? props.capture.value : null
+) as JsonDataType)
+
+const copyText = computed(() => {
+  if (!props.capture)
+    return ''
+
+  return props.capture.truncated
+    ? props.capture.preview
+    : JSON.stringify(props.capture.value, null, 2)
+})
+
+// 大 JSON 用虚拟滚动，避免一次渲染全部节点；小 JSON 保持自然高度。
+const useVirtual = computed(() => copyText.value.length > 50_000)
+
+async function copyJson() {
+  try {
+    await navigator.clipboard.writeText(copyText.value)
+    message.success(t('runTrace.inspector.debugCapture.copied'))
+  }
+  catch {
+    message.error(t('runTrace.inspector.debugCapture.copyFailed'))
+  }
+}
+</script>
+
+<template>
+  <Alert
+    v-if="!capture"
+    type="info"
+    show-icon
+    :message="t('runTrace.inspector.debugCapture.empty')"
+  />
+
+  <div v-else class="debug-json-pane">
+    <div class="debug-json-toolbar">
+      <Alert
+        v-if="capture.truncated"
+        class="debug-json-truncated"
+        type="warning"
+        show-icon
+        :message="t('runTrace.inspector.debugCapture.truncated')"
+      />
+      <Button size="small" @click="copyJson">
+        {{ t('runTrace.inspector.debugCapture.copy') }}
+      </Button>
+    </div>
+
+    <pre v-if="capture.truncated" class="debug-json-preview">{{ capture.preview }}</pre>
+    <VueJsonPretty
+      v-else
+      class="debug-json-tree"
+      :data="jsonData"
+      :deep="4"
+      :virtual="useVirtual"
+      :height="480"
+      show-length
+      show-icon
+    />
+  </div>
+</template>
+
+<style scoped>
+.debug-json-pane {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.debug-json-toolbar {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 8px;
+}
+
+.debug-json-truncated {
+  flex: 1;
+}
+
+.debug-json-preview,
+.debug-json-tree {
+  max-height: 60vh;
+  overflow: auto;
+  margin: 0;
+  padding: 8px;
+  border: 1px solid rgb(0 0 0 / 6%);
+  border-radius: 6px;
+  font-size: 12px;
+}
+
+.debug-json-preview {
+  white-space: pre-wrap;
+  word-break: break-all;
+}
+</style>

--- a/apps/admin/src/features/runs/trace/inspectors/RequestInspector.vue
+++ b/apps/admin/src/features/runs/trace/inspectors/RequestInspector.vue
@@ -17,6 +17,7 @@ import {
   formatRequestedModel,
   formatTokens,
 } from '../../run.utils'
+import DebugJsonPane from './DebugJsonPane.vue'
 import InspectorFieldList from './InspectorFieldList.vue'
 
 const props = defineProps<{
@@ -203,6 +204,14 @@ function formatObservation(observation: AdminContextObservationSummary): string 
 
     <TabPane key="safe-io" :tab="t('runTrace.inspector.tabs.safeIo')">
       <InspectorFieldList :items="safeIoFields" />
+    </TabPane>
+
+    <TabPane key="request-body" :tab="t('runTrace.inspector.tabs.requestBody')">
+      <DebugJsonPane :capture="item.debugRequestBody" />
+    </TabPane>
+
+    <TabPane key="raw-response" :tab="t('runTrace.inspector.tabs.rawResponse')">
+      <DebugJsonPane :capture="item.debugRawResponse" />
     </TabPane>
   </Tabs>
 </template>

--- a/apps/admin/src/i18n/messages.ts
+++ b/apps/admin/src/i18n/messages.ts
@@ -204,6 +204,7 @@ export const messages = {
       inspector: {
         ariaLabel: '运行轨迹检查器',
         empty: '选择一条轨迹记录查看详情',
+        resizerLabel: '拖拽调整检查器宽度，方向键微调，双击恢复默认',
         unavailable: '未记录',
         requestLabel: '请求 #{number}',
         safeRawDescription: '仅包含 Admin 安全白名单字段。',
@@ -681,6 +682,7 @@ export const messages = {
       inspector: {
         ariaLabel: 'Run trace inspector',
         empty: 'Select a trace record to inspect',
+        resizerLabel: 'Drag to resize the inspector, arrow keys to fine-tune, double-click to reset',
         unavailable: 'Unavailable',
         requestLabel: 'Request #{number}',
         safeRawDescription: 'Only Admin allowlisted safe fields are shown.',

--- a/apps/admin/src/i18n/messages.ts
+++ b/apps/admin/src/i18n/messages.ts
@@ -218,6 +218,15 @@ export const messages = {
           safeIo: '安全 I/O',
           content: '内容',
           safeRaw: '安全原始数据',
+          requestBody: '请求体',
+          rawResponse: '原始响应',
+        },
+        debugCapture: {
+          empty: '未捕获。需要在 API 环境中开启 AGENT_DEBUG_CAPTURE_MODEL_IO 后重新运行。',
+          truncated: '内容超过截断上限，仅展示前缀预览。',
+          copy: '复制 JSON',
+          copied: '已复制',
+          copyFailed: '复制失败',
         },
         fields: {
           request: '请求',
@@ -686,6 +695,15 @@ export const messages = {
           safeIo: 'Safe I/O',
           content: 'Content',
           safeRaw: 'Safe Raw',
+          requestBody: 'Request Body',
+          rawResponse: 'Raw Response',
+        },
+        debugCapture: {
+          empty: 'Not captured. Enable AGENT_DEBUG_CAPTURE_MODEL_IO in the API environment and rerun.',
+          truncated: 'Content exceeded the capture limit; only a prefix preview is shown.',
+          copy: 'Copy JSON',
+          copied: 'Copied',
+          copyFailed: 'Copy failed',
         },
         fields: {
           request: 'Request',

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -28,7 +28,7 @@
     "eval:retrieval-quality": "node --import tsx --env-file-if-exists=../../.env src/retrieval/evaluation/article-retrieval-quality-v2.cli.ts",
     "test:admin-runs": "pnpm build && node --test dist/admin-runs/admin-runs.controller.test.js dist/admin-runs/admin-runs.service.test.js dist/admin-runs/admin-retrieval-inspector.test.js",
     "test:db-reliability": "tsx --env-file-if-exists=../../.env --test src/prisma/prisma.service.reliability.test.ts",
-    "test:model-stream": "tsx --test src/llm/clients/openai-compatible-stream.adapter.test.ts src/agent-runtime/agent-runtime.service.test.ts src/agent-runtime/model-sampling-decision.test.ts",
+    "test:model-stream": "tsx --test src/llm/clients/openai-compatible-stream.adapter.test.ts src/llm/clients/openai-compatible-raw-capture.test.ts src/agent-runtime/agent-runtime.service.test.ts src/agent-runtime/model-sampling-decision.test.ts src/agent-runtime/model-io-debug-capture.test.ts",
     "test:llm-config": "tsx --test src/llm/model-profiles.test.ts src/llm/llm-runtime-config.test.ts src/llm/llm.module.test.ts src/llm/clients/openai-compatible.client.test.ts",
     "test:seo-service": "pnpm --filter @agent/contracts build && tsx --test src/seo/seo.service.test.ts src/seo/dto/seo-chat.dto.test.ts src/seo/prompts/seo-agent.prompt.test.ts",
     "test:tool-loop": "tsx --test src/agent-runtime/agent-runtime.service.test.ts src/agent-runtime/agent-runtime.policy.test.ts",

--- a/apps/api/src/admin-runs/admin-run.projector.ts
+++ b/apps/api/src/admin-runs/admin-run.projector.ts
@@ -2,6 +2,7 @@ import type {
   AdminAssistantOutputStep,
   AdminContextInspector,
   AdminContextObservationSummary,
+  AdminDebugModelIOCapture,
   AdminGenericStep,
   AdminInitialHistoryExcludedReason,
   AdminLoadConversationHistoryStep,
@@ -336,6 +337,8 @@ function projectModelSampling(
     intermediateTextChars,
     recordedDurationMs,
     contextInspector: projectContextInspector(input, output, step.status),
+    debugRequestBody: readDebugModelIOCapture(output, 'debugRequestBody'),
+    debugRawResponse: readDebugModelIOCapture(output, 'debugRawResponse'),
     inputSummary: summarize([
       ['samplingIndex', samplingIndex],
       ['samplingAttemptId', samplingAttemptId],
@@ -1239,7 +1242,42 @@ function toSafeStepProjection(
     inputSummary: item.inputSummary,
     outputSummary: item.outputSummary,
     hasError: item.hasError,
+    // debug 捕获属于白名单扩展字段：仅 model_sampling 且捕获存在时出现。
+    ...(item.kind === 'known' && item.type === 'model_sampling'
+      ? {
+          ...(item.debugRequestBody
+            ? { debugRequestBody: item.debugRequestBody }
+            : {}),
+          ...(item.debugRawResponse
+            ? { debugRawResponse: item.debugRawResponse }
+            : {}),
+        }
+      : {}),
   }
+}
+
+/**
+ * 读取落库的 debug 捕获信封；结构不符合预期时按未捕获处理（null），不报错。
+ */
+function readDebugModelIOCapture(
+  output: Record<string, unknown> | null,
+  key: 'debugRequestBody' | 'debugRawResponse',
+): AdminDebugModelIOCapture | null {
+  const envelope = readObject(output?.[key])
+
+  if (envelope === null)
+    return null
+
+  if (envelope.truncated === true) {
+    return typeof envelope.preview === 'string'
+      ? { truncated: true, preview: envelope.preview }
+      : null
+  }
+
+  if (envelope.truncated === false && 'value' in envelope)
+    return { truncated: false, value: envelope.value }
+
+  return null
 }
 
 function aggregateSamplingUsage(

--- a/apps/api/src/agent-runtime/agent-runtime.service.ts
+++ b/apps/api/src/agent-runtime/agent-runtime.service.ts
@@ -14,6 +14,7 @@ import type {
 } from './agent-runtime.types.js'
 import type { GroundedFinalizationAttemptSummary } from './grounding/grounded-answer.finalizer.js'
 import type { HistoryCursor } from './initial-context-selection.js'
+import type { DebugModelIOCaptured } from './model-io-debug-capture.js'
 import type {
   ModelSamplingSummary,
   SamplingDecision,
@@ -63,6 +64,7 @@ import {
   InitialContextSelectionService,
 } from './initial-context-selection.js'
 import { ModelContext } from './model-context.js'
+import { toModelIODebugCaptureEnvelope } from './model-io-debug-capture.js'
 import { streamModelSampling } from './model-sampling-decision.js'
 import {
   SamplingContextBudgetExceededError,
@@ -334,6 +336,9 @@ export class AgentRuntimeService {
           },
         }, databaseDeadline)
         const samplingStartedAt = Date.now()
+        // debug 捕获暂存：只有 AGENT_DEBUG_CAPTURE_MODEL_IO 开启时 client 才会回调，
+        // 开关关闭时始终为空对象，落库输出与现状完全一致。
+        const debugModelIO: DebugModelIOCaptured = {}
         let samplingDecision: SamplingDecision
         let contextPlanSummary: SamplingContextPlanSummary | undefined
         let plannedMessageCount = 0
@@ -354,7 +359,17 @@ export class AgentRuntimeService {
           const sampling = streamModelSampling(
             this.llmService.chatStream(
               contextPlan.items,
-              chatStreamOptions,
+              {
+                ...chatStreamOptions,
+                debugCapture: {
+                  onRequest: (requestBody) => {
+                    debugModelIO.requestBody = requestBody
+                  },
+                  onResponse: (rawResponse) => {
+                    debugModelIO.rawResponse = rawResponse
+                  },
+                },
+              },
             ),
             samplingAttemptId,
           )
@@ -393,6 +408,7 @@ export class AgentRuntimeService {
                 Date.now() - samplingStartedAt,
                 plannedMessageCount,
                 contextPlanSummary,
+                debugModelIO,
               ),
             },
           )
@@ -406,6 +422,7 @@ export class AgentRuntimeService {
               Date.now() - samplingStartedAt,
               plannedMessageCount,
               contextPlanSummary,
+              debugModelIO,
             ),
           }
           claimRunTermination(runCancellation, error)
@@ -999,6 +1016,7 @@ export class AgentRuntimeService {
     durationMs: number,
     messageCount: number,
     contextPlan?: SamplingContextPlanSummary,
+    debugModelIO?: DebugModelIOCaptured,
   ) {
     return {
       samplingAttemptId: summary.samplingAttemptId,
@@ -1024,6 +1042,7 @@ export class AgentRuntimeService {
       ...(contextPlan
         ? { contextPlan: contextPlan as unknown as Prisma.InputJsonValue }
         : {}),
+      ...this.toDebugModelIOOutput(debugModelIO),
     }
   }
 
@@ -1032,6 +1051,7 @@ export class AgentRuntimeService {
     durationMs: number,
     messageCount: number,
     contextPlan?: SamplingContextPlanSummary,
+    debugModelIO?: DebugModelIOCaptured,
   ) {
     const failedContextPlan = contextPlan
       ?? (error instanceof SamplingContextBudgetExceededError
@@ -1044,6 +1064,7 @@ export class AgentRuntimeService {
         durationMs,
         messageCount,
         failedContextPlan,
+        debugModelIO,
       )
     }
 
@@ -1059,7 +1080,39 @@ export class AgentRuntimeService {
               failedContextPlan as unknown as Prisma.InputJsonValue,
           }
         : {}),
+      ...this.toDebugModelIOOutput(debugModelIO),
     }
+  }
+
+  /**
+   * 把 debug 捕获暂存收敛成落库字段；未捕获时返回空对象，输出保持现状。
+   * 序列化失败降级为不写该侧字段并记 warning，不影响采样流程。
+   */
+  private toDebugModelIOOutput(
+    debugModelIO?: DebugModelIOCaptured,
+  ): Record<string, Prisma.InputJsonValue> {
+    const output: Record<string, Prisma.InputJsonValue> = {}
+
+    for (const [capturedKey, outputKey] of [
+      ['requestBody', 'debugRequestBody'],
+      ['rawResponse', 'debugRawResponse'],
+    ] as const) {
+      const captured = debugModelIO?.[capturedKey]
+
+      if (captured === undefined)
+        continue
+
+      const envelope = toModelIODebugCaptureEnvelope(captured)
+
+      if (envelope === undefined) {
+        this.logger.warn(`模型 I/O debug 捕获序列化失败，跳过 ${outputKey}`)
+        continue
+      }
+
+      output[outputKey] = envelope as unknown as Prisma.InputJsonValue
+    }
+
+    return output
   }
 
   /**

--- a/apps/api/src/agent-runtime/model-io-debug-capture.test.ts
+++ b/apps/api/src/agent-runtime/model-io-debug-capture.test.ts
@@ -1,0 +1,69 @@
+import assert from 'node:assert/strict'
+// eslint-disable-next-line test/no-import-node-test
+import { describe, it } from 'node:test'
+
+import {
+  MODEL_IO_DEBUG_CAPTURE_MAX_JSON_CHARS,
+  toModelIODebugCaptureEnvelope,
+} from './model-io-debug-capture.js'
+
+describe('toModelIODebugCaptureEnvelope', () => {
+  it('正常值返回未截断信封，并经 JSON round-trip 清理', () => {
+    const envelope = toModelIODebugCaptureEnvelope({
+      model: 'deepseek-v4-flash',
+      messages: [{ role: 'user', content: '你好' }],
+      dropped: undefined,
+    })
+
+    assert.deepEqual(envelope, {
+      truncated: false,
+      value: {
+        model: 'deepseek-v4-flash',
+        messages: [{ role: 'user', content: '你好' }],
+      },
+    })
+  })
+
+  it('超过上限时截断为前缀预览字符串', () => {
+    const envelope = toModelIODebugCaptureEnvelope({
+      content: 'x'.repeat(MODEL_IO_DEBUG_CAPTURE_MAX_JSON_CHARS + 1),
+    })
+
+    assert.ok(envelope)
+    assert.equal(envelope.truncated, true)
+
+    if (envelope.truncated) {
+      assert.equal(
+        envelope.preview.length,
+        MODEL_IO_DEBUG_CAPTURE_MAX_JSON_CHARS,
+      )
+      assert.ok(envelope.preview.startsWith('{"content":"xxx'))
+    }
+  })
+
+  it('截断点落在代理对中间时去掉孤立高位代理', () => {
+    // 让 JSON 序列化后第 MAX-1 / MAX 位恰好是一个 emoji 的两个 code unit。
+    const envelope = toModelIODebugCaptureEnvelope({
+      content: `${'x'.repeat(MODEL_IO_DEBUG_CAPTURE_MAX_JSON_CHARS - 13)}😀`,
+    })
+
+    assert.ok(envelope)
+    assert.equal(envelope.truncated, true)
+
+    if (envelope.truncated) {
+      assert.equal(
+        envelope.preview.length,
+        MODEL_IO_DEBUG_CAPTURE_MAX_JSON_CHARS - 1,
+      )
+      assert.ok(envelope.preview.endsWith('x'))
+    }
+  })
+
+  it('循环引用等不可序列化值降级为 undefined', () => {
+    const circular: Record<string, unknown> = {}
+    circular.self = circular
+
+    assert.equal(toModelIODebugCaptureEnvelope(circular), undefined)
+    assert.equal(toModelIODebugCaptureEnvelope(undefined), undefined)
+  })
+})

--- a/apps/api/src/agent-runtime/model-io-debug-capture.ts
+++ b/apps/api/src/agent-runtime/model-io-debug-capture.ts
@@ -1,0 +1,53 @@
+import type { AdminDebugModelIOCapture } from '@agent/contracts'
+
+/** 一轮采样内暂存的 debug 捕获原始值；未开启捕获时两侧都为 undefined。 */
+export interface DebugModelIOCaptured {
+  requestBody?: unknown
+  rawResponse?: unknown
+}
+
+/** 单侧捕获 JSON 序列化后的截断上限（约 200KB，以字符数近似）。 */
+export const MODEL_IO_DEBUG_CAPTURE_MAX_JSON_CHARS = 200_000
+
+/**
+ * 把 debug 捕获的原始值收敛成可落库的信封。
+ *
+ * - 正常：{ truncated: false, value }（经 JSON round-trip，保证 Prisma Json 兼容）；
+ * - 超限：{ truncated: true, preview } 只保留前缀字符串；
+ * - 序列化失败（循环引用等）：返回 undefined，由调用方降级为不写并记 warning。
+ */
+export function toModelIODebugCaptureEnvelope(
+  value: unknown,
+): AdminDebugModelIOCapture | undefined {
+  let json: string | undefined
+
+  try {
+    json = JSON.stringify(value)
+  }
+  catch {
+    return undefined
+  }
+
+  if (typeof json !== 'string')
+    return undefined
+
+  if (json.length > MODEL_IO_DEBUG_CAPTURE_MAX_JSON_CHARS) {
+    let preview = json.slice(0, MODEL_IO_DEBUG_CAPTURE_MAX_JSON_CHARS)
+    const lastCode = preview.charCodeAt(preview.length - 1)
+
+    // 截断点落在代理对中间会留下孤立高位代理，形成非法 JSON 字符串
+    // （Postgres jsonb 会拒绝），去掉最后一个 code unit。
+    if (lastCode >= 0xD800 && lastCode <= 0xDBFF)
+      preview = preview.slice(0, -1)
+
+    return {
+      truncated: true,
+      preview,
+    }
+  }
+
+  return {
+    truncated: false,
+    value: JSON.parse(json),
+  }
+}

--- a/apps/api/src/llm/clients/openai-compatible-raw-capture.test.ts
+++ b/apps/api/src/llm/clients/openai-compatible-raw-capture.test.ts
@@ -1,0 +1,185 @@
+import type { ChatCompletionChunk } from 'openai/resources/chat/completions'
+import assert from 'node:assert/strict'
+// eslint-disable-next-line test/no-import-node-test
+import { describe, it } from 'node:test'
+
+import { teeRawResponseCapture } from './openai-compatible-raw-capture.js'
+
+describe('teeRawResponseCapture', () => {
+  it('原样透传 chunk，并在流结束后组装完整原始响应', async () => {
+    const chunks = [
+      createChunk({
+        delta: { role: 'assistant', content: '你' },
+      }),
+      createChunk({
+        delta: { content: '好' },
+        finish_reason: 'stop',
+      }),
+      createUsageChunk({
+        prompt_tokens: 10,
+        completion_tokens: 2,
+        total_tokens: 12,
+      }),
+    ]
+    let captured: unknown
+
+    const forwarded: ChatCompletionChunk[] = []
+
+    for await (const chunk of teeRawResponseCapture(
+      toAsyncIterable(chunks),
+      (rawResponse) => {
+        captured = rawResponse
+      },
+    )) {
+      forwarded.push(chunk)
+    }
+
+    assert.deepEqual(forwarded, chunks)
+    assert.deepEqual(captured, {
+      id: 'chunk-1',
+      object: 'chat.completion',
+      created: 1_756_000_000,
+      model: 'deepseek-v4-flash',
+      choices: [
+        {
+          index: 0,
+          finish_reason: 'stop',
+          message: {
+            role: 'assistant',
+            content: '你好',
+          },
+        },
+      ],
+      usage: {
+        prompt_tokens: 10,
+        completion_tokens: 2,
+        total_tokens: 12,
+      },
+    })
+  })
+
+  it('按 index 拼接 tool_calls 分片（非 0 起始时压缩空洞），并保留 reasoning_content', async () => {
+    const chunks = [
+      createChunk({
+        delta: {
+          role: 'assistant',
+          reasoning_content: '需要检索',
+          tool_calls: [
+            {
+              index: 1,
+              id: 'call_1',
+              type: 'function',
+              function: { name: 'search_', arguments: '{"query"' },
+            },
+          ],
+        } as ChatCompletionChunk.Choice.Delta,
+      }),
+      createChunk({
+        delta: {
+          tool_calls: [
+            {
+              index: 1,
+              function: { name: 'articles', arguments: ':"seo"}' },
+            },
+          ],
+        },
+        finish_reason: 'tool_calls',
+      }),
+    ]
+    let captured: unknown
+
+    for await (const _ of teeRawResponseCapture(
+      toAsyncIterable(chunks),
+      (rawResponse) => {
+        captured = rawResponse
+      },
+    )) {
+      // 只消费流
+    }
+
+    assert.deepEqual(captured, {
+      id: 'chunk-1',
+      object: 'chat.completion',
+      created: 1_756_000_000,
+      model: 'deepseek-v4-flash',
+      choices: [
+        {
+          index: 0,
+          finish_reason: 'tool_calls',
+          message: {
+            role: 'assistant',
+            content: null,
+            reasoning_content: '需要检索',
+            tool_calls: [
+              {
+                id: 'call_1',
+                type: 'function',
+                function: {
+                  name: 'search_articles',
+                  arguments: '{"query":"seo"}',
+                },
+              },
+            ],
+          },
+        },
+      ],
+    })
+  })
+
+  it('流中途抛错时不产生捕获结果并透传错误', async () => {
+    let captured: unknown
+    const failing = async function* (): AsyncGenerator<ChatCompletionChunk> {
+      yield createChunk({ delta: { content: '部分' } })
+      throw new Error('stream broken')
+    }
+
+    await assert.rejects(async () => {
+      for await (const _ of teeRawResponseCapture(failing(), (rawResponse) => {
+        captured = rawResponse
+      })) {
+        // 只消费流
+      }
+    }, /stream broken/)
+
+    assert.equal(captured, undefined)
+  })
+})
+
+function createChunk(choice: {
+  delta: ChatCompletionChunk.Choice.Delta
+  finish_reason?: ChatCompletionChunk.Choice['finish_reason']
+}): ChatCompletionChunk {
+  return {
+    id: 'chunk-1',
+    object: 'chat.completion.chunk',
+    created: 1_756_000_000,
+    model: 'deepseek-v4-flash',
+    choices: [
+      {
+        index: 0,
+        delta: choice.delta,
+        finish_reason: choice.finish_reason ?? null,
+        logprobs: null,
+      },
+    ],
+  }
+}
+
+function createUsageChunk(
+  usage: NonNullable<ChatCompletionChunk['usage']>,
+): ChatCompletionChunk {
+  return {
+    id: 'chunk-1',
+    object: 'chat.completion.chunk',
+    created: 1_756_000_000,
+    model: 'deepseek-v4-flash',
+    choices: [],
+    usage,
+  }
+}
+
+async function* toAsyncIterable(
+  chunks: ChatCompletionChunk[],
+): AsyncGenerator<ChatCompletionChunk> {
+  yield* chunks
+}

--- a/apps/api/src/llm/clients/openai-compatible-raw-capture.ts
+++ b/apps/api/src/llm/clients/openai-compatible-raw-capture.ts
@@ -1,0 +1,101 @@
+import type { ChatCompletionChunk } from 'openai/resources/chat/completions'
+
+interface RawToolCallSlot {
+  id?: string
+  type?: string
+  function: {
+    name: string
+    arguments: string
+  }
+}
+
+/**
+ * debug 捕获用的透传聚合器：原样转发每个 chunk，同时把流式 delta 组装成
+ * 一份非流式形态的原始响应 JSON，流正常结束后交给 onResponse。
+ *
+ * 只做字段拼接，不做业务校验（校验属于 stream adapter 的职责）；
+ * 流中途抛错时不产生捕获结果。
+ */
+export async function* teeRawResponseCapture(
+  chunks: AsyncIterable<ChatCompletionChunk>,
+  onResponse: (rawResponse: unknown) => void,
+): AsyncGenerator<ChatCompletionChunk> {
+  let id: string | undefined
+  let model: string | undefined
+  let created: number | undefined
+  let finishReason: string | null = null
+  let usage: ChatCompletionChunk['usage'] | undefined
+  const contentChunks: string[] = []
+  const reasoningContentChunks: string[] = []
+  const toolCalls: RawToolCallSlot[] = []
+
+  for await (const chunk of chunks) {
+    id ??= chunk.id
+    model ??= chunk.model
+    created ??= chunk.created
+
+    const choice = chunk.choices[0]
+
+    if (choice) {
+      const delta = choice.delta as ChatCompletionChunk.Choice.Delta & {
+        reasoning_content?: string | null
+      }
+
+      if (delta.content)
+        contentChunks.push(delta.content)
+      if (delta.reasoning_content)
+        reasoningContentChunks.push(delta.reasoning_content)
+
+      for (const toolCallDelta of delta.tool_calls ?? []) {
+        const slot = toolCalls[toolCallDelta.index]
+          ?? (toolCalls[toolCallDelta.index] = { function: { name: '', arguments: '' } })
+
+        if (toolCallDelta.id)
+          slot.id = toolCallDelta.id
+        if (toolCallDelta.type)
+          slot.type = toolCallDelta.type
+        if (toolCallDelta.function?.name)
+          slot.function.name += toolCallDelta.function.name
+        if (toolCallDelta.function?.arguments)
+          slot.function.arguments += toolCallDelta.function.arguments
+      }
+
+      if (choice.finish_reason)
+        finishReason = choice.finish_reason
+    }
+
+    if (chunk.usage)
+      usage = chunk.usage
+
+    yield chunk
+  }
+
+  const content = contentChunks.join('')
+  const reasoningContent = reasoningContentChunks.join('')
+  // index 由 provider 提供，可能非 0 起始或有空洞；压缩稀疏位，避免序列化出 null 项。
+  const compactToolCalls = toolCalls.filter(slot => slot !== undefined)
+
+  onResponse({
+    id,
+    object: 'chat.completion',
+    created,
+    model,
+    choices: [
+      {
+        index: 0,
+        finish_reason: finishReason,
+        message: {
+          role: 'assistant',
+          content: content.length > 0 ? content : null,
+          ...(reasoningContent.length > 0
+            ? { reasoning_content: reasoningContent }
+            : {}),
+          ...(compactToolCalls.length > 0
+            ? { tool_calls: compactToolCalls }
+            : {}),
+        },
+      },
+    ],
+    ...(usage ? { usage } : {}),
+  })
+}

--- a/apps/api/src/llm/clients/openai-compatible.client.ts
+++ b/apps/api/src/llm/clients/openai-compatible.client.ts
@@ -38,6 +38,7 @@ import {
   LLMRateLimitError,
   LLMServerError,
 } from '../llm.errors.js'
+import { teeRawResponseCapture } from './openai-compatible-raw-capture.js'
 import { adaptOpenAICompatibleStream } from './openai-compatible-stream.adapter.js'
 
 type ChatCompletionBaseParams = Pick<
@@ -111,24 +112,37 @@ export class OpenAICompatibleClient {
       timeout: this.runtimeConfigService.value.streamTimeoutMs,
       ...(options?.signal ? { signal: options.signal } : {}),
     }
+    // debug 捕获只在开关开启且调用方提供回调时生效；请求体不含 apiKey / baseUrl
+    // 等凭据（它们只存在于 SDK client 配置里，不在请求 params 中）。
+    const debugCapture = this.runtimeConfigService.value.captureModelIO
+      ? options?.debugCapture
+      : undefined
 
     try {
-      const stream = await client.chat.completions.create(
-        {
-          ...this.buildBaseChatCompletionParams(
-            messages.map(toOpenAIModelInputItem),
-            options,
-          ),
-          ...toOpenAIChatTools(options?.tools),
-          stream: true,
-          stream_options: {
-            include_usage: true,
-          },
+      const requestParams = {
+        ...this.buildBaseChatCompletionParams(
+          messages.map(toOpenAIModelInputItem),
+          options,
+        ),
+        ...toOpenAIChatTools(options?.tools),
+        stream: true as const,
+        stream_options: {
+          include_usage: true,
         },
+      }
+
+      debugCapture?.onRequest(requestParams)
+
+      const stream = await client.chat.completions.create(
+        requestParams,
         requestOptions,
       )
 
-      yield* adaptOpenAICompatibleStream(stream)
+      yield* adaptOpenAICompatibleStream(
+        debugCapture
+          ? teeRawResponseCapture(stream, debugCapture.onResponse)
+          : stream,
+      )
     }
     catch (cause) {
       throw this.toLLMError(cause)

--- a/apps/api/src/llm/llm-runtime-config.test.ts
+++ b/apps/api/src/llm/llm-runtime-config.test.ts
@@ -21,6 +21,29 @@ describe('resolveLLMRuntimeConfig', () => {
     })
   })
 
+  it('AGENT_DEBUG_CAPTURE_MODEL_IO 只接受 1 / true 为开启', () => {
+    for (const enabled of ['1', 'true', 'TRUE', ' true ']) {
+      assert.equal(
+        resolveLLMRuntimeConfig(
+          createEnv({ AGENT_DEBUG_CAPTURE_MODEL_IO: enabled }),
+        ).captureModelIO,
+        true,
+      )
+    }
+    for (const disabled of [undefined, '', '0', 'false', 'yes', 'on']) {
+      assert.equal(
+        resolveLLMRuntimeConfig(
+          createEnv(
+            disabled === undefined
+              ? {}
+              : { AGENT_DEBUG_CAPTURE_MODEL_IO: disabled },
+          ),
+        ).captureModelIO,
+        false,
+      )
+    }
+  })
+
   it('接受边界内的严格正整数覆盖', () => {
     const config = resolveLLMRuntimeConfig(createEnv({
       LLM_CHAT_REQUEST_TIMEOUT_MS: '90000',

--- a/apps/api/src/llm/llm-runtime-config.ts
+++ b/apps/api/src/llm/llm-runtime-config.ts
@@ -13,6 +13,7 @@ export const DEFAULT_LLM_RUNTIME_CONFIG = {
   streamTimeoutMs: 600_000,
   defaultMaxOutputTokens: 65_536,
   applicationMaxOutputTokens: 131_072,
+  captureModelIO: false,
 } as const
 
 export interface LLMRuntimeConfig {
@@ -24,6 +25,8 @@ export interface LLMRuntimeConfig {
   streamTimeoutMs: number
   defaultMaxOutputTokens: number
   applicationMaxOutputTokens: number
+  /** debug 开关：是否捕获 provider 原始请求 / 响应 JSON，默认关闭。 */
+  captureModelIO: boolean
 }
 
 export interface ChatRequestConfig {
@@ -97,7 +100,14 @@ export function resolveLLMRuntimeConfig(
     streamTimeoutMs,
     defaultMaxOutputTokens,
     applicationMaxOutputTokens,
+    captureModelIO: readBooleanFlag(env, 'AGENT_DEBUG_CAPTURE_MODEL_IO'),
   }
+}
+
+function readBooleanFlag(env: NodeJS.ProcessEnv, name: string): boolean {
+  const value = env[name]?.trim().toLowerCase()
+
+  return value === '1' || value === 'true'
 }
 
 export function resolveChatRequestConfig(

--- a/apps/api/src/llm/llm.types.ts
+++ b/apps/api/src/llm/llm.types.ts
@@ -31,12 +31,28 @@ export interface ChatOptions {
   responseFormat?: { type: 'json_object' } | { type: 'text' }
 }
 
+/**
+ * debug 模型 I/O 捕获回调。
+ *
+ * 仅当 AGENT_DEBUG_CAPTURE_MODEL_IO 开启时由 client 调用；载荷是 provider
+ * 原始 JSON，类型刻意保持 unknown——它只用于观测落库，不进入业务逻辑，
+ * 不构成对"不暴露 OpenAI SDK 原始 response"边界的破例。
+ */
+export interface ModelIODebugCapture {
+  /** 请求真正发出前回调，body 为实际请求体（不含凭据）。 */
+  onRequest: (requestBody: unknown) => void
+  /** 模型流正常结束后回调，raw 为流式组装出的完整原始响应。 */
+  onResponse: (rawResponse: unknown) => void
+}
+
 /** chatStream() 方法的可选参数。 */
 export interface ChatStreamOptions extends ChatOptions {
   /** 外部中止信号，用于后续支持用户主动停止生成。 */
   signal?: AbortSignal
   /** 只包含模型可见字段的工具说明。 */
   tools?: ModelToolSpec[]
+  /** debug 捕获回调；未开启捕获开关时不会被调用。 */
+  debugCapture?: ModelIODebugCapture
 }
 
 export const SUPPORTED_DEEPSEEK_MODELS = [

--- a/packages/contracts/src/admin-run.ts
+++ b/packages/contracts/src/admin-run.ts
@@ -323,6 +323,16 @@ export interface AdminLoadConversationHistoryStep extends AdminRunKnownTimelineI
   messageCount: number | null
 }
 
+/**
+ * debug 捕获的模型 I/O 原始 JSON 信封。
+ *
+ * 仅在 AGENT_DEBUG_CAPTURE_MODEL_IO 开启时产生；value 为 provider 原始 JSON，
+ * 只用于观测展示，不参与任何业务逻辑。超过截断上限时只保留 preview 字符串。
+ */
+export type AdminDebugModelIOCapture
+  = | { truncated: false, value: unknown }
+    | { truncated: true, preview: string }
+
 export interface AdminModelSamplingStep extends AdminRunKnownTimelineItemBase {
   type: 'model_sampling'
   samplingIndex: number | null
@@ -338,6 +348,10 @@ export interface AdminModelSamplingStep extends AdminRunKnownTimelineItemBase {
   intermediateTextChars: number | null
   recordedDurationMs: number | null
   contextInspector: AdminContextInspector
+  /** debug 捕获：实际发给 provider 的请求体；未开启捕获或数据缺失为 null。 */
+  debugRequestBody: AdminDebugModelIOCapture | null
+  /** debug 捕获：流式组装后的 provider 原始响应；未开启捕获或数据缺失为 null。 */
+  debugRawResponse: AdminDebugModelIOCapture | null
 }
 
 export interface AdminToolExecutionStep extends AdminRunKnownTimelineItemBase {
@@ -401,6 +415,9 @@ export interface AdminRunSafeStepProjection {
   inputSummary: string | null
   outputSummary: string | null
   hasError: boolean
+  /** debug 捕获白名单字段：仅 model_sampling 且捕获存在时出现。 */
+  debugRequestBody?: AdminDebugModelIOCapture
+  debugRawResponse?: AdminDebugModelIOCapture
 }
 
 export interface AdminRunSafeRawData {

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -4,6 +4,7 @@ export type {
   AdminContextInspectorAvailability,
   AdminContextInspectorOutcome,
   AdminContextObservationSummary,
+  AdminDebugModelIOCapture,
   AdminGenericStep,
   AdminGroundedAnswerRejectionCode,
   AdminGroundedCitationCorrelation,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -53,6 +53,9 @@ importers:
       vue-i18n:
         specifier: ^11.4.6
         version: 11.4.6(vue@3.5.35(typescript@6.0.3))
+      vue-json-pretty:
+        specifier: ^2.6.0
+        version: 2.6.0(vue@3.5.35(typescript@6.0.3))
       vue-router:
         specifier: ^5.1.0
         version: 5.1.0(@vue/compiler-sfc@3.5.35)(pinia@3.0.4(typescript@6.0.3)(vue@3.5.35(typescript@6.0.3)))(vite@7.3.3(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.22.3)(yaml@2.9.0))(vue@3.5.35(typescript@6.0.3))
@@ -3690,6 +3693,12 @@ packages:
     engines: {node: '>= 22'}
     peerDependencies:
       vue: ^3.0.0
+
+  vue-json-pretty@2.6.0:
+    resolution: {integrity: sha512-glz1aBVS35EO8+S9agIl3WOQaW2cJZW192UVKTuGmryx01ZvOVWc4pR3t+5UcyY4jdOfBUgVHjcpRpcnjRhCAg==}
+    engines: {node: '>= 10.0.0', npm: '>= 5.0.0'}
+    peerDependencies:
+      vue: '>=3.0.0'
 
   vue-router@5.1.0:
     resolution: {integrity: sha512-HAbiLzLEHQwxPgvsbOJDAwtavszEgLwri6XfyrsPECIFez8+59xc9LofWVdc/HEaSRT822lJ8H9Ns38VVond5g==}
@@ -7366,6 +7375,10 @@ snapshots:
       '@intlify/devtools-types': 11.4.6
       '@intlify/shared': 11.4.6
       '@vue/devtools-api': 6.6.4
+      vue: 3.5.35(typescript@6.0.3)
+
+  vue-json-pretty@2.6.0(vue@3.5.35(typescript@6.0.3)):
+    dependencies:
       vue: 3.5.35(typescript@6.0.3)
 
   vue-router@5.1.0(@vue/compiler-sfc@3.5.35)(pinia@3.0.4(typescript@6.0.3)(vue@3.5.35(typescript@6.0.3)))(vite@7.3.3(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.22.3)(yaml@2.9.0))(vue@3.5.35(typescript@6.0.3)):


### PR DESCRIPTION
Closes #86

## 改动摘要

- **开关**:新增 `AGENT_DEBUG_CAPTURE_MODEL_IO`(默认关闭;`LLMRuntimeConfig.captureModelIO`),`.env.example` 已同步。关闭时 `model_sampling` step 落库输出与现状完全一致。
- **请求侧捕获**:`OpenAICompatibleClient.chatStream` 在开关开启且调用方提供 `debugCapture` 回调时,把实际发出的请求 params(model、messages、tools、temperature、max_tokens、stream 参数;不含 apiKey/baseUrl,它们只在 SDK client 配置里)回调给运行时。
- **响应侧捕获**:新增 `teeRawResponseCapture` 透传聚合器,把流式 chunk 组装成非流式形态的原始响应(content / reasoning_content / tool_calls 按 index 拼接并压缩空洞 / finish_reason / usage),流正常结束后回调;中途抛错不产生捕获。
- **落库**:新增 `toModelIODebugCaptureEnvelope` 截断信封(约 200K 字符上限、截断点代理对安全、序列化失败降级为不写 + warning),挂到 `model_sampling` step `output.debugRequestBody` / `output.debugRawResponse`,失败路径同样携带。
- **投影**:contracts 新增 `AdminDebugModelIOCapture`;`AdminModelSamplingStep` 增加两个 debug 字段;`safeRawData` 白名单按 Issue 决策纳入(仅 model_sampling 且捕获存在时出现)。
- **后台 UI**:请求检查器新增「请求体」「原始响应」两个 tab,新组件 `DebugJsonPane`(vue-json-pretty 折叠树 + 复制按钮 + 未捕获/已截断提示 + 大 JSON 虚拟滚动;字段缺失或为 null 均按未捕获处理)。

### 与 Issue 的偏差说明

- Issue 示意 `input.debugRequestBody`;实现将请求体与原始响应都放在 `output`,因为 recorder 的 `completeStep` / 失败收口只更新 `output`,且请求体在 step 创建之后才构建。语义上仍按"请求/响应"分 tab 展示,无信息损失。

### 明确未做

- 不捕获 finalization Prompt / reasoning / hidden draft(维持既有刻意排除设计,finalization 的 `chatStream` 调用未传 `debugCapture`)。
- 不做逐 SSE chunk 持久化、不改 Prisma schema、不动 tool_execution 等其他 step。

## 验证

| 命令 | 结果 |
| --- | --- |
| `pnpm typecheck` | api / web / admin 全部通过 |
| `pnpm --filter @agent/api lint`、`--filter @agent/admin lint` | 0 错误(根 `pnpm lint` 的 110 个报错全部位于 `docs/research/**` markdown 代码块,为改动前既有基线) |
| `pnpm --filter @agent/api test:model-stream` | 77 pass(含新增 raw-capture 3 个、debug-capture 信封 4 个) |
| `pnpm --filter @agent/api test:llm-config` | 18 pass(含开关解析用例) |
| `pnpm --filter @agent/api test:admin-runs` | 139 pass(投影兼容,历史数据无 debug 字段不受影响) |
| `pnpm --filter @agent/admin test` | admin state / i18n / run data checks 全过 |
| `pnpm --filter @agent/admin build` | 通过(vue-json-pretty 打包正常) |

端到端人工验证路径(留待验收):`.env` 已置 `AGENT_DEBUG_CAPTURE_MODEL_IO=1`,重启 API(注意 `dev` 跑 dist,需先 build 或用 `dev:api:watch`)后发一条新消息,在后台该 run 的请求检查器查看两个新 tab;历史 run 显示「未捕获」提示属预期。

## commit 前 /code-review 结论与处理

共 8 条 findings:

**已修复(4)**
1. 截断点劈开代理对可能产生非法 JSON 字符串 → slice 后检测并去掉孤立高位代理,新增测试。
2. `apps/admin/e2e/fixtures.ts` 的 samplingStep fixture 漏加新必填字段(e2e 在 tsconfig/lint 范围外,工具查不到)→ 已补 `debugRequestBody/debugRawResponse: null`;`DebugJsonPane` 空态判断同时已从 `=== null` 改为 falsy(兼容旧 API 返回的 undefined)。
3. tool_calls 按 provider index 落位,非 0 起始/空洞会序列化出 null 项 → 输出前压缩稀疏位,测试改为 index=1 覆盖。
4. vue-json-pretty 未开虚拟滚动,近上限 JSON 一次渲染全部节点 → 超过 50K 字符启用 `virtual`。

**误报(1)**
5. "改动直接落在 master":实际全程在 `codex/issue-86-model-io-capture` 分支,review 环境读取 git 状态有误。

**不修——与已确认规格冲突(2)**
6. "debug 字段不应进 safeRawData":Issue #86 澄清与决策记录明确"debug 字段纳入 safeRawData 白名单",验收标准要求安全原始数据 tab 可一键复制该 JSON,按事实来源保留。
7. "vue-json-pretty 依赖可用 `<pre>` 替代":组件选型是 Gate 决策(用户明确要求 VS Code 风格可折叠预览,现有依赖无此能力),保留;虚拟滚动问题已按第 4 条修复。

**不修——超出 Issue 范围,记为已知风险(1)**
8. admin 列表查询(`ADMIN_RUN_LIST_SELECT`)拉全量 step output,debug 开启后列表变重:根治需独立存储/schema 变更,Issue 明确"不改 Prisma schema、不加新表";开关默认关闭、学习环境可控。若未来长期开启,应把捕获移到独立列或表。

## 已知风险

- 同上第 8 条:debug 开启期间 run 列表/详情响应体积随捕获增大(单侧 ≤200K 字符,截断保护已有)。
- 「原始响应」为流式重组结果(代码注释已标注),不保留未知 provider 字段(如未来新增的 delta 字段);DeepSeek 当前字段(content/reasoning_content/tool_calls/usage/finish_reason)已全覆盖。

## 建议阅读顺序与调用链

1. `packages/contracts/src/admin-run.ts` — `AdminDebugModelIOCapture` 信封契约。
2. `apps/api/src/llm/llm-runtime-config.ts` → `llm.types.ts`(`ModelIODebugCapture` 回调边界)。
3. `apps/api/src/llm/clients/openai-compatible.client.ts` → `openai-compatible-raw-capture.ts`(捕获点与流重组)。
4. `apps/api/src/agent-runtime/agent-runtime.service.ts`(采样循环接线)→ `model-io-debug-capture.ts`(截断信封)。
5. `apps/api/src/admin-runs/admin-run.projector.ts`(投影 + safeRawData 白名单)。
6. `apps/admin/.../RequestInspector.vue` → `DebugJsonPane.vue`(展示)。

调用链:`AgentRuntimeService.runTurnStream`(per-attempt `debugCapture` 回调)→ `LLMService.chatStream` → `OpenAICompatibleClient.chatStream`(开关判定,onRequest;`teeRawResponseCapture` 包裹流,onResponse)→ 采样结束 `toSamplingStepOutput` / 失败 `toFailedSamplingStepOutput` → `toModelIODebugCaptureEnvelope` 截断落库 → `admin-run.projector` 投影 → `RequestInspector` 两个新 tab。

实施状态:已实现 / 验收状态:待验收

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014iWCQ6bVoFnjiDZA8y5ycz
