### PR TITLE
refactor(agent-runtime): 收敛单次 Run 配置解析边界与配置导航（#92）

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -50,7 +50,7 @@ Claude Code 应作为 Agent 应用开发学习搭档，负责按正式 Issue 实
 
 `docs/development-task-plan.md` 只保留为旧入口兼容，不再写入新任务。
 
-当前 Agent 主线状态：Phase 1-8 已 Completed 并归档（Phase 8 Task 0、1、2A、2B、3A、3B、3C 全部 Completed）；当前无 Active Agent Task；当前阶段为 Phase 8 源码阅读（学习阶段），下一阶段学习内容暂不定义；Phase 9 未定案；Minimal Compaction 继续保持 Gated；Admin Task 4 保持 Planned。
+当前 Agent 主线状态：Phase 1-8 已 Completed 并归档（Phase 8 Task 0、1、2A、2B、3A、3B、3C 全部 Completed）；当前 Active Agent Task 为 Run 配置解析边界（#92，已实现、待验收）；当前阶段为 Phase 8 源码阅读（学习阶段），下一阶段学习内容暂不定义；Phase 9 未定案；Minimal Compaction 继续保持 Gated；Admin Task 4 保持 Planned。
 
 ## 4. 关键目录与任务入口
 

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -33,7 +33,7 @@
     "test:model-stream": "tsx --test src/llm/clients/openai-compatible-stream.adapter.test.ts src/llm/clients/openai-compatible-raw-capture.test.ts src/agent-runtime/agent-runtime.service.test.ts src/agent-runtime/model-sampling-decision.test.ts src/agent-runtime/model-io-debug-capture.test.ts",
     "test:llm-config": "tsx --test src/llm/model-profiles.test.ts src/llm/llm-runtime-config.test.ts src/llm/llm.module.test.ts src/llm/clients/openai-compatible.client.test.ts",
     "test:seo-service": "pnpm --filter @agent/contracts build && tsx --test src/seo/seo.service.test.ts src/seo/dto/seo-chat.dto.test.ts src/seo/prompts/seo-agent.prompt.test.ts",
-    "test:tool-loop": "tsx --test src/agent-runtime/agent-runtime.service.test.ts src/agent-runtime/agent-runtime.policy.test.ts",
+    "test:tool-loop": "tsx --test src/agent-runtime/agent-runtime.service.test.ts src/agent-runtime/agent-runtime.policy.test.ts src/agent-runtime/agent-run-configuration.service.test.ts",
     "test:tools": "tsx --test src/tools/*.test.ts src/tools/**/*.test.ts",
     "pretypecheck": "pnpm --workspace-root prisma:generate",
     "typecheck": "tsc --noEmit",

--- a/apps/api/src/agent-runtime/agent-run-configuration.service.test.ts
+++ b/apps/api/src/agent-runtime/agent-run-configuration.service.test.ts
@@ -1,0 +1,156 @@
+import type { LLMService } from '../llm/llm.service.js'
+import type { ToolRegistryService } from '../tools/core/tool-registry.service.js'
+import type { ToolDefinition } from '../tools/core/tool.types.js'
+import type { AgentRuntimePolicy, AgentRuntimePolicyService } from './agent-runtime.policy.js'
+import assert from 'node:assert/strict'
+// 项目本轮使用 Node 原生测试运行器，不引入 Vitest。
+// eslint-disable-next-line test/no-import-node-test
+import { describe, it } from 'node:test'
+
+import { AgentRunConfigurationService } from './agent-run-configuration.service.js'
+import { DEFAULT_AGENT_RUNTIME_POLICY } from './agent-runtime.policy.js'
+
+function createToolDefinition(name: string): ToolDefinition {
+  return {
+    name,
+    version: '1',
+    description: `${name} 测试定义`,
+    input: {
+      schema: {
+        type: 'object',
+        properties: {},
+        required: [],
+        additionalProperties: false,
+      },
+      parse: () => ({}),
+    },
+    timeoutMs: 1_000,
+    maxObservationChars: 1_000,
+    requiresApproval: false,
+    idempotent: true,
+    risk: {
+      level: 'low',
+      sideEffect: 'none',
+      network: 'none',
+    },
+    evidencePolicy: 'discovery_only',
+  }
+}
+
+function createService(input: {
+  policy?: Partial<AgentRuntimePolicy>
+  registeredToolNames?: string[]
+} = {}) {
+  const resolveCalls: Array<Record<string, unknown> | undefined> = []
+  const llmService = {
+    resolveChatRequestConfig: (options?: {
+      model?: string
+      temperature?: number
+      maxTokens?: number
+    }) => {
+      resolveCalls.push(options)
+
+      return {
+        model: options?.model ?? 'deepseek-v4-flash',
+        contextWindowTokens: 1_000_000,
+        maxOutputTokens: options?.maxTokens ?? 65_536,
+        temperature: options?.temperature ?? 0.7,
+      }
+    },
+  } as unknown as LLMService
+  const registeredToolNames = input.registeredToolNames
+    ?? [
+      'hidden_admin_tool',
+      'get_article_detail',
+      'retrieve_article_context',
+      'search_articles',
+    ]
+  const registry = {
+    get: (name: string) => (
+      registeredToolNames.includes(name)
+        ? { definition: createToolDefinition(name) }
+        : undefined
+    ),
+  } as unknown as ToolRegistryService
+  const service = new AgentRunConfigurationService(
+    {
+      value: { ...DEFAULT_AGENT_RUNTIME_POLICY, ...input.policy },
+    } as AgentRuntimePolicyService,
+    llmService,
+    registry,
+  )
+
+  return { service, resolveCalls }
+}
+
+describe('AgentRunConfigurationService', () => {
+  it('组合 resolved 请求配置与 allowlist 内 Tool，排除未列入的工具', () => {
+    const { service } = createService()
+
+    const configuration = service.resolve({ temperature: 0.4 })
+
+    assert.deepEqual(service.policy, DEFAULT_AGENT_RUNTIME_POLICY)
+    assert.deepEqual(
+      configuration.toolDefinitions.map(definition => definition.name),
+      ['search_articles', 'get_article_detail', 'retrieve_article_context'],
+    )
+    assert.deepEqual(
+      configuration.modelTools.map(tool => tool.name),
+      ['search_articles', 'get_article_detail', 'retrieve_article_context'],
+    )
+    assert.deepEqual(configuration.request, {
+      model: 'deepseek-v4-flash',
+      contextWindowTokens: 1_000_000,
+      maxOutputTokens: 65_536,
+      temperature: 0.4,
+    })
+  })
+
+  it('maxToolCalls=0 时不向模型暴露任何 Tool，但保留服务端定义', () => {
+    const { service } = createService({ policy: { maxToolCalls: 0 } })
+
+    const configuration = service.resolve({ temperature: 0.4 })
+
+    assert.deepEqual(configuration.modelTools, [])
+    assert.equal(configuration.toolDefinitions.length, 3)
+  })
+
+  it('Registry 缺少 allowlisted Tool 时跳过，不伪造定义', () => {
+    const { service } = createService({
+      registeredToolNames: ['search_articles'],
+    })
+
+    const configuration = service.resolve({ temperature: 0.4 })
+
+    assert.deepEqual(
+      configuration.toolDefinitions.map(definition => definition.name),
+      ['search_articles'],
+    )
+    assert.deepEqual(
+      configuration.modelTools.map(tool => tool.name),
+      ['search_articles'],
+    )
+  })
+
+  it('请求级覆盖透传给 LLM 解析边界；空字符串 model 回落默认', () => {
+    const { service, resolveCalls } = createService()
+
+    const configuration = service.resolve({
+      model: 'deepseek-v4-pro',
+      temperature: 0.4,
+      maxTokens: 4_096,
+    })
+
+    assert.deepEqual(resolveCalls[0], {
+      model: 'deepseek-v4-pro',
+      temperature: 0.4,
+      maxTokens: 4_096,
+    })
+    assert.equal(configuration.request.model, 'deepseek-v4-pro')
+    assert.equal(configuration.request.maxOutputTokens, 4_096)
+
+    // 空字符串回落默认模型是重构前 runTurnStream 的既有语义，这里锁定现状。
+    service.resolve({ model: '', temperature: 0.4 })
+    assert.deepEqual(resolveCalls[1], { temperature: 0.4 })
+  })
+})

--- a/apps/api/src/agent-runtime/agent-run-configuration.service.ts
+++ b/apps/api/src/agent-runtime/agent-run-configuration.service.ts
@@ -1,0 +1,110 @@
+import type { ResolvedChatRequestConfig } from '../llm/llm-runtime-config.js'
+import type { ModelToolSpec } from '../llm/model-tool-spec.types.js'
+import type { ToolDefinition } from '../tools/core/tool.types.js'
+import type { AgentRuntimePolicy } from './agent-runtime.policy.js'
+
+import { Inject, Injectable, Logger } from '@nestjs/common'
+
+import { LLMService } from '../llm/llm.service.js'
+import { toModelToolSpec } from '../tools/core/model-tool-spec.mapper.js'
+import { ToolRegistryService } from '../tools/core/tool-registry.service.js'
+import { AgentRuntimePolicyService } from './agent-runtime.policy.js'
+
+/** 单次 Agent Run 允许暴露给模型的 Tool allowlist；顺序即暴露顺序。 */
+const AGENT_RUN_TOOL_NAMES = [
+  'search_articles',
+  'get_article_detail',
+  'retrieve_article_context',
+] as const
+
+/** 请求级配置覆盖，来自单轮用户输入。 */
+export interface AgentRunRequestOverrides {
+  model?: string
+  temperature?: number
+  maxTokens?: number
+}
+
+/**
+ * 一次 Agent Run 的完整已解析配置。
+ *
+ * 只包含单次 Run 编排所需的事实：resolved 模型请求配置、allowlist 内的
+ * Tool 定义与模型可见 Tool 说明。运行策略经 `policy` getter 单独读取
+ * （deadline 时序要求），不在返回值中重复暴露。数据库、Embedding、
+ * Admin 等应用级配置不属于这里。
+ */
+export interface ResolvedAgentRunConfiguration {
+  request: ResolvedChatRequestConfig
+  toolDefinitions: ToolDefinition[]
+  modelTools: ModelToolSpec[]
+}
+
+/**
+ * 单次 Agent Run 配置解析入口。
+ *
+ * 各领域配置仍由各自边界定义与校验（Policy 环境解析、LLM 请求校验、
+ * Tool Definition 自带 policy）；本服务只负责把它们组合成一份
+ * ResolvedAgentRunConfiguration，让 AgentRuntimeService 不再自行
+ * 读取 Policy、筛选 Tool 或穿透 LLM 边界补查 Model Profile。
+ */
+@Injectable()
+export class AgentRunConfigurationService {
+  private readonly logger = new Logger(AgentRunConfigurationService.name)
+
+  constructor(
+    @Inject(AgentRuntimePolicyService)
+    private readonly runtimePolicyService: AgentRuntimePolicyService,
+
+    @Inject(LLMService)
+    private readonly llmService: LLMService,
+
+    @Inject(ToolRegistryService)
+    private readonly toolRegistryService: ToolRegistryService,
+  ) {}
+
+  /**
+   * 运行策略单独暴露：Run deadline 必须在请求级配置解析（可能抛
+   * LLMConfigError）之前生效，Policy 本身是启动期已校验的非抛错读取。
+   */
+  get policy(): AgentRuntimePolicy {
+    return this.runtimePolicyService.value
+  }
+
+  /**
+   * 解析一次 Run 的完整配置。
+   *
+   * 请求级 model / maxTokens 非法时抛 LLMConfigError；调用时机由
+   * Runtime 控制，以保持配置错误发生时既有的 Run 终态化语义。
+   * Registry 缺失 allowlisted Tool 时按现状跳过，不伪造定义。
+   */
+  resolve(overrides: AgentRunRequestOverrides): ResolvedAgentRunConfiguration {
+    const toolDefinitions = AGENT_RUN_TOOL_NAMES.flatMap((name) => {
+      const definition = this.toolRegistryService.get(name)?.definition
+
+      if (!definition) {
+        this.logger.warn(`allowlist 工具 ${name} 未在 Registry 注册，本次 Run 不暴露该工具`)
+
+        return []
+      }
+
+      return [definition]
+    })
+    const modelTools = this.policy.maxToolCalls === 0
+      ? []
+      : toolDefinitions.map(toModelToolSpec)
+    const request = this.llmService.resolveChatRequestConfig({
+      ...(overrides.model ? { model: overrides.model } : {}),
+      ...(overrides.temperature === undefined
+        ? {}
+        : { temperature: overrides.temperature }),
+      ...(overrides.maxTokens === undefined
+        ? {}
+        : { maxTokens: overrides.maxTokens }),
+    })
+
+    return {
+      request,
+      toolDefinitions,
+      modelTools,
+    }
+  }
+}

--- a/apps/api/src/agent-runtime/agent-runtime.module.ts
+++ b/apps/api/src/agent-runtime/agent-runtime.module.ts
@@ -2,6 +2,7 @@ import { Module } from '@nestjs/common'
 
 import { PrismaModule } from '../prisma/prisma.module.js'
 import { ToolsModule } from '../tools/tools.module.js'
+import { AgentRunConfigurationService } from './agent-run-configuration.service.js'
 import { AgentRunRecorderService } from './agent-run-recorder.service.js'
 import { AgentRuntimePolicyService } from './agent-runtime.policy.js'
 import { AgentRuntimeService } from './agent-runtime.service.js'
@@ -16,6 +17,7 @@ import { SamplingContextPlanner } from './sampling-context-planner.js'
   imports: [PrismaModule, ToolsModule],
   providers: [
     AgentRuntimePolicyService,
+    AgentRunConfigurationService,
     DeepSeekV4TokenEstimator,
     {
       provide: TokenEstimator,

--- a/apps/api/src/agent-runtime/agent-runtime.policy.ts
+++ b/apps/api/src/agent-runtime/agent-runtime.policy.ts
@@ -18,11 +18,11 @@ export const DEFAULT_AGENT_RUNTIME_POLICY = {
 } as const
 
 export interface AgentRuntimePolicy {
-  historyCandidateBatchSize: number
-  historyCandidateHardLimit: number
-  maxSamplingRounds: number
-  maxToolCalls: number
-  runDeadlineMs: number
+  readonly historyCandidateBatchSize: number
+  readonly historyCandidateHardLimit: number
+  readonly maxSamplingRounds: number
+  readonly maxToolCalls: number
+  readonly runDeadlineMs: number
 }
 
 @Injectable()

--- a/apps/api/src/agent-runtime/agent-runtime.service.test.ts
+++ b/apps/api/src/agent-runtime/agent-runtime.service.test.ts
@@ -37,11 +37,13 @@ import {
   MessageRole,
   MessageStatus,
 } from '../generated/prisma/client.js'
+import { getModelProfile } from '../llm/model-profiles.js'
 import {
   DatabaseCommitOutcomeUnknownError,
   DatabaseOperationDeadlineExceededError,
 } from '../prisma/prisma.service.js'
 import { toChatStreamEvent } from '../seo/seo-chat-stream-event.mapper.js'
+import { AgentRunConfigurationService } from './agent-run-configuration.service.js'
 import {
   AgentRunTerminalizationError,
   ContextTokenEstimationError,
@@ -135,6 +137,37 @@ describe('AgentRuntimeService model stream', () => {
       0,
     )
     assertNoUnfinishedSteps(harness)
+  })
+
+  it('请求级覆盖 model / maxTokens 时 Initial Context 与 Provider 请求使用同一份 resolved 配置', async () => {
+    const harness = createHarness(() => toModelStream([
+      { type: 'text_delta', delta: '好' },
+      { type: 'response_completed', finishReason: 'stop' },
+    ]))
+
+    const events = await collectEvents(harness.service.runTurnStream({
+      conversationId: 'conversation-1',
+      userContent: '问题',
+      model: 'deepseek-v4-pro',
+      temperature: 0.4,
+      maxTokens: 4_096,
+      buildModelMessages: historyMessages => historyMessages,
+    }))
+
+    assert.equal(events.at(-1)?.type, 'run_completed')
+
+    const initialContext = (
+      harness.recorder.steps[2]?.input as Record<string, unknown>
+    ).initialContext as Record<string, unknown>
+
+    assert.equal(initialContext.resolvedModel, 'deepseek-v4-pro')
+    assert.equal(initialContext.resolvedMaxOutputTokens, 4_096)
+    assert.equal(harness.llmCalls[0]?.options?.model, initialContext.resolvedModel)
+    assert.equal(
+      harness.llmCalls[0]?.options?.maxTokens,
+      initialContext.resolvedMaxOutputTokens,
+    )
+    assert.equal(harness.llmCalls[0]?.options?.temperature, 0.4)
   })
 
   it('零 Tool Budget 时不向模型暴露 Tool 并正常完成', async () => {
@@ -2532,10 +2565,23 @@ function createHarness(
     options: ChatStreamOptions | undefined
   }> = []
   const llmService = {
-    resolveChatRequestConfig: (options?: { model?: string, maxTokens?: number }) => ({
-      model: options?.model ?? 'deepseek-v4-flash',
-      maxOutputTokens: options?.maxTokens ?? 65_536,
-    }),
+    // contextWindowTokens 取真实 Model Profile，让 context 预算测试
+    // 与生产模型能力保持锚定，不冻结在手写字面量上。
+    resolveChatRequestConfig: (options?: {
+      model?: string
+      temperature?: number
+      maxTokens?: number
+    }) => {
+      const model = options?.model ?? 'deepseek-v4-flash'
+
+      return {
+        model,
+        contextWindowTokens: getModelProfile(model)?.contextWindowTokens
+          ?? 1_000_000,
+        maxOutputTokens: options?.maxTokens ?? 65_536,
+        temperature: options?.temperature ?? 0.7,
+      }
+    },
     chatStream: (messages: ModelInputItem[], options?: ChatStreamOptions) => {
       const callIndex = llmCalls.length
 
@@ -2549,12 +2595,7 @@ function createHarness(
   } as unknown as LLMService
   const toolRegistryService = new FakeToolRegistryService()
   const toolInvocationService = new FakeToolInvocationService(invokeTool)
-  const service = new AgentRuntimeService(
-    llmService,
-    prisma as unknown as PrismaService,
-    recorder as unknown as AgentRunRecorderService,
-    toolRegistryService as unknown as ToolRegistryService,
-    toolInvocationService as unknown as ToolInvocationService,
+  const runConfigurationService = new AgentRunConfigurationService(
     {
       value: {
         historyCandidateBatchSize: 50,
@@ -2565,6 +2606,15 @@ function createHarness(
         ...policy,
       },
     } as AgentRuntimePolicyService,
+    llmService,
+    toolRegistryService as unknown as ToolRegistryService,
+  )
+  const service = new AgentRuntimeService(
+    llmService,
+    prisma as unknown as PrismaService,
+    recorder as unknown as AgentRunRecorderService,
+    toolInvocationService as unknown as ToolInvocationService,
+    runConfigurationService,
     new InitialContextSelectionService(tokenEstimator),
     new SamplingContextPlanner(tokenEstimator),
   )
@@ -2573,6 +2623,7 @@ function createHarness(
     llmCalls,
     prisma,
     recorder,
+    service,
     toolInvocations: toolInvocationService.invocations,
     toolExecutionContexts: toolInvocationService.contexts,
     assistantMessage: () => prisma.messages.find(
@@ -2596,6 +2647,14 @@ class FakeToolRegistryService {
       retrieveArticleContextDefinition,
       searchArticlesDefinition,
     ]
+  }
+
+  get(name: string): { definition: ToolDefinition } | undefined {
+    const definition = this.listDefinitions().find(
+      candidate => candidate.name === name,
+    )
+
+    return definition ? { definition } : undefined
   }
 }
 

--- a/apps/api/src/agent-runtime/agent-runtime.service.ts
+++ b/apps/api/src/agent-runtime/agent-runtime.service.ts
@@ -5,7 +5,7 @@ import type {
   MessageRole as PrismaMessageRole,
   MessageStatus as PrismaMessageStatus,
 } from '../generated/prisma/client.js'
-import type { ChatMessage } from '../llm/llm.types.js'
+import type { ChatMessage, ChatStreamOptions } from '../llm/llm.types.js'
 import type { DatabaseOperationDeadline } from '../prisma/prisma.service.js'
 import type { ToolResult } from '../tools/core/tool.types.js'
 import type {
@@ -24,20 +24,18 @@ import type { SamplingContextPlanSummary } from './sampling-context-planner.js'
 import { Inject, Injectable, Logger, NotFoundException } from '@nestjs/common'
 import { MessageRole, MessageStatus } from '../generated/prisma/client.js'
 import { LLMService } from '../llm/llm.service.js'
-import { getModelProfile } from '../llm/model-profiles.js'
 import {
   DatabaseCommitOutcomeUnknownError,
   DatabaseOperationDeadlineExceededError,
   PrismaService,
 } from '../prisma/prisma.service.js'
-import { toModelToolSpec } from '../tools/core/model-tool-spec.mapper.js'
 import { ToolInvocationService } from '../tools/core/tool-invocation.service.js'
 import {
   normalizeToolObservation,
   TOOL_OBSERVATION_HARD_MAX_CHARS,
 } from '../tools/core/tool-observation.js'
-import { ToolRegistryService } from '../tools/core/tool-registry.service.js'
 import { normalizeToolStepSummary } from '../tools/core/tool-step-summary.js'
+import { AgentRunConfigurationService } from './agent-run-configuration.service.js'
 import {
   AGENT_STEP_TYPES,
   AgentRunRecorderService,
@@ -50,7 +48,6 @@ import {
   ContextTokenEstimationError,
   ModelSamplingIncompleteError,
 } from './agent-runtime.errors.js'
-import { AgentRuntimePolicyService } from './agent-runtime.policy.js'
 import { submitGroundedAnswerToolSpec } from './grounding/grounded-answer.contract.js'
 import {
   GroundedFinalizationFailedError,
@@ -70,12 +67,6 @@ import {
   SamplingContextBudgetExceededError,
   SamplingContextPlanner,
 } from './sampling-context-planner.js'
-
-const AGENT_RUN_TOOL_NAMES = [
-  'search_articles',
-  'get_article_detail',
-  'retrieve_article_context',
-] as const
 
 const TERMINALIZATION_DEADLINE_MS = 5_000
 
@@ -121,14 +112,11 @@ export class AgentRuntimeService {
     @Inject(AgentRunRecorderService)
     private readonly agentRunRecorderService: AgentRunRecorderService,
 
-    @Inject(ToolRegistryService)
-    private readonly toolRegistryService: ToolRegistryService,
-
     @Inject(ToolInvocationService)
     private readonly toolInvocationService: ToolInvocationService,
 
-    @Inject(AgentRuntimePolicyService)
-    private readonly runtimePolicyService: AgentRuntimePolicyService,
+    @Inject(AgentRunConfigurationService)
+    private readonly runConfigurationService: AgentRunConfigurationService,
 
     @Inject(InitialContextSelectionService)
     private readonly initialContextSelectionService: InitialContextSelectionService,
@@ -169,7 +157,8 @@ export class AgentRuntimeService {
       const currentAgentRunId = agentRun.id
 
       agentRunId = currentAgentRunId
-      const runtimePolicy = this.runtimePolicyService.value
+      // Run deadline 必须先于请求级配置解析生效；policy 是启动期已校验的非抛错读取。
+      const runtimePolicy = this.runConfigurationService.policy
 
       runCancellation = createRunCancellation(
         input.signal,
@@ -191,24 +180,11 @@ export class AgentRuntimeService {
         databaseDeadline,
       )
 
-      const registeredToolDefinitions = this.toolRegistryService.listDefinitions()
-      const toolDefinitions = AGENT_RUN_TOOL_NAMES.flatMap((name) => {
-        const definition = registeredToolDefinitions.find(
-          candidate => candidate.name === name,
-        )
-
-        return definition ? [definition] : []
-      })
-      const modelTools = runtimePolicy.maxToolCalls === 0
-        ? []
-        : toolDefinitions.map(toModelToolSpec)
-      const resolvedRequestConfig = this.llmService.resolveChatRequestConfig({
-        ...(input.model ? { model: input.model } : {}),
-        ...(input.maxTokens === undefined
-          ? {}
-          : { maxTokens: input.maxTokens }),
-      })
-      const modelProfile = getModelProfile(resolvedRequestConfig.model)!
+      // 配置解析时机保持在 Run / receiveUserMessageStep 落库之后：请求级
+      // 配置错误仍走既有 failRun 终态化，不改变 Run 生命周期语义。
+      // 覆盖字段的规范化只在 resolve() 内做一层，这里不重复过滤。
+      const { request: resolvedRequestConfig, toolDefinitions, modelTools }
+        = this.runConfigurationService.resolve(input)
       const loadHistoryStep = await this.agentRunRecorderService.startStep({
         runId: currentAgentRunId,
         type: AGENT_STEP_TYPES.loadConversationHistory,
@@ -220,7 +196,7 @@ export class AgentRuntimeService {
 
       const selection = await this.initialContextSelectionService.select({
         resolvedModel: resolvedRequestConfig.model,
-        contextWindowTokens: modelProfile.contextWindowTokens,
+        contextWindowTokens: resolvedRequestConfig.contextWindowTokens,
         resolvedMaxOutputTokens: resolvedRequestConfig.maxOutputTokens,
         candidateBatchSize: runtimePolicy.historyCandidateBatchSize,
         candidateHardLimit: runtimePolicy.historyCandidateHardLimit,
@@ -298,9 +274,11 @@ export class AgentRuntimeService {
         assistantOutputStepId = step.id
       }
 
-      const chatStreamOptions = {
+      // Initial Context、后续 Sampling 与 Grounded finalization 共用同一份
+      // resolved 请求配置；Provider Client 端的重校验只会 fail-fast，不会漂移。
+      const chatStreamOptions: ChatStreamOptions = {
         model: resolvedRequestConfig.model,
-        temperature: input.temperature,
+        temperature: resolvedRequestConfig.temperature,
         maxTokens: resolvedRequestConfig.maxOutputTokens,
         signal: runSignal,
         tools: modelTools,

--- a/apps/api/src/agent-runtime/grounding/grounded-answer.db.test.ts
+++ b/apps/api/src/agent-runtime/grounding/grounded-answer.db.test.ts
@@ -8,6 +8,7 @@ import type { ChatStreamOptions } from '../../llm/llm.types.js'
 import type { ModelInputItem } from '../../llm/model-input.types.js'
 import type { ModelStreamEvent } from '../../llm/model-stream.types.js'
 import type { ArticleRetrievalPool } from '../../retrieval/postgres-article-retrieval.repository.js'
+import type { AgentRuntimePolicyService } from '../agent-runtime.policy.js'
 import type { AgentRuntimeEvent } from '../agent-runtime.types.js'
 import type { TokenEstimatorInput } from '../deepseek-v4-token-estimator.js'
 import assert from 'node:assert/strict'
@@ -28,6 +29,7 @@ import {
   MessageRole,
   MessageStatus,
 } from '../../generated/prisma/client.js'
+import { getModelProfile } from '../../llm/model-profiles.js'
 import { PrismaService } from '../../prisma/prisma.service.js'
 import { HybridArticleRetriever } from '../../retrieval/hybrid-article-retriever.js'
 import { LexicalArticleRetriever } from '../../retrieval/lexical-article-retriever.js'
@@ -46,6 +48,7 @@ import {
   retrieveArticleContextDefinition,
   RetrieveArticleContextTool,
 } from '../../tools/retrieval/retrieve-article-context.tool.js'
+import { AgentRunConfigurationService } from '../agent-run-configuration.service.js'
 import { AgentRunRecorderService } from '../agent-run-recorder.service.js'
 import { AgentRuntimeService } from '../agent-runtime.service.js'
 import { TokenEstimator } from '../deepseek-v4-token-estimator.js'
@@ -992,10 +995,21 @@ describe('Grounded Answer PostgreSQL integration', { concurrency: 1 }, () => {
 
     let callIndex = 0
     const llmService = {
-      resolveChatRequestConfig: () => ({
-        model: 'deepseek-v4-flash',
-        maxOutputTokens: 65_536,
-      }),
+      resolveChatRequestConfig: (options?: {
+        model?: string
+        temperature?: number
+        maxTokens?: number
+      }) => {
+        const model = options?.model ?? 'deepseek-v4-flash'
+
+        return {
+          model,
+          contextWindowTokens: getModelProfile(model)?.contextWindowTokens
+            ?? 1_000_000,
+          maxOutputTokens: options?.maxTokens ?? 65_536,
+          temperature: options?.temperature ?? 0.7,
+        }
+      },
       chatStream: (messages: ModelInputItem[], _options?: ChatStreamOptions) => {
         const createStream = modelStreams[callIndex]
 
@@ -1013,12 +1027,7 @@ describe('Grounded Answer PostgreSQL integration', { concurrency: 1 }, () => {
         )
       },
     } as unknown as LLMService
-    const service = new AgentRuntimeService(
-      llmService,
-      prisma,
-      new AgentRunRecorderService(prisma),
-      registry,
-      new ToolInvocationService(registry),
+    const runConfigurationService = new AgentRunConfigurationService(
       {
         value: {
           historyCandidateBatchSize: 50,
@@ -1027,7 +1036,16 @@ describe('Grounded Answer PostgreSQL integration', { concurrency: 1 }, () => {
           maxToolCalls: 1,
           runDeadlineMs: 60_000,
         },
-      } as never,
+      } as AgentRuntimePolicyService,
+      llmService,
+      registry,
+    )
+    const service = new AgentRuntimeService(
+      llmService,
+      prisma,
+      new AgentRunRecorderService(prisma),
+      new ToolInvocationService(registry),
+      runConfigurationService,
       new InitialContextSelectionService(new TestTokenEstimator()),
       new SamplingContextPlanner(new TestTokenEstimator()),
     )

--- a/apps/api/src/agent-runtime/grounding/grounded-answer.runtime.test.ts
+++ b/apps/api/src/agent-runtime/grounding/grounded-answer.runtime.test.ts
@@ -26,7 +26,9 @@ import assert from 'node:assert/strict'
 import { describe, it } from 'node:test'
 
 import { MessageRole, MessageStatus } from '../../generated/prisma/client.js'
+import { getModelProfile } from '../../llm/model-profiles.js'
 import { toChatStreamEvent } from '../../seo/seo-chat-stream-event.mapper.js'
+import { AgentRunConfigurationService } from '../agent-run-configuration.service.js'
 import { AGENT_STEP_TYPES } from '../agent-run-recorder.service.js'
 import { AgentRuntimeService } from '../agent-runtime.service.js'
 import { TokenEstimator } from '../deepseek-v4-token-estimator.js'
@@ -1399,10 +1401,21 @@ function createHarness(options: CreateHarnessOptions) {
     return [...text.matchAll(/evk_[a-f\d]{32}/g)].map(match => match[0])
   }
   const llmService = {
-    resolveChatRequestConfig: (config?: { model?: string, maxTokens?: number }) => ({
-      model: config?.model ?? 'deepseek-v4-flash',
-      maxOutputTokens: config?.maxTokens ?? 65_536,
-    }),
+    resolveChatRequestConfig: (config?: {
+      model?: string
+      temperature?: number
+      maxTokens?: number
+    }) => {
+      const model = config?.model ?? 'deepseek-v4-flash'
+
+      return {
+        model,
+        contextWindowTokens: getModelProfile(model)?.contextWindowTokens
+          ?? 1_000_000,
+        maxOutputTokens: config?.maxTokens ?? 65_536,
+        temperature: config?.temperature ?? 0.7,
+      }
+    },
     chatStream: (messages: ModelInputItem[], streamOptions?: ChatStreamOptions) => {
       const callIndex = llmCalls.length
 
@@ -1430,12 +1443,7 @@ function createHarness(options: CreateHarnessOptions) {
       }
     },
   } as unknown as ToolInvocationService
-  const service = new AgentRuntimeService(
-    llmService,
-    prisma as unknown as PrismaService,
-    recorder as unknown as AgentRunRecorderService,
-    new FakeToolRegistryService() as unknown as ToolRegistryService,
-    toolInvocationService,
+  const runConfigurationService = new AgentRunConfigurationService(
     {
       value: {
         historyCandidateBatchSize: 50,
@@ -1445,6 +1453,15 @@ function createHarness(options: CreateHarnessOptions) {
         runDeadlineMs: 600_000,
       },
     } as AgentRuntimePolicyService,
+    llmService,
+    new FakeToolRegistryService() as unknown as ToolRegistryService,
+  )
+  const service = new AgentRuntimeService(
+    llmService,
+    prisma as unknown as PrismaService,
+    recorder as unknown as AgentRunRecorderService,
+    toolInvocationService,
+    runConfigurationService,
     new InitialContextSelectionService(new TestTokenEstimator()),
     new SamplingContextPlanner(new TestTokenEstimator()),
   )
@@ -1525,6 +1542,14 @@ const discoveryDefinition: ToolDefinition = {
 class FakeToolRegistryService {
   listDefinitions(): ToolDefinition[] {
     return [discoveryDefinition, detailDefinition, eligibleDefinition]
+  }
+
+  get(name: string): { definition: ToolDefinition } | undefined {
+    const definition = this.listDefinitions().find(
+      candidate => candidate.name === name,
+    )
+
+    return definition ? { definition } : undefined
   }
 }
 

--- a/apps/api/src/agent-runtime/grounding/grounded-answer.smoke.cli.ts
+++ b/apps/api/src/agent-runtime/grounding/grounded-answer.smoke.cli.ts
@@ -25,6 +25,7 @@ import {
   retrieveArticleContextDefinition,
   RetrieveArticleContextTool,
 } from '../../tools/retrieval/retrieve-article-context.tool.js'
+import { AgentRunConfigurationService } from '../agent-run-configuration.service.js'
 import { AgentRunRecorderService } from '../agent-run-recorder.service.js'
 import { AgentRuntimeService } from '../agent-runtime.service.js'
 import { DeepSeekV4TokenEstimator } from '../deepseek-v4-token-estimator.js'
@@ -112,24 +113,28 @@ export async function executeGroundedAnswerSmoke(
 
   const tokenEstimator = new DeepSeekV4TokenEstimator()
   const runtimeConfigService = new LLMRuntimeConfigService()
+  const llmService = new LLMService(
+    new OpenAICompatibleClient(runtimeConfigService),
+    runtimeConfigService,
+  )
   const runtime = new AgentRuntimeService(
-    new LLMService(
-      new OpenAICompatibleClient(runtimeConfigService),
-      runtimeConfigService,
-    ),
+    llmService,
     prisma,
     new AgentRunRecorderService(prisma),
-    registry,
     new ToolInvocationService(registry),
-    {
-      value: {
-        historyCandidateBatchSize: 50,
-        historyCandidateHardLimit: 1_000,
-        maxSamplingRounds: 4,
-        maxToolCalls: 2,
-        runDeadlineMs: 300_000,
+    new AgentRunConfigurationService(
+      {
+        value: {
+          historyCandidateBatchSize: 50,
+          historyCandidateHardLimit: 1_000,
+          maxSamplingRounds: 4,
+          maxToolCalls: 2,
+          runDeadlineMs: 300_000,
+        },
       },
-    },
+      llmService,
+      registry,
+    ),
     new InitialContextSelectionService(tokenEstimator),
     new SamplingContextPlanner(tokenEstimator),
   )

--- a/apps/api/src/llm/clients/openai-compatible.client.ts
+++ b/apps/api/src/llm/clients/openai-compatible.client.ts
@@ -26,9 +26,6 @@ import {
   resolveChatRequestConfig,
 } from '../llm-runtime-config.js'
 import {
-  DEFAULT_CHAT_TEMPERATURE,
-} from '../llm.constants.js'
-import {
   LLMApiError,
   LLMAuthError,
   LLMBalanceError,
@@ -170,7 +167,7 @@ export class OpenAICompatibleClient {
     const params: ChatCompletionBaseParams = {
       model: requestConfig.model,
       messages,
-      temperature: options?.temperature ?? DEFAULT_CHAT_TEMPERATURE,
+      temperature: requestConfig.temperature,
       max_tokens: requestConfig.maxOutputTokens,
     }
 

--- a/apps/api/src/llm/llm-runtime-config.test.ts
+++ b/apps/api/src/llm/llm-runtime-config.test.ts
@@ -119,8 +119,28 @@ describe('resolveChatRequestConfig', () => {
 
     assert.deepEqual(resolveChatRequestConfig(runtimeConfig), {
       model: 'deepseek-v4-flash',
+      contextWindowTokens: 1_000_000,
       maxOutputTokens: 65_536,
+      temperature: 0.7,
     })
+  })
+
+  it('resolved 配置携带调用级覆盖后的完整模型事实', () => {
+    const runtimeConfig = resolveLLMRuntimeConfig(createEnv())
+
+    assert.deepEqual(
+      resolveChatRequestConfig(runtimeConfig, {
+        model: 'deepseek-v4-pro',
+        temperature: 0.4,
+        maxTokens: 4_096,
+      }),
+      {
+        model: 'deepseek-v4-pro',
+        contextWindowTokens: 1_000_000,
+        maxOutputTokens: 4_096,
+        temperature: 0.4,
+      },
+    )
   })
 
   it('拒绝不支持的调用级模型及越过应用硬上限的输出预算', () => {

--- a/apps/api/src/llm/llm-runtime-config.ts
+++ b/apps/api/src/llm/llm-runtime-config.ts
@@ -1,4 +1,5 @@
-import type { ChatOptions, SupportedDeepSeekModel } from './llm.types.js'
+import type { ChatOptions } from './llm.types.js'
+import type { SupportedDeepSeekModel } from './model-profiles.js'
 import process from 'node:process'
 import { Injectable } from '@nestjs/common'
 
@@ -6,6 +7,9 @@ import { LLMAuthError, LLMConfigError } from './llm.errors.js'
 import { getModelProfile } from './model-profiles.js'
 
 const MAX_TIMER_TIMEOUT_MS = 2_147_483_647
+
+/** 请求未显式指定 temperature 时的默认值。 */
+const DEFAULT_CHAT_TEMPERATURE = 0.7
 
 export const DEFAULT_LLM_RUNTIME_CONFIG = {
   metadataRequestTimeoutMs: 10_000,
@@ -29,9 +33,17 @@ export interface LLMRuntimeConfig {
   captureModelIO: boolean
 }
 
-export interface ChatRequestConfig {
+/**
+ * 单次 chat 请求的完整 resolved 配置。
+ *
+ * 它是调用方继续决策所需的全部模型事实：携带 contextWindowTokens，
+ * 调用方（如 Context Selection）不需要再穿透 LLM 边界补查 Model Profile。
+ */
+export interface ResolvedChatRequestConfig {
   model: SupportedDeepSeekModel
+  contextWindowTokens: number
   maxOutputTokens: number
+  temperature: number
 }
 
 @Injectable()
@@ -113,7 +125,7 @@ function readBooleanFlag(env: NodeJS.ProcessEnv, name: string): boolean {
 export function resolveChatRequestConfig(
   runtimeConfig: LLMRuntimeConfig,
   options: ChatOptions = {},
-): ChatRequestConfig {
+): ResolvedChatRequestConfig {
   const requestedModel = (options.model ?? runtimeConfig.model).trim()
   const profile = getModelProfile(requestedModel)
 
@@ -144,7 +156,9 @@ export function resolveChatRequestConfig(
 
   return {
     model: profile.id,
+    contextWindowTokens: profile.contextWindowTokens,
     maxOutputTokens,
+    temperature: options.temperature ?? DEFAULT_CHAT_TEMPERATURE,
   }
 }
 

--- a/apps/api/src/llm/llm.constants.ts
+++ b/apps/api/src/llm/llm.constants.ts
@@ -1,1 +1,0 @@
-export const DEFAULT_CHAT_TEMPERATURE = 0.7

--- a/apps/api/src/llm/llm.service.ts
+++ b/apps/api/src/llm/llm.service.ts
@@ -1,4 +1,4 @@
-import type { ChatRequestConfig } from './llm-runtime-config.js'
+import type { ResolvedChatRequestConfig } from './llm-runtime-config.js'
 import type {
   ChatMessage,
   ChatOptions,
@@ -27,7 +27,7 @@ export class LLMService {
     private readonly runtimeConfigService: LLMRuntimeConfigService,
   ) {}
 
-  resolveChatRequestConfig(options?: ChatOptions): ChatRequestConfig {
+  resolveChatRequestConfig(options?: ChatOptions): ResolvedChatRequestConfig {
     return resolveChatRequestConfig(this.runtimeConfigService.value, options)
   }
 

--- a/apps/api/src/llm/llm.types.ts
+++ b/apps/api/src/llm/llm.types.ts
@@ -55,13 +55,6 @@ export interface ChatStreamOptions extends ChatOptions {
   debugCapture?: ModelIODebugCapture
 }
 
-export const SUPPORTED_DEEPSEEK_MODELS = [
-  'deepseek-v4-flash',
-  'deepseek-v4-pro',
-] as const
-
-export type SupportedDeepSeekModel = typeof SUPPORTED_DEEPSEEK_MODELS[number]
-
 export interface DeepSeekModelInfo {
   id: string
   object: 'model'

--- a/apps/api/src/llm/model-profiles.ts
+++ b/apps/api/src/llm/model-profiles.ts
@@ -1,4 +1,16 @@
-import type { SupportedDeepSeekModel } from './llm.types.js'
+/**
+ * LLM 领域的模型注册入口：支持模型名单与模型能力 Profile 在此维护，
+ * Record 类型保证名单与 Profile 双向一致。
+ * 注意：前端另持有一份展示用名单（apps/web/src/types/llm.ts 的
+ * DeepSeekModelId / FALLBACK_DEEPSEEK_MODELS），新增模型时需同步。
+ */
+
+export const SUPPORTED_DEEPSEEK_MODELS = [
+  'deepseek-v4-flash',
+  'deepseek-v4-pro',
+] as const
+
+export type SupportedDeepSeekModel = typeof SUPPORTED_DEEPSEEK_MODELS[number]
 
 export interface ModelProfile {
   id: SupportedDeepSeekModel

--- a/apps/api/src/seo/dto/seo-chat.dto.ts
+++ b/apps/api/src/seo/dto/seo-chat.dto.ts
@@ -9,7 +9,7 @@ import {
   MaxLength,
 } from 'class-validator'
 
-import { SUPPORTED_DEEPSEEK_MODELS } from '../../llm/llm.types.js'
+import { SUPPORTED_DEEPSEEK_MODELS } from '../../llm/model-profiles.js'
 
 export class SeoChatDto implements SeoChatRequest {
   @IsString()

--- a/docs/README.md
+++ b/docs/README.md
@@ -7,7 +7,7 @@
 ```text
 阶段 1-8：Completed
 Phase 8：Completed
-Active Agent Task：无
+Active Agent Task：Run 配置解析边界（#92，已实现、待验收）
 Minimal Compaction：Gated
 Admin Task 4：Planned
 Phase 9：未定案
@@ -23,7 +23,7 @@ Phase 8 已完成：
 - Task 3B：Web Grounding 状态、Sources disclosure、Source cards 与 Chromium，#60 / #61 / `572ad206`；
 - Task 3C：Admin Retrieval / Finalization / Citation Inspector，#62 / #63 / `20f838fb`。
 
-当前为 Phase 8 源码阅读阶段，不创建正式 Issue；下一阶段学习内容暂不定义。Phase 9 尚未定案。
+当前为 Phase 8 源码阅读阶段；源码阅读发现的可维护性问题已立项为正式 Issue #92（[Run 配置解析边界](./tasks/agent-run-configuration.md)，已实现、待验收）。下一阶段学习内容暂不定义。Phase 9 尚未定案。
 
 ## 文档入口
 

--- a/docs/research/configuration-map.md
+++ b/docs/research/configuration-map.md
@@ -1,0 +1,51 @@
+# 当前源码配置地图（Issue #92）
+
+本文是阅读导航，不是运行时事实来源；每类配置的事实来源永远是对应源码文件。基线：Issue #92 合入后的 `apps/api`。
+
+## 配置分类与事实来源
+
+| 类别 | 含义 | 事实来源 | 校验时机 |
+| --- | --- | --- | --- |
+| 环境配置（LLM） | API Key、Base URL、默认模型、超时、输出预算上限 | `apps/api/src/llm/llm-runtime-config.ts`（`resolveLLMRuntimeConfig`） | Nest 启动期 fail-fast |
+| 环境配置（Run Policy） | history 候选批量 / 上限、sampling 轮数、Tool Call 预算、Run deadline | `apps/api/src/agent-runtime/agent-runtime.policy.ts`（`resolveAgentRuntimePolicy`） | Nest 启动期 fail-fast |
+| 环境配置（Embedding） | Gemini API Key、批量、重试、请求超时 | `apps/api/src/embeddings/embedding-provider.ts` | 构建 provider 时解析 |
+| 环境配置（数据库） | `DATABASE_URL`、操作 deadline | `apps/api/src/prisma/prisma.service.ts` | 连接时 |
+| 环境配置（检索运行时） | 混合检索装配所需的 env | `apps/api/src/retrieval/hybrid-article-retrieval.runtime.ts` | 装配时 |
+| Provider 模型能力 | 支持模型名单 + 每个模型的 context window / Provider 输出上限 | `apps/api/src/llm/model-profiles.ts`（LLM 领域单点；前端另有展示用名单 `apps/web/src/types/llm.ts`，新增模型需同步） | 编译期 `Record` 双向约束 |
+| 请求级覆盖 | HTTP 请求可覆盖 model（`SeoChatDto` 白名单校验）；temperature / maxTokens 目前只由服务端调用方设置（`SeoService` 固定 temperature 0.4，maxTokens 未使用） | `apps/api/src/llm/llm-runtime-config.ts`（`resolveChatRequestConfig` → `ResolvedChatRequestConfig`） | model / maxTokens 解析时抛 `LLMConfigError`；temperature 无范围校验，仅缺省补 0.7——未来暴露给 HTTP 前必须先加 DTO 校验 |
+| 单次 Run 组合配置 | 一次 Agent Run 的 resolved 请求配置 + Tool allowlist（policy 经 getter 读取） | `apps/api/src/agent-runtime/agent-run-configuration.service.ts`（`AgentRunConfigurationService.resolve` → `ResolvedAgentRunConfiguration`） | Run 内、AgentRun 落库后解析 |
+| Tool Policy | 每个 Tool 的 timeout、Observation 预算、risk、approval、evidence policy | 各 Tool 自己的 definition（`apps/api/src/tools/**`，类型见 `tools/core/tool.types.ts`） | 注册时 + 编译期 |
+| 公共契约 | 前后端共享协议与类型 | `packages/contracts/` | 编译期 |
+| 算法不变量 | Context budget 比例、TokenEstimator、History Selection、Observation 硬上限等 | 各算法文件内常量（如 `initial-context-selection.ts`、`tool-observation.ts`） | 不可由环境变量改变 |
+| 部署变量说明 | 各环境变量的示例与注释 | `.env.example` | 无（文档性质） |
+
+以上未列出的 env 读取点（如 `main.ts` 端口、各 smoke / CLI 专用变量）以 `.env.example` 与对应源码为准；本表只收录长期配置边界。
+
+## 单次 Run 的配置解析链
+
+```text
+AgentRuntimePolicyService（启动期已校验）──┐
+LLMService.resolveChatRequestConfig ───────┼─→ AgentRunConfigurationService.resolve()
+ToolRegistryService.get(name) ─────────────┘        │
+                                                     ▼
+                                     ResolvedAgentRunConfiguration
+                                     { request, toolDefinitions, modelTools }
+                                                     │
+                                                     ▼
+                                          AgentRuntimeService.runTurnStream()
+                （Initial Context、Sampling、Grounded finalization 共用同一份 request）
+```
+
+要点：
+
+- 回答“本轮用什么模型、多大预算、暴露哪些 Tool”，只读 `agent-run-configuration.service.ts` 一个入口。
+- `ResolvedChatRequestConfig` 携带 `contextWindowTokens`，Runtime 不再穿透 LLM 边界补查 Model Profile。
+- Provider Client 端对已 resolved 值的重校验是确定性 fail-fast，不会产生第二份事实。
+- 配置解析时机保持在 userMessage / AgentRun / receiveUserMessageStep 落库之后：请求级配置错误仍走既有 `failRun` 终态化。
+- `policy` 在 Run deadline 建立时单独读取（启动期已校验、非抛错），先于可能抛错的请求解析。
+
+## 边界纪律
+
+- `AgentRunConfigurationService` 只组合单次 Run 所需配置；数据库、Embedding、Admin 等应用配置不得进入。
+- 各领域配置的定义与校验留在各自边界；组合入口不重新实现解析。
+- Grounding / Citation / Evidence 的公共字段限制不在本地图范围（见 Issue #92 D-11，另行立项）。

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -7,7 +7,7 @@
 ```text
 阶段 1-8：Completed
 Phase 8：Completed
-Active Agent Task：无
+Active Agent Task：Run 配置解析边界（#92，已实现、待验收）
 Minimal Compaction：Gated
 Admin Observability：Task 0-3、Enhancement 1、Phase 8 Task 3C Completed
 Admin Task 4：Planned
@@ -145,7 +145,7 @@ Phase 8 Task 3C 已完成安全 Retrieval Inspector，但不自动启动 Task 4�
 
 ```text
 Phase 8：Completed / 已归档（docs/tasks/completed/phase-08-grounded-retrieval.md）
-Active Agent Task：无
+Active Agent Task：Run 配置解析边界（#92，已实现、待验收）
 当前阶段：Phase 8 源码阅读（学习阶段）
 下一阶段学习内容：暂不定义
 ```

--- a/docs/tasks/README.md
+++ b/docs/tasks/README.md
@@ -8,7 +8,7 @@
 阶段 1-8：Completed
 Phase 8：Completed
 Task 0、1、2A、2B、3A、3B、3C：Completed
-Active Agent Task：无
+Active Agent Task：Run 配置解析边界（#92，已实现、待验收）
 Minimal Compaction：Gated
 Admin Task 4：Planned
 Phase 9：未定案
@@ -18,7 +18,8 @@ Phase 9：未定案
 
 | 区域 | 状态 | 文档 | 说明 |
 | --- | --- | --- | --- |
-| Agent 主线 | **阶段 1-8 Completed / 当前无 Active Task** | [roadmap.md](../roadmap.md) | 当前为 Phase 8 源码阅读阶段 |
+| Agent 主线 | **阶段 1-8 Completed** | [roadmap.md](../roadmap.md) | 当前为 Phase 8 源码阅读阶段 |
+| Run 配置解析边界（#92） | **Active（已实现、待验收）** | [agent-run-configuration.md](./agent-run-configuration.md) | 横向 refactor，源码阅读阶段发现的可维护性问题 |
 | Phase 8：Grounded Retrieval / RAG Baseline | **Completed** | [completed/phase-08-grounded-retrieval.md](./completed/phase-08-grounded-retrieval.md) | Task 0-3C 全部完成，已归档 |
 | Phase 7：Context Engineering | **Completed** | [completed/phase-07-context-engineering.md](./completed/phase-07-context-engineering.md) | Task 0-3 Completed；Minimal Compaction Gated |
 | Phase 6：有界单 Agent Loop | **Completed** | [completed/phase-06-bounded-agent-loop.md](./completed/phase-06-bounded-agent-loop.md) | bounded loop、deadline、终态可靠性 |
@@ -44,7 +45,7 @@ Phase 8 全部 Task 文档已合并归档到 [completed/phase-08-grounded-retrie
 
 ## 当前正式动作
 
-当前没有 Active Agent Task，也没有自动启动的下一正式 Issue。
+当前 Active Task：[Run 配置解析边界（#92）](./agent-run-configuration.md)，已实现、待验收；没有自动启动的下一正式 Issue。
 
 当前阶段为 Phase 8 源码阅读（学习阶段）：回读 Phase 8 代码与数据链路，覆盖 Chunking、Embedding、Hybrid Retrieval、Tool、Grounding、Web Source UI 和 Admin Inspector。下一阶段学习内容暂不定义；源码阅读完成后再讨论 Phase 9。
 

--- a/docs/tasks/agent-run-configuration.md
+++ b/docs/tasks/agent-run-configuration.md
@@ -49,4 +49,5 @@
 
 ## GitHub 交付
 
-- Draft PR：实现与验证完成后创建，链接在 PR 创建后回填；Draft 转 Ready 与合并需用户明确授权。
+- Draft PR：[#93](https://github.com/mufeiyu-ayu/agent/pull/93)；Draft 转 Ready 与合并需用户明确授权。
+- Gate READY 记录：[Issue #92 评论](https://github.com/mufeiyu-ayu/agent/issues/92#issuecomment-5380675918)。

--- a/docs/tasks/agent-run-configuration.md
+++ b/docs/tasks/agent-run-configuration.md
@@ -1,0 +1,52 @@
+# Task：单次 Run 配置解析边界与配置导航（Issue #92）
+
+- 实施状态：已实现
+- 验收状态：待验收
+- Issue：[#92](https://github.com/mufeiyu-ayu/agent/issues/92)
+- 分支：`codex/issue-92-run-config-boundary`
+
+## 目标
+
+建立单次 Agent Run 的统一配置解析入口 `AgentRunConfigurationService`，把散落在 `runTurnStream()` 内的 Policy 读取、Tool allowlist 筛选、模型请求解析和 Model Profile 补查收敛为一份 `ResolvedAgentRunConfiguration`；补一份当前源码配置地图。
+
+## 改动摘要
+
+- `apps/api/src/llm/llm-runtime-config.ts`：`ChatRequestConfig` 重命名为 `ResolvedChatRequestConfig`，补全 `contextWindowTokens` 与 `temperature`；`DEFAULT_CHAT_TEMPERATURE` 并入本文件，删除单行 `llm.constants.ts`。
+- `apps/api/src/llm/model-profiles.ts`：`SUPPORTED_DEEPSEEK_MODELS` 与 `SupportedDeepSeekModel` 从 `llm.types.ts` 移入，模型名单与 Profile 单文件维护。
+- 新增 `apps/api/src/agent-runtime/agent-run-configuration.service.ts`：组合 resolved 请求配置 + Tool allowlist；`policy` 经 getter 单独暴露（Run deadline 需在可能抛错的请求解析之前生效）；Registry 缺失 allowlisted Tool 时记录 warn 并按既有语义跳过。
+- `apps/api/src/agent-runtime/agent-runtime.service.ts`：移除 `getModelProfile` 穿透依赖与 `!` 断言、`AGENT_RUN_TOOL_NAMES`、Tool 筛选与 Policy 直读；配置解析时机保持在 AgentRun / receiveUserMessageStep 落库之后，终态化语义不变；Initial Context、Sampling、Grounded finalization 共用同一份 resolved 请求配置。
+- Provider Client 改用 `requestConfig.temperature`（同默认值，行为不变）。
+- 测试：新增 `agent-run-configuration.service.test.ts`（allowlist 顺序 / 排除、`maxToolCalls=0`、Registry 缺失跳过、覆盖透传、空 model 回落）；`agent-runtime.service.test.ts` 新增 AC-04 用例（请求级覆盖时 Context 与 Provider 请求同源）；4 处构造点（harness、grounding runtime/db 测试、smoke CLI）同步更新。
+- 文档：新增 [`docs/research/configuration-map.md`](../research/configuration-map.md) 配置地图。
+
+## Red 用例结果
+
+- [x] `ResolvedChatRequestConfig` 直接提供 `contextWindowTokens`（llm-runtime-config 单测）。
+- [x] `AgentRuntimeService` 不再导入 `getModelProfile`，无 `!` 断言（rg + typecheck）。
+- [x] resolved model / max output 同时用于 Initial Context 与模型请求（AC-04 新用例）。
+- [x] 覆盖 model / maxTokens 时 Context 与 Provider 请求严格一致（AC-04 新用例）。
+- [x] 不支持模型 / 越界 maxTokens 在 Provider 请求前失败（既有 llm-config 用例保持通过）。
+- [x] 默认 `maxToolCalls=2` allowlist 不变；`maxToolCalls=0` 时 model tools 为空（新单测 + 既有零预算用例）。
+- [x] Tool Registry 缺定义时保持当前行为（新单测）。
+- [x] LLM / Policy 默认配置与 fail-fast 测试保持通过。
+- [x] `runTurnStream()` 内不再散落配置组合逻辑（代码审查）。
+
+## 验证记录（2026-08-22，本地）
+
+| 命令 | 结果 |
+| --- | --- |
+| `pnpm --filter @agent/api test:llm-config` | 19/19 通过 |
+| `pnpm --filter @agent/api test:tool-loop` | 61/61 通过 |
+| `pnpm --filter @agent/api test:context` | 24/24 通过 |
+| `pnpm --filter @agent/api test:model-stream` | 77/77 通过 |
+| `pnpm --filter @agent/api test:seo-service` | 31/31 通过 |
+| `pnpm --filter @agent/api test:grounding` | 171/171 通过 |
+| `pnpm --filter @agent/api lint` | 通过 |
+| `pnpm typecheck`（root，web/admin/api） | 通过 |
+| `git diff --check` | 通过 |
+
+`test:grounding-db` / smoke 未运行（需数据库与真实模型凭据）；构造链影响已由 `test:grounding` 内的 runtime 测试与 typecheck 覆盖。
+
+## GitHub 交付
+
+- Draft PR：实现与验证完成后创建，链接在 PR 创建后回填；Draft 转 Ready 与合并需用户明确授权。

--- a/docs/work-log.md
+++ b/docs/work-log.md
@@ -6,7 +6,7 @@
 
 | 类型 | 当前记录 | 下一步 |
 | --- | --- | --- |
-| Agent 主线 | 阶段 1-8 Completed；当前无 Active Agent Task | Phase 8 源码阅读（学习阶段）；下一阶段学习内容暂不定义 |
+| Agent 主线 | 阶段 1-8 Completed；Active Task：Run 配置解析边界（#92，已实现、待验收） | Phase 8 源码阅读（学习阶段）；下一阶段学习内容暂不定义 |
 | Phase 8 | Task 0、1、2A、2B、3A、3B、3C 全部 Completed | [阶段归档](./tasks/completed/phase-08-grounded-retrieval.md) |
 | Minimal Compaction | Gated | 只有真实 Context 压力证据满足触发条件后才讨论 |
 | Admin Console | Task 0-3、Enhancement 1-3、Phase 8 Task 3C Completed；Task 4 Planned | 不自动启动 Auth / RBAC |


### PR DESCRIPTION
Closes #92

## 改动摘要

- 新增 `AgentRunConfigurationService`（`apps/api/src/agent-runtime/agent-run-configuration.service.ts`）：单次 Run 配置解析入口，组合 resolved 请求配置 + Tool allowlist；`policy` 经 getter 单独暴露（Run deadline 必须先于可抛错的请求解析生效）；Registry 缺失 allowlisted Tool 时 `logger.warn` 并按既有语义跳过。
- `ChatRequestConfig` → `ResolvedChatRequestConfig`，补全 `contextWindowTokens` / `temperature`；`AgentRuntimeService` 消除 `getModelProfile()` 穿透依赖与 `!` 断言（AC-02 / AC-03）。
- `SUPPORTED_DEEPSEEK_MODELS` + `SupportedDeepSeekModel` 移入 `model-profiles.ts`，模型名单与 Profile 同文件维护（AC-05）；`DEFAULT_CHAT_TEMPERATURE` 并入 `llm-runtime-config.ts`，删除单行 `llm.constants.ts`。
- 配置解析时机保持在 userMessage / AgentRun / receiveUserMessageStep 落库之后，配置错误仍走既有 failRun 终态化；Initial Context、Sampling、Grounded finalization 共用同一份 resolved 请求配置（AC-04）。
- `AgentRuntimePolicy` 字段加 `readonly`；Provider Client 改用 `requestConfig.temperature`（同默认值，行为不变）。
- 测试：新增 `agent-run-configuration.service.test.ts`（allowlist 顺序 / 排除 / `maxToolCalls=0` / Registry 缺失 / 覆盖透传 / 空 model 回落）与 AC-04 同源行为用例；4 处构造点（harness、grounding runtime/db 测试、smoke CLI）同步更新，fake resolver 以真实 Model Profile 锚定 `contextWindowTokens`。
- docs：新增 `docs/research/configuration-map.md` 配置地图与 `docs/tasks/agent-run-configuration.md`（已实现、待验收）；`tasks/README` / `roadmap` / `docs/README` / `work-log` / `CLAUDE.md` 状态行同步为 #92 Active。

**明确未做**：不改任何 env 变量 / 默认值 / Tool policy / 公开协议 / Prisma / Grounding 契约；不拆 `AgentRuntimeService` 其余部分；不引入依赖；不收敛 web 端展示用模型名单（见风险）。

## 验证

| 命令 | 结果 |
| --- | --- |
| `pnpm --filter @agent/api test:llm-config` | 19/19 |
| `pnpm --filter @agent/api test:tool-loop` | 61/61 |
| `pnpm --filter @agent/api test:context` | 24/24 |
| `pnpm --filter @agent/api test:model-stream` | 77/77 |
| `pnpm --filter @agent/api test:seo-service` | 31/31 |
| `pnpm --filter @agent/api test:grounding` | 171/171 |
| `pnpm --filter @agent/api lint` / `pnpm typecheck`（root） / `git diff --check` | 通过 |

`test:grounding-db` / smoke 未运行（需隔离数据库与真实模型凭据）；构造链影响已由 `test:grounding` 内 runtime 套件与 typecheck 覆盖。

## commit 前 /code-review 结论与处理

审查暂存区 diff 产出 15 条 findings（无崩溃级 bug），处理如下：

**已修复（并入本提交）**：配置地图“temperature/maxTokens 可请求覆盖且抛 LLMConfigError”的失实声明（改为如实描述 HTTP 面只暴露 model、temperature 无范围校验）；`ResolvedAgentRunConfiguration` 移除死字段 `policy`（防止后来者绕过 getter 破坏 deadline 时序）；`AgentRuntimePolicy` 字段加 readonly；runtime 调用点与 resolve() 的双层条件展开去重（规范化只留 resolve() 一层）；allowlist 解析改 `registry.get(name)` + 缺失 warn；测试 fake 以真实 `getModelProfile` 锚定 contextWindowTokens（4 处）；db 测试 fake 改为回显 options、`as never` 改为类型化 cast；新单测默认 policy 改为 import `DEFAULT_AGENT_RUNTIME_POLICY`；`model-profiles.ts` 头注释如实注明 web 侧另有展示名单；`chatStreamOptions` 加 `ChatStreamOptions` 类型标注；收回 `AGENT_RUN_TOOL_NAMES` / `DEFAULT_CHAT_TEMPERATURE` 两个无消费者 export；任务文档 PR 状态改为如实的 Draft 表述；roadmap / docs/README / work-log / CLAUDE.md 状态行与看板一致化；Gate READY 结论已补记为 Issue #92 评论。

**不修（附理由）**：`model:''` 回落默认模型与空白串抛错的不对称——重构前 `runTurnStream()` 的既有语义，Issue 明确本任务行为不变，测试以注释标注后锁定现状；AC-04 用例单测判别力有限——默认路径用例已断言 resolved 默认值（65_536 / deepseek-v4-flash），回退为直读 input.* 会在该用例失败，套件级判别力成立；`toolDefinitions` / `modelTools` 数组 readonly 化——会波及 `ChatStreamOptions` 等 LLM 类型面，超出本 Issue 范围；`toChatStreamOptions()` helper——当前单一使用点，YAGNI，已用类型标注兜住字段名漂移；4 份 fake resolver 完全去重为共享 fixture——超最小改动，已用真实 Profile 锚定消除最危险的漂移轴；AgentRuntimeModule 装配测试——需要可连接数据库的 Nest bootstrap，属预存缺口，建议另行立项。

## 已知风险

- web 端 `apps/web/src/types/llm.ts` 持有独立的展示用模型名单（预存重复，非本 diff 引入）；新增模型需同步，已在 `model-profiles.ts` 注释与配置地图标注。
- Provider Client 仍对已 resolved 值做确定性重校验（既有行为保留）；漏传字段会静默取默认而非 fail-fast，已由默认路径测试断言兜住。

## 建议阅读顺序

1. `docs/research/configuration-map.md`（配置分类地图）
2. `apps/api/src/llm/llm-runtime-config.ts`（`ResolvedChatRequestConfig` 补全）
3. `apps/api/src/agent-runtime/agent-run-configuration.service.ts`（新边界）
4. `apps/api/src/agent-runtime/agent-runtime.service.ts`（`runTurnStream()` 内配置组合块的消失）
5. 测试：`agent-run-configuration.service.test.ts` → `agent-runtime.service.test.ts` 新 AC-04 用例

真实调用链：`SeoService → AgentRuntimeService.runTurnStream()`（policy getter 定 deadline → `resolve(input)` 得 request/tools → Initial Context Selection 与 chatStreamOptions 共用 request）`→ LLMService.chatStream → OpenAICompatibleClient`。

实施状态：已实现 / 验收状态：待验收

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JY2YkXEh98fUTxiNgdFPEc