### PR TITLE
refactor(admin): 统一后台面板层次与信息密度——次级面板色 token、字段列表排版与列表页高度策略

### DIFF
--- a/apps/admin/src/App.vue
+++ b/apps/admin/src/App.vue
@@ -17,30 +17,74 @@ const { locale, t } = useI18n()
 
 const antLocale = computed(() => locale.value === 'en-US' ? enUS : zhCN)
 
-const themeConfig = computed<ThemeConfig>(() => ({
-  algorithm: preferences.resolvedTheme === 'dark'
-    ? antdTheme.darkAlgorithm
-    : antdTheme.defaultAlgorithm,
-  token: {
-    borderRadius: 8,
-    colorPrimary: '#006fe6',
-    fontFamily: 'var(--admin-font-family)',
+/**
+ * ant-design-vue 的 token 需要真实色值参与派生计算，无法直接消费 CSS 变量，
+ * 因此这里镜像 styles/index.css 的关键色。改动其一必须同步另一处。
+ */
+const seedColors = {
+  light: {
+    colorPrimary: '#1c6ced',
+    colorBgContainer: '#ffffff',
+    colorBgElevated: '#ffffff',
+    colorBgLayout: '#f5f7f9',
+    colorBorderSecondary: '#e7e9ee',
+    colorText: '#282c34',
+    colorTextSecondary: '#6b7280',
   },
-  components: {
-    Button: {
-      controlHeight: 34,
-    },
-    Card: {
-      paddingLG: 20,
-    },
-    Menu: {
-      itemBorderRadius: 8,
-      itemHeight: 38,
-      itemMarginBlock: 2,
-      itemMarginInline: 8,
-    },
+  dark: {
+    colorPrimary: '#518ff6',
+    colorBgContainer: '#1c1e24',
+    colorBgElevated: '#232630',
+    colorBgLayout: '#111317',
+    colorBorderSecondary: '#34363d',
+    colorText: '#f0f2f4',
+    colorTextSecondary: '#a4a9b4',
   },
-}))
+} as const
+
+const themeConfig = computed<ThemeConfig>(() => {
+  const dark = preferences.resolvedTheme === 'dark'
+
+  return {
+    algorithm: dark ? antdTheme.darkAlgorithm : antdTheme.defaultAlgorithm,
+    token: {
+      ...(dark ? seedColors.dark : seedColors.light),
+      borderRadius: 10,
+      fontFamily: 'var(--admin-font-family)',
+      fontSize: 14,
+    },
+    components: {
+      Button: {
+        controlHeight: 34,
+        borderRadius: 8,
+      },
+      Card: {
+        paddingLG: 20,
+      },
+      Input: {
+        borderRadius: 8,
+      },
+      Select: {
+        borderRadius: 8,
+      },
+      Menu: {
+        itemBorderRadius: 8,
+        itemHeight: 38,
+        itemMarginBlock: 2,
+        itemMarginInline: 8,
+      },
+      Segmented: {
+        borderRadius: 8,
+        bgColorSelected: dark ? '#2b2f3a' : '#ffffff',
+      },
+      Table: {
+        tableHeaderBg: 'transparent',
+        tableHeaderCellSplitColor: 'transparent',
+        tableRowHoverBg: dark ? '#22252d' : '#f5f7fa',
+      },
+    },
+  }
+})
 
 watch([() => route.meta.titleKey, locale], () => {
   const title = route.meta.titleKey ? t(route.meta.titleKey) : route.meta.title

--- a/apps/admin/src/components/common/EmptyState.vue
+++ b/apps/admin/src/components/common/EmptyState.vue
@@ -34,13 +34,13 @@ const simpleImage = Empty.PRESENTED_IMAGE_SIMPLE
   display: block;
   margin-bottom: 5px;
   color: var(--admin-text);
-  font-size: 14px;
+  font-size: var(--admin-font-md);
 }
 
 .empty-state p {
   max-width: 420px;
   margin: 0;
   color: var(--admin-text-muted);
-  font-size: 12px;
+  font-size: var(--admin-font-sm);
 }
 </style>

--- a/apps/admin/src/components/common/PageHeader.vue
+++ b/apps/admin/src/components/common/PageHeader.vue
@@ -32,7 +32,7 @@ defineProps<{
   display: block;
   margin-bottom: 7px;
   color: var(--admin-primary);
-  font-size: 10px;
+  font-size: var(--admin-font-2xs);
   font-weight: 700;
   letter-spacing: 0.13em;
   text-transform: uppercase;
@@ -41,7 +41,7 @@ defineProps<{
 h1 {
   margin: 0;
   color: var(--admin-text);
-  font-size: 23px;
+  font-size: var(--admin-font-2xl);
   font-weight: 650;
   letter-spacing: -0.025em;
 }
@@ -50,7 +50,7 @@ p {
   max-width: 680px;
   margin: 7px 0 0;
   color: var(--admin-text-muted);
-  font-size: 13px;
+  font-size: var(--admin-font-sm);
   line-height: 1.65;
 }
 

--- a/apps/admin/src/components/common/StatusBadge.vue
+++ b/apps/admin/src/components/common/StatusBadge.vue
@@ -23,7 +23,7 @@ withDefaults(defineProps<{
   border-radius: 999px;
   color: var(--admin-text-muted);
   background: var(--admin-surface);
-  font-size: 11px;
+  font-size: var(--admin-font-xs);
   font-weight: 600;
 }
 

--- a/apps/admin/src/components/layout/AdminBreadcrumb.vue
+++ b/apps/admin/src/components/layout/AdminBreadcrumb.vue
@@ -36,6 +36,6 @@ const parent = computed(() => route.meta.parentPath && (route.meta.parentTitleKe
 
 <style scoped>
 .admin-breadcrumb {
-  font-size: 13px;
+  font-size: var(--admin-font-sm);
 }
 </style>

--- a/apps/admin/src/components/layout/AdminHeader.vue
+++ b/apps/admin/src/components/layout/AdminHeader.vue
@@ -85,7 +85,7 @@ const { t } = useI18n()
   width: 34px;
   place-items: center;
   color: var(--admin-text-muted);
-  font-size: 16px;
+  font-size: var(--admin-font-lg);
 }
 
 .admin-header__actions {
@@ -100,7 +100,7 @@ const { t } = useI18n()
   border: 1px solid var(--admin-border);
   border-radius: 999px;
   color: var(--admin-text-muted);
-  font-size: 11px;
+  font-size: var(--admin-font-xs);
 }
 
 .admin-header__environment i {
@@ -127,7 +127,7 @@ const { t } = useI18n()
   border-radius: 50%;
   color: var(--admin-primary);
   background: var(--admin-primary-soft);
-  font-size: 14px;
+  font-size: var(--admin-font-md);
 }
 
 .admin-header__user > span {
@@ -137,13 +137,13 @@ const { t } = useI18n()
 
 .admin-header__user strong {
   color: var(--admin-text);
-  font-size: 12px;
+  font-size: var(--admin-font-sm);
   font-weight: 600;
 }
 
 .admin-header__user small {
   margin-top: 3px;
   color: var(--admin-text-subtle);
-  font-size: 10px;
+  font-size: var(--admin-font-2xs);
 }
 </style>

--- a/apps/admin/src/components/layout/AdminLogo.vue
+++ b/apps/admin/src/components/layout/AdminLogo.vue
@@ -42,7 +42,7 @@ const { t } = useI18n()
   color: #fff;
   background: var(--admin-primary);
   box-shadow: 0 5px 14px rgb(0 111 230 / 24%);
-  font-size: 17px;
+  font-size: var(--admin-font-lg);
 }
 
 .admin-logo__copy {
@@ -53,7 +53,7 @@ const { t } = useI18n()
 }
 
 .admin-logo__copy strong {
-  font-size: 14px;
+  font-size: var(--admin-font-md);
   font-weight: 650;
   letter-spacing: -0.01em;
 }
@@ -61,7 +61,7 @@ const { t } = useI18n()
 .admin-logo__copy small {
   margin-top: 4px;
   color: var(--admin-text-muted);
-  font-size: 10px;
+  font-size: var(--admin-font-2xs);
   letter-spacing: 0.08em;
   text-transform: uppercase;
 }

--- a/apps/admin/src/components/layout/AdminRouteTabs.vue
+++ b/apps/admin/src/components/layout/AdminRouteTabs.vue
@@ -140,7 +140,7 @@ function getTabTitle(tab: RouteTab): string {
   background: transparent;
   cursor: pointer;
   font: inherit;
-  font-size: 12px;
+  font-size: var(--admin-font-sm);
 }
 
 .route-tab:has(.route-tab__close) > button:first-child {
@@ -151,7 +151,7 @@ function getTabTitle(tab: RouteTab): string {
   width: 24px;
   padding: 0 8px 0 2px;
   color: var(--admin-text-subtle);
-  font-size: 10px;
+  font-size: var(--admin-font-2xs);
 }
 
 .route-tab .route-tab__close:hover {

--- a/apps/admin/src/components/layout/AdminSidebar.vue
+++ b/apps/admin/src/components/layout/AdminSidebar.vue
@@ -100,7 +100,7 @@ const activeMenuPath = computed(() => resolveActiveMenuPath(route))
 .admin-nav__section {
   padding: 4px 10px 8px;
   color: var(--admin-text-subtle);
-  font-size: 10px;
+  font-size: var(--admin-font-2xs);
   font-weight: 650;
   letter-spacing: 0.12em;
   text-transform: uppercase;
@@ -112,9 +112,9 @@ const activeMenuPath = computed(() => resolveActiveMenuPath(route))
   align-items: center;
   gap: 11px;
   padding: 0 12px;
-  border-radius: var(--admin-radius);
+  border-radius: var(--admin-radius-sm);
   color: var(--admin-text-muted);
-  font-size: 14px;
+  font-size: var(--admin-font-md);
   font-weight: 500;
   text-decoration: none;
   transition: color 140ms ease, background-color 140ms ease;
@@ -133,7 +133,7 @@ const activeMenuPath = computed(() => resolveActiveMenuPath(route))
 .admin-nav__icon {
   width: 16px;
   flex: 0 0 16px;
-  font-size: 16px;
+  font-size: var(--admin-font-lg);
 }
 
 .is-collapsed .admin-nav__item {
@@ -154,7 +154,7 @@ const activeMenuPath = computed(() => resolveActiveMenuPath(route))
   background: var(--admin-hover);
   cursor: pointer;
   font: inherit;
-  font-size: 13px;
+  font-size: var(--admin-font-sm);
 }
 
 .admin-sidebar__toggle:hover {

--- a/apps/admin/src/components/layout/LanguageSwitcher.vue
+++ b/apps/admin/src/components/layout/LanguageSwitcher.vue
@@ -47,11 +47,11 @@ function selectLocale(value: AdminLocale): void {
   justify-content: center;
   gap: 6px;
   color: var(--admin-text-muted);
-  font-size: 13px;
+  font-size: var(--admin-font-sm);
 }
 
 .language-trigger span {
-  font-size: 11px;
+  font-size: var(--admin-font-xs);
   font-weight: 600;
 }
 </style>

--- a/apps/admin/src/components/layout/ThemeToggle.vue
+++ b/apps/admin/src/components/layout/ThemeToggle.vue
@@ -81,7 +81,7 @@ function selectTheme(value: AdminTheme) {
   width: 34px;
   place-items: center;
   color: var(--admin-text-muted);
-  font-size: 16px;
+  font-size: var(--admin-font-lg);
 }
 
 .theme-menu {
@@ -106,7 +106,7 @@ function selectTheme(value: AdminTheme) {
   background: transparent;
   cursor: pointer;
   font: inherit;
-  font-size: 12px;
+  font-size: var(--admin-font-xs);
   text-align: left;
 }
 

--- a/apps/admin/src/features/runs/components/RunStatusTag.vue
+++ b/apps/admin/src/features/runs/components/RunStatusTag.vue
@@ -28,7 +28,7 @@ const color = computed(() => ({
   min-width: 70px;
   margin-inline-end: 0;
   text-align: center;
-  font-size: 10px;
+  font-size: var(--admin-font-2xs);
   font-weight: 650;
   letter-spacing: 0.025em;
 }

--- a/apps/admin/src/features/runs/trace/RunTraceHeader.vue
+++ b/apps/admin/src/features/runs/trace/RunTraceHeader.vue
@@ -150,9 +150,9 @@ async function copyRunId() {
 .trace-header__run-id > span {
   grid-column: 1 / -1;
   color: var(--admin-text-muted);
-  font-size: 10px;
+  font-size: var(--admin-font-2xs);
   font-weight: 700;
-  letter-spacing: 0.08em;
+  letter-spacing: 0.07em;
   text-transform: uppercase;
 }
 
@@ -161,7 +161,7 @@ async function copyRunId() {
   overflow: hidden;
   color: var(--admin-primary);
   font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
-  font-size: 10px;
+  font-size: var(--admin-font-xs);
   text-overflow: ellipsis;
   white-space: nowrap;
 }
@@ -170,8 +170,8 @@ async function copyRunId() {
   min-width: 0;
   overflow: hidden;
   color: var(--admin-text);
-  font-family: monospace;
-  font-size: 14px;
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: var(--admin-font-md);
   font-weight: 600;
   text-overflow: ellipsis;
   white-space: nowrap;
@@ -184,11 +184,11 @@ async function copyRunId() {
   place-items: center;
   padding: 0;
   border: 0;
-  border-radius: var(--admin-radius);
+  border-radius: var(--admin-radius-sm);
   color: var(--admin-text-subtle);
   background: transparent;
   cursor: pointer;
-  font-size: 13px;
+  font-size: var(--admin-font-sm);
 }
 
 .trace-header__copy:hover {
@@ -202,7 +202,7 @@ async function copyRunId() {
 
 .trace-header__identity :deep(.run-status-tag) {
   min-width: 78px;
-  font-size: 11px;
+  font-size: var(--admin-font-2xs);
 }
 
 .trace-header__metrics,
@@ -238,7 +238,7 @@ async function copyRunId() {
 .trace-header dt {
   overflow: hidden;
   color: var(--admin-text-muted);
-  font-size: 10px;
+  font-size: var(--admin-font-xs);
   font-weight: 600;
   text-overflow: ellipsis;
   white-space: nowrap;
@@ -249,8 +249,8 @@ async function copyRunId() {
   margin: 4px 0 0;
   overflow: hidden;
   color: var(--admin-text);
-  font-family: monospace;
-  font-size: 13px;
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: var(--admin-font-sm);
   font-variant-numeric: tabular-nums;
   text-overflow: ellipsis;
   white-space: nowrap;
@@ -261,7 +261,7 @@ async function copyRunId() {
   grid-template-columns: repeat(3, minmax(0, 1fr));
   padding: 8px 18px;
   border-top: 1px solid var(--admin-border);
-  background: color-mix(in srgb, var(--admin-bg-deep) 52%, var(--admin-surface));
+  background: var(--admin-surface-muted);
 }
 
 .trace-header__times > div {
@@ -274,7 +274,7 @@ async function copyRunId() {
 .trace-header__times dd {
   margin: 0;
   color: var(--admin-text-muted);
-  font-size: 11px;
+  font-size: var(--admin-font-xs);
 }
 
 @container run-trace (max-width: 880px) {

--- a/apps/admin/src/features/runs/trace/RunTraceInspector.vue
+++ b/apps/admin/src/features/runs/trace/RunTraceInspector.vue
@@ -165,13 +165,17 @@ const title = computed(() => {
 </template>
 
 <style scoped>
+/* 次级面板：底色比左侧 Ledger 下沉一层，内容以白卡浮于其上 */
 .run-trace-inspector {
+  /* 面板宽度可被拖拽独立调整，字段列表的断点必须以本面板为准，
+     不能沿用整个工作区的 run-trace 容器。 */
+  container: trace-inspector / inline-size;
   min-width: 0;
   height: 100%;
   min-height: 0;
   overflow: auto;
   color: var(--admin-text);
-  background: var(--admin-surface);
+  background: var(--admin-surface-muted);
   scrollbar-gutter: stable;
 }
 
@@ -181,8 +185,8 @@ const title = computed(() => {
   top: 0;
   display: flex;
   min-width: 0;
-  padding: 12px 18px 0;
-  background: var(--admin-surface);
+  padding: 14px 16px 0;
+  background: var(--admin-surface-muted);
 }
 
 .run-trace-inspector__switch :deep(.ant-segmented) {
@@ -194,14 +198,13 @@ const title = computed(() => {
 .run-trace-inspector__header {
   position: sticky;
   z-index: 2;
-  top: 40px;
+  top: 42px;
   display: flex;
   align-items: flex-start;
   justify-content: space-between;
   gap: 16px;
-  padding: 18px 18px 15px;
-  border-bottom: 1px solid var(--admin-border);
-  background: var(--admin-surface);
+  padding: 16px 16px 14px;
+  background: var(--admin-surface-muted);
 }
 
 .run-trace-inspector__identity {
@@ -210,9 +213,9 @@ const title = computed(() => {
 
 .run-trace-inspector__identity > span {
   color: var(--admin-text-muted);
-  font-size: 11px;
+  font-size: var(--admin-font-2xs);
   font-weight: 700;
-  letter-spacing: 0.08em;
+  letter-spacing: 0.07em;
   text-transform: uppercase;
 }
 
@@ -220,8 +223,8 @@ const title = computed(() => {
   margin: 6px 0 3px;
   overflow: hidden;
   color: var(--admin-text);
-  font-size: 17px;
-  font-weight: 680;
+  font-size: var(--admin-font-lg);
+  font-weight: 650;
   line-height: 1.35;
   text-overflow: ellipsis;
   white-space: nowrap;
@@ -230,8 +233,8 @@ const title = computed(() => {
 .run-trace-inspector__identity code {
   display: block;
   overflow: hidden;
-  color: var(--admin-text-muted);
-  font-size: 11px;
+  color: var(--admin-text-subtle);
+  font-size: var(--admin-font-2xs);
   text-overflow: ellipsis;
   white-space: nowrap;
 }
@@ -246,24 +249,26 @@ const title = computed(() => {
 
 .run-trace-inspector__badges :deep(.ant-tag) {
   margin: 0;
-  font-size: 11px;
+  border-radius: var(--admin-radius-sm);
+  font-size: var(--admin-font-2xs);
 }
 
 .run-trace-inspector__body {
-  padding: 0 18px 24px;
+  padding: 0 16px 24px;
 }
 
+/* Tabs 栏贴在 sticky header 下方，背景需与面板底色一致才不露出内容 */
 .run-trace-inspector__body :deep(.trace-inspector-tabs > .ant-tabs-nav) {
   position: sticky;
   z-index: 1;
-  top: 88px;
-  margin-bottom: 18px;
-  background: var(--admin-surface);
+  top: 92px;
+  margin-bottom: 14px;
+  background: var(--admin-surface-muted);
 }
 
 .run-trace-inspector__body :deep(.trace-inspector-tabs .ant-tabs-tab) {
-  padding-block: 12px;
-  font-size: 13px;
+  padding-block: 10px;
+  font-size: var(--admin-font-sm);
 }
 
 .run-trace-inspector__empty {

--- a/apps/admin/src/features/runs/trace/RunTraceLedger.vue
+++ b/apps/admin/src/features/runs/trace/RunTraceLedger.vue
@@ -206,7 +206,7 @@ function requestLabel(group: TraceRequestGroup): string {
   border-spacing: 0;
   table-layout: fixed;
   color: var(--admin-text);
-  font-size: 13px;
+  font-size: var(--admin-font-sm);
 }
 
 .trace-ledger__event-column {
@@ -221,8 +221,8 @@ function requestLabel(group: TraceRequestGroup): string {
   padding: 0 12px;
   border-bottom: 1px solid var(--admin-border-strong);
   color: var(--admin-text-muted);
-  background: color-mix(in srgb, var(--admin-bg-deep) 70%, var(--admin-surface));
-  font-size: 11px;
+  background: var(--admin-surface-muted);
+  font-size: var(--admin-font-xs);
   font-weight: 600;
   text-align: left;
 }
@@ -260,7 +260,7 @@ function requestLabel(group: TraceRequestGroup): string {
 .trace-ledger__request td {
   height: 38px;
   border-bottom-color: var(--admin-border-strong);
-  background: color-mix(in srgb, var(--admin-bg-deep) 52%, var(--admin-surface));
+  background: var(--admin-surface-muted);
 }
 
 .trace-ledger__request td:first-child,
@@ -270,8 +270,8 @@ function requestLabel(group: TraceRequestGroup): string {
 
 .trace-ledger__request td:first-child {
   color: var(--admin-text-muted);
-  font-family: monospace;
-  font-size: 11px;
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: var(--admin-font-xs);
 }
 
 .trace-ledger__collapse {
@@ -282,11 +282,11 @@ function requestLabel(group: TraceRequestGroup): string {
   margin-right: 3px;
   padding: 0;
   border: 0;
-  border-radius: var(--admin-radius);
+  border-radius: var(--admin-radius-sm);
   color: var(--admin-text-subtle);
   background: transparent;
   cursor: pointer;
-  font-size: 9px;
+  font-size: var(--admin-font-2xs);
 }
 
 .trace-ledger__collapse:hover {
@@ -306,7 +306,7 @@ function requestLabel(group: TraceRequestGroup): string {
   min-width: 0;
   align-items: baseline;
   gap: 12px;
-  font-size: 12px;
+  font-size: var(--admin-font-sm);
   white-space: nowrap;
 }
 
@@ -324,7 +324,7 @@ function requestLabel(group: TraceRequestGroup): string {
 
 .trace-ledger__request-content small {
   margin-left: auto;
-  font-size: 10px;
+  font-size: var(--admin-font-2xs);
   letter-spacing: 0.04em;
   text-transform: uppercase;
 }
@@ -344,7 +344,7 @@ function requestLabel(group: TraceRequestGroup): string {
   gap: 5px;
   overflow: hidden;
   color: var(--admin-text-muted);
-  font-size: 12px;
+  font-size: var(--admin-font-xs);
   font-weight: 700;
   letter-spacing: 0;
   text-overflow: ellipsis;
@@ -374,8 +374,8 @@ function requestLabel(group: TraceRequestGroup): string {
 
 .trace-ledger__record code {
   color: var(--admin-text-muted);
-  font-family: monospace;
-  font-size: 10px;
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: var(--admin-font-xs);
 }
 
 .trace-ledger__record-main {
@@ -403,20 +403,20 @@ function requestLabel(group: TraceRequestGroup): string {
 }
 
 .trace-ledger__content strong {
-  font-size: 13px;
+  font-size: var(--admin-font-sm);
   font-weight: 650;
 }
 
 .trace-ledger__content span,
 .trace-ledger__record-main > small {
   color: var(--admin-text-muted);
-  font-size: 13px;
+  font-size: var(--admin-font-sm);
 }
 
 .trace-ledger__record-main > small {
   flex: none;
-  font-family: monospace;
-  font-size: 10px;
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: var(--admin-font-xs);
   font-variant-numeric: tabular-nums;
 }
 
@@ -424,10 +424,10 @@ function requestLabel(group: TraceRequestGroup): string {
   flex: none;
   padding: 1px 5px;
   border: 1px solid var(--admin-border-strong);
-  border-radius: var(--admin-radius);
+  border-radius: var(--admin-radius-sm);
   color: var(--admin-text-muted);
-  background: var(--admin-bg-deep);
-  font-size: 10px;
+  background: var(--admin-surface-muted);
+  font-size: var(--admin-font-2xs);
 }
 
 .trace-ledger__record.is-error .trace-ledger__content strong,
@@ -450,7 +450,7 @@ function requestLabel(group: TraceRequestGroup): string {
 
   .trace-ledger__kind {
     width: 64px;
-    font-size: 10px;
+    font-size: var(--admin-font-2xs);
   }
 
   .trace-ledger__content {

--- a/apps/admin/src/features/runs/trace/RunTraceOverview.vue
+++ b/apps/admin/src/features/runs/trace/RunTraceOverview.vue
@@ -167,7 +167,7 @@ function spanLabel(span: TraceOverviewSpan): string {
 
 .trace-overview__heading strong {
   color: var(--admin-text);
-  font-size: 12px;
+  font-size: var(--admin-font-sm);
   font-weight: 650;
 }
 
@@ -179,7 +179,7 @@ function spanLabel(span: TraceOverviewSpan): string {
 .trace-overview__axis,
 .trace-overview__empty {
   color: var(--admin-text-muted);
-  font-size: 10px;
+  font-size: var(--admin-font-2xs);
   font-variant-numeric: tabular-nums;
 }
 
@@ -200,7 +200,7 @@ function spanLabel(span: TraceOverviewSpan): string {
   justify-content: flex-end;
   padding-right: 9px;
   color: var(--admin-text-muted);
-  font-size: 11px;
+  font-size: var(--admin-font-xs);
   font-weight: 600;
 }
 
@@ -228,7 +228,7 @@ function spanLabel(span: TraceOverviewSpan): string {
   height: 8px;
   padding: 0;
   border: 0;
-  border-radius: var(--admin-radius);
+  border-radius: var(--admin-radius-sm);
   background: var(--trace-span-color);
   cursor: pointer;
   opacity: 0.72;

--- a/apps/admin/src/features/runs/trace/RunTraceToolbar.vue
+++ b/apps/admin/src/features/runs/trace/RunTraceToolbar.vue
@@ -86,7 +86,7 @@ const { locale, t } = useI18n()
   gap: 14px;
   padding: 3px 12px;
   border-bottom: 1px solid var(--admin-border);
-  background: color-mix(in srgb, var(--admin-bg-deep) 38%, var(--admin-surface));
+  background: var(--admin-surface-muted);
 }
 
 .trace-toolbar__stats {
@@ -111,14 +111,14 @@ const { locale, t } = useI18n()
 .trace-toolbar__stats dt,
 .trace-toolbar__count {
   color: var(--admin-text-muted);
-  font-size: 11px;
+  font-size: var(--admin-font-xs);
 }
 
 .trace-toolbar__stats dd {
   margin: 0;
   color: var(--admin-text);
-  font-family: monospace;
-  font-size: 12px;
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: var(--admin-font-sm);
   font-variant-numeric: tabular-nums;
 }
 
@@ -132,11 +132,11 @@ const { locale, t } = useI18n()
   min-height: 32px;
   padding: 0 10px;
   border: 1px solid transparent;
-  border-radius: var(--admin-radius);
+  border-radius: var(--admin-radius-sm);
   color: var(--admin-text-muted);
   background: transparent;
   cursor: pointer;
-  font-size: 12px;
+  font-size: var(--admin-font-sm);
   transition: background-color 160ms ease, border-color 160ms ease, color 160ms ease, transform 160ms ease;
 }
 
@@ -167,10 +167,10 @@ const { locale, t } = useI18n()
   margin-left: auto;
   padding: 0 10px;
   border: 1px solid var(--admin-border);
-  border-radius: var(--admin-radius);
+  border-radius: var(--admin-radius-sm);
   color: var(--admin-text-muted);
   background: var(--admin-surface);
-  font-size: 12px;
+  font-size: var(--admin-font-sm);
 }
 
 .trace-toolbar__search:focus-within {
@@ -186,7 +186,7 @@ const { locale, t } = useI18n()
   outline: 0;
   color: var(--admin-text);
   background: transparent;
-  font-size: 12px;
+  font-size: var(--admin-font-sm);
 }
 
 .trace-toolbar__search input::placeholder {

--- a/apps/admin/src/features/runs/trace/RunTraceWorkspace.vue
+++ b/apps/admin/src/features/runs/trace/RunTraceWorkspace.vue
@@ -333,7 +333,8 @@ function resetInspectorWidth() {
 .run-trace-workspace__frame {
   display: flex;
   min-width: 0;
-  height: calc(100dvh - 156px);
+  /* 视口高度扣掉头部、路由标签与页面外框，随 token 自动跟随 */
+  height: calc(100dvh - var(--admin-header-height) - var(--admin-tabs-height) - 68px);
   min-height: 590px;
   flex-direction: column;
   overflow: hidden;

--- a/apps/admin/src/features/runs/trace/inspectors/DebugJsonPane.vue
+++ b/apps/admin/src/features/runs/trace/inspectors/DebugJsonPane.vue
@@ -109,10 +109,12 @@ async function copyJson() {
   max-height: 60vh;
   overflow: auto;
   margin: 0;
-  padding: 8px;
+  padding: 12px;
   border: 1px solid var(--admin-border);
-  border-radius: 6px;
-  font-size: 12px;
+  border-radius: var(--admin-radius-md);
+  background: var(--admin-surface-raised);
+  box-shadow: var(--admin-shadow-sm);
+  font-size: var(--admin-font-xs);
 }
 
 .debug-json-preview {

--- a/apps/admin/src/features/runs/trace/inspectors/GenericInspector.vue
+++ b/apps/admin/src/features/runs/trace/inspectors/GenericInspector.vue
@@ -71,7 +71,7 @@ function duration(value: number | null): string {
 .safe-raw-note {
   margin: 0 0 12px;
   color: var(--admin-text-muted);
-  font-size: 12px;
+  font-size: var(--admin-font-sm);
   line-height: 1.6;
 }
 
@@ -81,10 +81,11 @@ pre {
   padding: 14px;
   overflow: auto;
   border: 1px solid var(--admin-border);
-  border-radius: var(--admin-radius);
+  border-radius: var(--admin-radius-md);
   color: var(--admin-text);
-  background: var(--admin-bg-deep);
-  font-size: 11px;
+  background: var(--admin-surface-raised);
+  box-shadow: var(--admin-shadow-sm);
+  font-size: var(--admin-font-xs);
   line-height: 1.65;
   white-space: pre-wrap;
   overflow-wrap: anywhere;

--- a/apps/admin/src/features/runs/trace/inspectors/InspectorFieldList.vue
+++ b/apps/admin/src/features/runs/trace/inspectors/InspectorFieldList.vue
@@ -29,46 +29,53 @@ defineProps<{
 </template>
 
 <style scoped>
+/* 每个分组是一张浮在次级面板底色上的内容卡，边界由卡片承担，行间不再画横线。 */
+.inspector-field-list {
+  padding: 14px 16px;
+  border: 1px solid var(--admin-border);
+  border-radius: var(--admin-radius-md);
+  background: var(--admin-surface-raised);
+  box-shadow: var(--admin-shadow-sm);
+}
+
 .inspector-field-list + .inspector-field-list {
-  margin-top: 22px;
+  margin-top: 12px;
 }
 
 .inspector-field-list h4 {
-  margin: 0 0 10px;
+  margin: 0 0 8px;
+  padding-bottom: 10px;
+  border-bottom: 1px solid var(--admin-border);
   color: var(--admin-text-muted);
-  font-size: 11px;
+  font-size: var(--admin-font-2xs);
   font-weight: 700;
-  letter-spacing: 0.08em;
+  letter-spacing: 0.07em;
   text-transform: uppercase;
 }
 
+/* label 定宽，value 紧跟左对齐，短值不再被比例列推开 */
 .inspector-field-list dl {
+  display: grid;
   margin: 0;
-  border-top: 1px solid var(--admin-border);
+  grid-template-columns: 128px minmax(0, 1fr);
+  column-gap: 16px;
 }
 
 .inspector-field-list dl > :is(dt, dd) {
   margin: 0;
-  padding-block: 11px;
-  border-bottom: 1px solid var(--admin-border);
-}
-
-.inspector-field-list dl {
-  display: grid;
-  grid-template-columns: minmax(112px, 0.8fr) minmax(0, 1.2fr);
-  column-gap: 12px;
+  padding-block: 7px;
 }
 
 .inspector-field-list dt {
   color: var(--admin-text-muted);
-  font-size: 13px;
+  font-size: var(--admin-font-sm);
   line-height: 1.5;
 }
 
 .inspector-field-list dd {
   min-width: 0;
   color: var(--admin-text);
-  font-size: 13px;
+  font-size: var(--admin-font-sm);
   font-weight: 550;
   line-height: 1.5;
   overflow-wrap: anywhere;
@@ -76,7 +83,16 @@ defineProps<{
 }
 
 .inspector-field-list dd.is-mono {
-  font-size: 12px;
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: var(--admin-font-xs);
   font-variant-numeric: tabular-nums;
+}
+
+/* 窄面板下收紧 label 列，给长 ID / 时间戳留出值宽 */
+@container trace-inspector (max-width: 380px) {
+  .inspector-field-list dl {
+    grid-template-columns: 104px minmax(0, 1fr);
+    column-gap: 12px;
+  }
 }
 </style>

--- a/apps/admin/src/features/runs/trace/inspectors/MessageInspector.vue
+++ b/apps/admin/src/features/runs/trace/inspectors/MessageInspector.vue
@@ -112,16 +112,17 @@ function duration(value: number | null): string {
 <style scoped>
 .message-preview {
   min-width: 0;
-  margin-bottom: 20px;
-  padding: 15px;
+  margin-bottom: 12px;
+  padding: 14px 16px;
   border: 1px solid var(--admin-border);
-  border-radius: var(--admin-radius);
-  background: var(--admin-bg-deep);
+  border-radius: var(--admin-radius-md);
+  background: var(--admin-surface-raised);
+  box-shadow: var(--admin-shadow-sm);
 }
 
 .message-preview span {
   color: var(--admin-text-muted);
-  font-size: 11px;
+  font-size: var(--admin-font-2xs);
   font-weight: 700;
   letter-spacing: 0.07em;
   text-transform: uppercase;
@@ -130,7 +131,7 @@ function duration(value: number | null): string {
 .message-preview p {
   margin: 9px 0 0;
   color: var(--admin-text);
-  font-size: 13px;
+  font-size: var(--admin-font-sm);
   line-height: 1.65;
   overflow-wrap: anywhere;
   white-space: pre-wrap;

--- a/apps/admin/src/features/runs/trace/inspectors/RetrievalInspector.vue
+++ b/apps/admin/src/features/runs/trace/inspectors/RetrievalInspector.vue
@@ -391,7 +391,7 @@ function callStatusColor(ok: boolean | null): string {
   min-width: 0;
   margin: 0;
   color: var(--admin-text-muted);
-  font-size: 12px;
+  font-size: var(--admin-font-sm);
   line-height: 1.6;
   overflow-wrap: anywhere;
 }
@@ -404,16 +404,16 @@ function callStatusColor(ok: boolean | null): string {
 .retrieval-inspector__block h4 {
   margin: 0 0 10px;
   color: var(--admin-text-muted);
-  font-size: 11px;
+  font-size: var(--admin-font-2xs);
   font-weight: 700;
-  letter-spacing: 0.08em;
+  letter-spacing: 0.07em;
   text-transform: uppercase;
 }
 
 .retrieval-inspector__hint {
   margin: 0;
   color: var(--admin-text-muted);
-  font-size: 12px;
+  font-size: var(--admin-font-sm);
   line-height: 1.6;
   overflow-wrap: anywhere;
 }
@@ -429,9 +429,11 @@ function callStatusColor(ok: boolean | null): string {
 
 .retrieval-inspector__card {
   min-width: 0;
-  padding: 12px;
+  padding: 14px 16px;
   border: 1px solid var(--admin-border);
-  border-radius: 8px;
+  border-radius: var(--admin-radius-md);
+  background: var(--admin-surface-raised);
+  box-shadow: var(--admin-shadow-sm);
 }
 
 .retrieval-inspector__card-head {
@@ -445,14 +447,15 @@ function callStatusColor(ok: boolean | null): string {
 
 .retrieval-inspector__card-head :deep(.ant-tag) {
   margin: 0;
-  font-size: 11px;
+  border-radius: var(--admin-radius-sm);
+  font-size: var(--admin-font-2xs);
 }
 
 .retrieval-inspector__card-head code,
 .retrieval-inspector__card-head strong {
   min-width: 0;
   color: var(--admin-text);
-  font-size: 12px;
+  font-size: var(--admin-font-sm);
   overflow-wrap: anywhere;
 }
 
@@ -464,7 +467,7 @@ function callStatusColor(ok: boolean | null): string {
   border-radius: 999px;
   background: var(--admin-border);
   color: var(--admin-text-muted);
-  font-size: 11px;
+  font-size: var(--admin-font-2xs);
   font-weight: 700;
   place-content: center;
 }
@@ -483,7 +486,7 @@ function callStatusColor(ok: boolean | null): string {
 
 .retrieval-inspector__facts dt {
   color: var(--admin-text-muted);
-  font-size: 11px;
+  font-size: var(--admin-font-xs);
   line-height: 1.5;
 }
 
@@ -491,7 +494,7 @@ function callStatusColor(ok: boolean | null): string {
   min-width: 0;
   margin: 0;
   color: var(--admin-text);
-  font-size: 12px;
+  font-size: var(--admin-font-sm);
   font-weight: 550;
   line-height: 1.5;
   overflow-wrap: anywhere;
@@ -516,7 +519,7 @@ function callStatusColor(ok: boolean | null): string {
   flex-wrap: wrap;
   gap: 6px;
   color: var(--admin-text-muted);
-  font-size: 11px;
+  font-size: var(--admin-font-xs);
   overflow-wrap: anywhere;
 }
 

--- a/apps/admin/src/stores/preferences.ts
+++ b/apps/admin/src/stores/preferences.ts
@@ -37,7 +37,7 @@ export const useAdminPreferencesStore = defineStore('admin-preferences', () => {
     document.documentElement.style.colorScheme = value
     document.querySelector('meta[name="theme-color"]')?.setAttribute(
       'content',
-      value === 'dark' ? '#1c1d20' : '#ffffff',
+      value === 'dark' ? '#1c1e24' : '#f5f7f9',
     )
   }, { immediate: true })
 

--- a/apps/admin/src/styles/index.css
+++ b/apps/admin/src/styles/index.css
@@ -1,25 +1,54 @@
 :root {
   --admin-font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif;
-  --admin-header-height: 50px;
-  --admin-tabs-height: 38px;
+  --admin-header-height: 52px;
+  --admin-tabs-height: 40px;
   --admin-sidebar-width: 224px;
   --admin-sidebar-collapsed-width: 60px;
-  --admin-radius: 8px;
-  --admin-primary: hsl(212deg 100% 45%);
-  --admin-primary-soft: hsl(212deg 100% 45% / 10%);
-  --admin-success: hsl(144deg 57% 45%);
-  --admin-success-strong: hsl(144deg 55% 31%);
-  --admin-success-soft: hsl(144deg 57% 45% / 10%);
-  --admin-bg: hsl(0deg 0% 100%);
-  --admin-bg-deep: hsl(216deg 20.1% 95.5%);
+
+  /* 字号阶梯：11px 为全局下限，正文与表格内容不低于 12px */
+  --admin-font-2xs: 11px;
+  --admin-font-xs: 12px;
+  --admin-font-sm: 13px;
+  --admin-font-md: 14px;
+  --admin-font-lg: 16px;
+  --admin-font-xl: 20px;
+  --admin-font-2xl: 24px;
+
+  /* 圆角阶梯：控件 / 卡片 / 大容器分级 */
+  --admin-radius-sm: 6px;
+  --admin-radius-md: 10px;
+  --admin-radius-lg: 14px;
+
+  --admin-primary: hsl(217deg 85% 52%);
+  --admin-primary-hover: hsl(217deg 85% 46%);
+  --admin-primary-soft: hsl(217deg 85% 52% / 9%);
+  --admin-success: hsl(150deg 52% 42%);
+  --admin-success-strong: hsl(150deg 55% 30%);
+  --admin-success-soft: hsl(150deg 52% 42% / 10%);
+  --admin-warning: hsl(35deg 88% 48%);
+  --admin-warning-strong: hsl(30deg 85% 38%);
+  --admin-warning-soft: hsl(35deg 88% 48% / 11%);
+  --admin-danger: hsl(354deg 70% 51%);
+  --admin-danger-strong: hsl(354deg 70% 44%);
+  --admin-danger-soft: hsl(354deg 70% 51% / 10%);
+
+  /* 面板层级：页面底 < 卡片 < 次级面板底 < 次级面板内容卡 */
+  --admin-bg-deep: hsl(220deg 24% 95.5%);
   --admin-surface: hsl(0deg 0% 100%);
-  --admin-text: hsl(210deg 6% 21%);
-  --admin-text-muted: hsl(240deg 3.8% 43%);
-  --admin-text-subtle: hsl(217deg 10.6% 62%);
-  --admin-border: hsl(240deg 5.9% 90%);
-  --admin-border-strong: hsl(216deg 11% 83%);
-  --admin-hover: hsl(240deg 4.8% 95.9%);
-  --admin-card-shadow: 0 1px 2px rgb(15 23 42 / 3%);
+  --admin-surface-muted: hsl(220deg 22% 96.5%);
+  --admin-surface-raised: hsl(0deg 0% 100%);
+
+  --admin-text: hsl(220deg 13% 18%);
+  --admin-text-muted: hsl(220deg 9% 46%);
+  --admin-text-subtle: hsl(220deg 9% 62%);
+  --admin-border: hsl(220deg 16% 92%);
+  --admin-border-strong: hsl(220deg 14% 86%);
+  --admin-hover: hsl(220deg 20% 93.5%);
+
+  /* 阴影阶梯：卡片贴地，浮层抬起 */
+  --admin-shadow-sm: 0 1px 2px hsl(220deg 40% 20% / 4%), 0 1px 3px hsl(220deg 40% 20% / 3%);
+  --admin-shadow-md: 0 2px 4px hsl(220deg 40% 20% / 4%), 0 10px 24px -8px hsl(220deg 40% 20% / 10%);
+
   color-scheme: light;
   font-family: var(--admin-font-family);
   font-synthesis: none;
@@ -27,21 +56,35 @@
 }
 
 :root[data-theme='dark'] {
-  --admin-primary: hsl(212deg 100% 62%);
-  --admin-primary-soft: hsl(212deg 100% 62% / 12%);
-  --admin-success: hsl(144deg 57% 58%);
-  --admin-success-strong: hsl(144deg 57% 67%);
-  --admin-success-soft: hsl(144deg 57% 58% / 11%);
-  --admin-bg: hsl(222.3deg 10.4% 12.3%);
-  --admin-bg-deep: hsl(220deg 13.1% 9%);
-  --admin-surface: hsl(222.3deg 10.4% 12.3%);
-  --admin-text: hsl(0deg 0% 95%);
-  --admin-text-muted: hsl(240deg 5% 65%);
-  --admin-text-subtle: hsl(218deg 11% 52%);
-  --admin-border: hsl(240deg 3.7% 22%);
-  --admin-border-strong: hsl(240deg 3.7% 29%);
-  --admin-hover: hsl(216deg 5% 19%);
-  --admin-card-shadow: 0 1px 2px rgb(0 0 0 / 16%);
+  --admin-primary: hsl(217deg 90% 64%);
+  --admin-primary-hover: hsl(217deg 90% 70%);
+  --admin-primary-soft: hsl(217deg 90% 64% / 14%);
+  --admin-success: hsl(150deg 52% 55%);
+  --admin-success-strong: hsl(150deg 55% 64%);
+  --admin-success-soft: hsl(150deg 52% 55% / 13%);
+  --admin-warning: hsl(35deg 88% 60%);
+  --admin-warning-strong: hsl(35deg 90% 66%);
+  --admin-warning-soft: hsl(35deg 88% 60% / 14%);
+  --admin-danger: hsl(354deg 78% 65%);
+  --admin-danger-strong: hsl(354deg 80% 71%);
+  --admin-danger-soft: hsl(354deg 78% 65% / 14%);
+
+  /* 暗色下次级面板取「更深」方向，形成下沉而非漂浮 */
+  --admin-bg-deep: hsl(222deg 14% 8%);
+  --admin-surface: hsl(222deg 12% 12.5%);
+  --admin-surface-muted: hsl(222deg 13% 10%);
+  --admin-surface-raised: hsl(222deg 11% 15.5%);
+
+  --admin-text: hsl(220deg 15% 95%);
+  --admin-text-muted: hsl(220deg 9% 66%);
+  --admin-text-subtle: hsl(220deg 8% 52%);
+  --admin-border: hsl(222deg 8% 22%);
+  --admin-border-strong: hsl(222deg 8% 29%);
+  --admin-hover: hsl(222deg 9% 18%);
+
+  --admin-shadow-sm: 0 1px 2px hsl(0deg 0% 0% / 24%);
+  --admin-shadow-md: 0 2px 4px hsl(0deg 0% 0% / 24%), 0 10px 24px -8px hsl(0deg 0% 0% / 36%);
+
   color-scheme: dark;
 }
 
@@ -73,7 +116,7 @@ body {
   color: var(--admin-text);
   background: var(--admin-bg-deep);
   font-family: var(--admin-font-family);
-  font-size: 14px;
+  font-size: var(--admin-font-md);
 }
 
 button,
@@ -87,6 +130,12 @@ button:focus-visible,
 a:focus-visible {
   outline: 2px solid var(--admin-primary);
   outline-offset: 2px;
+}
+
+/* antd 4.2.6 的按钮默认带 `0 2px 0` 实心阴影，观感偏旧；
+   该阴影由全局 controlOutline 派生，无法在 Button 组件 token 里单独关掉。 */
+.ant-btn {
+  box-shadow: none;
 }
 
 ::selection {

--- a/apps/admin/src/views/ConversationDetailView.vue
+++ b/apps/admin/src/views/ConversationDetailView.vue
@@ -357,7 +357,8 @@ function handleRunsPageChange(page: number, pageSize: number) {
 <style scoped>
 .conversation-page {
   display: flex;
-  height: calc(100dvh - var(--admin-header-height) - var(--admin-tabs-height) - 40px);
+  min-height: 380px;
+  max-height: calc(100dvh - var(--admin-header-height) - var(--admin-tabs-height) - 40px);
   flex-direction: column;
 }
 
@@ -367,8 +368,9 @@ function handleRunsPageChange(page: number, pageSize: number) {
   flex-direction: column;
   min-height: 0;
   border: 1px solid var(--admin-border);
+  border-radius: var(--admin-radius-md);
   background: var(--admin-surface);
-  box-shadow: var(--admin-card-shadow);
+  box-shadow: var(--admin-shadow-sm);
 }
 
 .detail-card :deep(> .ant-card-body) {
@@ -400,7 +402,7 @@ function handleRunsPageChange(page: number, pageSize: number) {
 .conversation-header__identity strong {
   overflow: hidden;
   color: var(--admin-text);
-  font-size: 15px;
+  font-size: var(--admin-font-lg);
   font-weight: 650;
   text-overflow: ellipsis;
   white-space: nowrap;
@@ -410,7 +412,7 @@ function handleRunsPageChange(page: number, pageSize: number) {
   overflow: hidden;
   color: var(--admin-text-subtle);
   font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
-  font-size: 10px;
+  font-size: var(--admin-font-xs);
   text-overflow: ellipsis;
   white-space: nowrap;
 }
@@ -424,14 +426,14 @@ function handleRunsPageChange(page: number, pageSize: number) {
 
 .conversation-header__meta dt {
   color: var(--admin-text-muted);
-  font-size: 10px;
+  font-size: var(--admin-font-xs);
   font-weight: 600;
 }
 
 .conversation-header__meta dd {
   margin: 2px 0 0;
   color: var(--admin-text);
-  font-size: 12px;
+  font-size: var(--admin-font-sm);
   font-variant-numeric: tabular-nums;
 }
 
@@ -450,7 +452,7 @@ function handleRunsPageChange(page: number, pageSize: number) {
 
 .detail-tabs :deep(.ant-tabs-tab) {
   padding: 12px 4px 10px;
-  font-size: 13px;
+  font-size: var(--admin-font-sm);
   font-weight: 600;
 }
 
@@ -481,9 +483,9 @@ function handleRunsPageChange(page: number, pageSize: number) {
   min-height: 0;
   flex-direction: column;
   gap: 14px;
-  padding: 16px;
+  padding: 18px 16px;
   overflow-y: auto;
-  background: var(--admin-bg-deep);
+  background: var(--admin-surface-muted);
 }
 
 .transcript-message {
@@ -508,7 +510,7 @@ function handleRunsPageChange(page: number, pageSize: number) {
   flex: none;
   place-items: center;
   border-radius: 50%;
-  font-size: 14px;
+  font-size: var(--admin-font-md);
 }
 
 .transcript-message.is-user .transcript-message__avatar {
@@ -537,10 +539,11 @@ function handleRunsPageChange(page: number, pageSize: number) {
 }
 
 .transcript-message__bubble {
-  padding: 10px 14px;
+  padding: 11px 15px;
   border: 1px solid var(--admin-border);
-  border-radius: 12px;
-  background: var(--admin-surface);
+  border-radius: var(--admin-radius-lg);
+  background: var(--admin-surface-raised);
+  box-shadow: var(--admin-shadow-sm);
 }
 
 .transcript-message.is-user .transcript-message__bubble {
@@ -551,7 +554,7 @@ function handleRunsPageChange(page: number, pageSize: number) {
 .transcript-message__bubble p {
   margin: 0;
   color: var(--admin-text);
-  font-size: 13px;
+  font-size: var(--admin-font-sm);
   line-height: 1.7;
   overflow-wrap: anywhere;
   white-space: pre-wrap;
@@ -562,7 +565,7 @@ function handleRunsPageChange(page: number, pageSize: number) {
   align-items: center;
   gap: 6px;
   color: var(--admin-text-subtle);
-  font-size: 10px;
+  font-size: var(--admin-font-xs);
 }
 
 .transcript-message footer :deep(.ant-tag) {
@@ -579,18 +582,19 @@ function handleRunsPageChange(page: number, pageSize: number) {
 }
 
 .runs-table :deep(.ant-table-thead > tr > th) {
-  height: 42px;
+  height: 44px;
+  border-bottom: 1px solid var(--admin-border);
   color: var(--admin-text-muted);
-  font-size: 10px;
-  font-weight: 650;
-  letter-spacing: 0.025em;
+  font-size: var(--admin-font-xs);
+  font-weight: 600;
+  letter-spacing: 0.01em;
   white-space: nowrap;
 }
 
 .runs-table :deep(.ant-table-tbody > tr > td) {
-  height: 47px;
+  height: 50px;
   color: var(--admin-text-muted);
-  font-size: 11px;
+  font-size: var(--admin-font-sm);
 }
 
 .run-id {
@@ -598,7 +602,7 @@ function handleRunsPageChange(page: number, pageSize: number) {
   overflow: hidden;
   color: var(--admin-primary);
   font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
-  font-size: 10px;
+  font-size: var(--admin-font-xs);
   text-overflow: ellipsis;
   white-space: nowrap;
 }
@@ -619,18 +623,18 @@ function handleRunsPageChange(page: number, pageSize: number) {
 
 .runs-footer {
   display: flex;
-  min-height: 48px;
+  min-height: 52px;
   flex: none;
   align-items: center;
   justify-content: space-between;
   gap: 16px;
   margin-top: auto;
-  padding: 8px 14px;
+  padding: 10px 16px;
   border-top: 1px solid var(--admin-border);
 }
 
 .runs-footer > span {
   color: var(--admin-text-subtle);
-  font-size: 10px;
+  font-size: var(--admin-font-xs);
 }
 </style>

--- a/apps/admin/src/views/ConversationsView.vue
+++ b/apps/admin/src/views/ConversationsView.vue
@@ -168,25 +168,25 @@ function handlePageChange(page: number, pageSize: number) {
 </template>
 
 <style scoped>
+/* 卡片按内容自适应高度，不再撑满视口；数据少时下方露出页面底色 */
 .conversations-page {
   display: flex;
-  min-height: calc(100dvh - var(--admin-header-height) - var(--admin-tabs-height) - 40px);
   flex-direction: column;
 }
 
 .table-card {
   display: flex;
-  flex: 1 0 auto;
   flex-direction: column;
   border: 1px solid var(--admin-border);
+  border-radius: var(--admin-radius-md);
   background: var(--admin-surface);
-  box-shadow: var(--admin-card-shadow);
+  box-shadow: var(--admin-shadow-sm);
 }
 
 .table-card :deep(> .ant-card-body) {
   display: flex;
   min-width: 0;
-  flex: 1;
+  min-height: 180px;
   flex-direction: column;
   padding: 0;
 }
@@ -200,22 +200,23 @@ function handlePageChange(page: number, pageSize: number) {
 }
 
 .conversations-table :deep(.ant-table) {
-  border-radius: 8px 8px 0 0;
+  border-radius: var(--admin-radius-md) var(--admin-radius-md) 0 0;
 }
 
 .conversations-table :deep(.ant-table-thead > tr > th) {
-  height: 42px;
+  height: 44px;
+  border-bottom: 1px solid var(--admin-border);
   color: var(--admin-text-muted);
-  font-size: 10px;
-  font-weight: 650;
-  letter-spacing: 0.025em;
+  font-size: var(--admin-font-xs);
+  font-weight: 600;
+  letter-spacing: 0.01em;
   white-space: nowrap;
 }
 
 .conversations-table :deep(.ant-table-tbody > tr > td) {
-  height: 47px;
+  height: 50px;
   color: var(--admin-text-muted);
-  font-size: 11px;
+  font-size: var(--admin-font-sm);
 }
 
 .conversation-id {
@@ -223,7 +224,7 @@ function handlePageChange(page: number, pageSize: number) {
   overflow: hidden;
   color: var(--admin-primary);
   font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
-  font-size: 10px;
+  font-size: var(--admin-font-xs);
   text-overflow: ellipsis;
   white-space: nowrap;
 }
@@ -244,17 +245,17 @@ function handlePageChange(page: number, pageSize: number) {
 
 .table-card__footer {
   display: flex;
-  min-height: 48px;
+  min-height: 52px;
   align-items: center;
   justify-content: space-between;
   gap: 16px;
   margin-top: auto;
-  padding: 8px 14px;
+  padding: 10px 16px;
   border-top: 1px solid var(--admin-border);
 }
 
 .table-card__footer > span {
   color: var(--admin-text-subtle);
-  font-size: 10px;
+  font-size: var(--admin-font-xs);
 }
 </style>

--- a/apps/admin/src/views/OverviewView.vue
+++ b/apps/admin/src/views/OverviewView.vue
@@ -335,7 +335,7 @@ function formatPercent(value: number, total: number): string {
 .dist-card {
   border: 1px solid var(--admin-border);
   background: var(--admin-surface);
-  box-shadow: var(--admin-card-shadow);
+  box-shadow: var(--admin-shadow-sm);
 }
 
 .stat-bar :deep(.ant-card-body) {
@@ -359,7 +359,7 @@ function formatPercent(value: number, total: number): string {
 .stat-cell small {
   display: block;
   color: var(--admin-text-muted);
-  font-size: 11px;
+  font-size: var(--admin-font-xs);
   font-weight: 600;
 }
 
@@ -368,7 +368,7 @@ function formatPercent(value: number, total: number): string {
   overflow: hidden;
   margin-top: 6px;
   color: var(--admin-text);
-  font-size: 22px;
+  font-size: var(--admin-font-2xl);
   font-variant-numeric: tabular-nums;
   font-weight: 680;
   letter-spacing: -0.02em;
@@ -380,7 +380,7 @@ function formatPercent(value: number, total: number): string {
   margin: 4px 0 0;
   overflow: hidden;
   color: var(--admin-text-subtle);
-  font-size: 11px;
+  font-size: var(--admin-font-2xs);
   text-overflow: ellipsis;
   white-space: nowrap;
 }
@@ -411,7 +411,7 @@ function formatPercent(value: number, total: number): string {
 .dist-card :deep(.ant-card-head-title) {
   padding: 10px 0;
   color: var(--admin-text-muted);
-  font-size: 11px;
+  font-size: var(--admin-font-xs);
   font-weight: 650;
 }
 
@@ -432,7 +432,7 @@ function formatPercent(value: number, total: number): string {
   margin: 0;
   padding: 18px 0 12px;
   color: var(--admin-text-subtle);
-  font-size: 12px;
+  font-size: var(--admin-font-sm);
 }
 
 .dist-list {
@@ -459,7 +459,7 @@ function formatPercent(value: number, total: number): string {
   gap: 7px;
   overflow: hidden;
   color: var(--admin-text);
-  font-size: 12px;
+  font-size: var(--admin-font-sm);
   font-weight: 600;
   text-overflow: ellipsis;
   white-space: nowrap;
@@ -475,7 +475,7 @@ function formatPercent(value: number, total: number): string {
 .dist-row__value {
   flex: none;
   color: var(--admin-text-muted);
-  font-size: 11px;
+  font-size: var(--admin-font-xs);
   font-variant-numeric: tabular-nums;
 }
 

--- a/apps/admin/src/views/RunDetailView.vue
+++ b/apps/admin/src/views/RunDetailView.vue
@@ -159,8 +159,9 @@ onBeforeUnmount(cancelRunLoad)
 .overview-card,
 .detail-tabs-card {
   border: 1px solid var(--admin-border);
+  border-radius: var(--admin-radius-md);
   background: var(--admin-surface);
-  box-shadow: var(--admin-card-shadow);
+  box-shadow: var(--admin-shadow-sm);
 }
 
 .detail-tabs-card {
@@ -179,7 +180,7 @@ onBeforeUnmount(cancelRunLoad)
 
 .detail-tabs :deep(.ant-tabs-tab) {
   padding: 14px 4px 12px;
-  font-size: 13px;
+  font-size: var(--admin-font-sm);
   font-weight: 600;
 }
 
@@ -192,12 +193,12 @@ onBeforeUnmount(cancelRunLoad)
 }
 
 .tab-notice :deep(.ant-alert-message) {
-  font-size: 13px;
+  font-size: var(--admin-font-sm);
   font-weight: 650;
 }
 
 .tab-notice :deep(.ant-alert-description) {
-  font-size: 12px;
+  font-size: var(--admin-font-sm);
 }
 
 .message-list {
@@ -210,7 +211,7 @@ onBeforeUnmount(cancelRunLoad)
   min-width: 0;
   padding: 14px 16px;
   border: 1px solid var(--admin-border);
-  border-radius: 8px;
+  border-radius: var(--admin-radius-md);
   background: var(--admin-surface);
 }
 
@@ -246,14 +247,14 @@ onBeforeUnmount(cancelRunLoad)
 .message-card time,
 .message-card code {
   color: var(--admin-text-subtle);
-  font-family: monospace;
-  font-size: 9px;
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: var(--admin-font-2xs);
 }
 
 .message-card p {
   margin: 12px 0 10px;
   color: var(--admin-text);
-  font-size: 12px;
+  font-size: var(--admin-font-sm);
   line-height: 1.75;
   overflow-wrap: anywhere;
 }

--- a/apps/admin/src/views/RunsView.vue
+++ b/apps/admin/src/views/RunsView.vue
@@ -301,42 +301,43 @@ function handlePageChange(page: number, pageSize: number) {
 </template>
 
 <style scoped>
+/* 卡片按内容自适应高度，不再撑满视口；数据少时下方露出页面底色 */
 .runs-page {
   display: flex;
-  min-height: calc(100dvh - var(--admin-header-height) - var(--admin-tabs-height) - 40px);
   flex-direction: column;
 }
 
 .summary-grid {
   display: grid;
   grid-template-columns: repeat(4, minmax(0, 1fr));
-  gap: 12px;
+  gap: 14px;
 }
 
 .summary-card,
 .filter-card,
 .table-card {
   border: 1px solid var(--admin-border);
+  border-radius: var(--admin-radius-md);
   background: var(--admin-surface);
-  box-shadow: var(--admin-card-shadow);
+  box-shadow: var(--admin-shadow-sm);
 }
 
 .summary-card :deep(.ant-card-body) {
   display: flex;
-  min-height: 96px;
+  min-height: 100px;
   align-items: center;
-  gap: 13px;
-  padding: 16px;
+  gap: 14px;
+  padding: 18px;
 }
 
 .summary-card__icon {
   display: grid;
-  width: 36px;
-  height: 36px;
-  flex: 0 0 36px;
+  width: 40px;
+  height: 40px;
+  flex: 0 0 40px;
   place-items: center;
-  border-radius: 9px;
-  font-size: 16px;
+  border-radius: var(--admin-radius-md);
+  font-size: var(--admin-font-lg);
 }
 
 .summary-card__icon.is-blue {
@@ -350,13 +351,13 @@ function handlePageChange(page: number, pageSize: number) {
 }
 
 .summary-card__icon.is-amber {
-  color: #b76400;
-  background: rgb(245 158 11 / 12%);
+  color: var(--admin-warning-strong);
+  background: var(--admin-warning-soft);
 }
 
 .summary-card__icon.is-red {
-  color: #cf1322;
-  background: rgb(207 19 34 / 10%);
+  color: var(--admin-danger-strong);
+  background: var(--admin-danger-soft);
 }
 
 .summary-card small,
@@ -367,31 +368,32 @@ function handlePageChange(page: number, pageSize: number) {
 
 .summary-card small {
   color: var(--admin-text-muted);
-  font-size: 10px;
+  font-size: var(--admin-font-xs);
   font-weight: 600;
 }
 
 .summary-card strong {
-  margin-top: 3px;
+  margin-top: 4px;
   color: var(--admin-text);
-  font-size: 20px;
-  font-weight: 680;
+  font-size: var(--admin-font-2xl);
+  font-weight: 650;
   letter-spacing: -0.025em;
+  line-height: 1.15;
 }
 
 .summary-card p {
-  margin: 2px 0 0;
+  margin: 3px 0 0;
   color: var(--admin-text-subtle);
-  font-size: 10px;
+  font-size: var(--admin-font-2xs);
 }
 
 .filter-card,
 .table-card {
-  margin-top: 12px;
+  margin-top: 14px;
 }
 
 .filter-card :deep(.ant-card-body) {
-  padding: 14px 16px 12px;
+  padding: 16px 18px 14px;
 }
 
 .run-filters {
@@ -402,7 +404,7 @@ function handlePageChange(page: number, pageSize: number) {
     minmax(230px, 1.2fr)
     auto;
   align-items: end;
-  gap: 12px;
+  gap: 14px;
 }
 
 .run-filters :deep(.ant-form-item) {
@@ -410,13 +412,13 @@ function handlePageChange(page: number, pageSize: number) {
 }
 
 .run-filters :deep(.ant-form-item-label) {
-  padding-bottom: 4px;
+  padding-bottom: 5px;
 }
 
 .run-filters :deep(.ant-form-item-label > label) {
   height: auto;
   color: var(--admin-text-muted);
-  font-size: 10px;
+  font-size: var(--admin-font-xs);
   font-weight: 600;
 }
 
@@ -426,19 +428,18 @@ function handlePageChange(page: number, pageSize: number) {
 
 .run-filters__actions {
   display: flex;
-  gap: 7px;
+  gap: 8px;
 }
 
 .table-card {
   display: flex;
-  flex: 1 0 auto;
   flex-direction: column;
 }
 
 .table-card :deep(> .ant-card-body) {
   display: flex;
   min-width: 0;
-  flex: 1;
+  min-height: 180px;
   flex-direction: column;
   padding: 0;
 }
@@ -452,22 +453,23 @@ function handlePageChange(page: number, pageSize: number) {
 }
 
 .runs-table :deep(.ant-table) {
-  border-radius: 8px 8px 0 0;
+  border-radius: var(--admin-radius-md) var(--admin-radius-md) 0 0;
 }
 
 .runs-table :deep(.ant-table-thead > tr > th) {
-  height: 42px;
+  height: 44px;
+  border-bottom: 1px solid var(--admin-border);
   color: var(--admin-text-muted);
-  font-size: 10px;
-  font-weight: 650;
-  letter-spacing: 0.025em;
+  font-size: var(--admin-font-xs);
+  font-weight: 600;
+  letter-spacing: 0.01em;
   white-space: nowrap;
 }
 
 .runs-table :deep(.ant-table-tbody > tr > td) {
-  height: 47px;
+  height: 50px;
   color: var(--admin-text-muted);
-  font-size: 11px;
+  font-size: var(--admin-font-sm);
 }
 
 .run-id {
@@ -475,7 +477,7 @@ function handlePageChange(page: number, pageSize: number) {
   overflow: hidden;
   color: var(--admin-primary);
   font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
-  font-size: 10px;
+  font-size: var(--admin-font-xs);
   text-overflow: ellipsis;
   white-space: nowrap;
 }
@@ -510,18 +512,18 @@ function handlePageChange(page: number, pageSize: number) {
 
 .table-card__footer {
   display: flex;
-  min-height: 48px;
+  min-height: 52px;
   align-items: center;
   justify-content: space-between;
   gap: 16px;
   margin-top: auto;
-  padding: 8px 14px;
+  padding: 10px 16px;
   border-top: 1px solid var(--admin-border);
 }
 
 .table-card__footer > span {
   color: var(--admin-text-subtle);
-  font-size: 10px;
+  font-size: var(--admin-font-xs);
 }
 
 @media (max-width: 1240px) {


### PR DESCRIPTION
Closes #96

## 改动概述

在共享层收敛三条全局规则，让 Admin 五个页面一并受益，而不是逐页调样式。

### Layer 1 · 主题 token（`apps/admin/src/styles/index.css`）

- 删除死变量 `--admin-bg`：与 `--admin-surface` 取值完全相同，且全仓库 0 处引用。
- 新增面板层级第三、四层：`--admin-surface-muted`（次级面板底）、`--admin-surface-raised`（次级面板上的内容卡）。
  明色为中性浅灰、暗色取「比卡片更深」的下沉方向。
- 新增字号阶梯 `--admin-font-2xs / xs / sm / md / lg / xl / 2xl`（11px 起），
  圆角阶梯 `--admin-radius-sm / md / lg`，阴影阶梯 `--admin-shadow-sm / md`。
- 主色由 `hsl(212deg 100% 45%)` 降饱和为 `hsl(217deg 85% 52%)`，同色系不换色相；
  补齐 warning / danger 语义色，替换 `RunsView` 中原先硬编码的 `#b76400` / `#cf1322`。
- 移除临时兼容别名 `--admin-radius` 与 `--admin-card-shadow`，全部引用改指新阶梯，不留同义双 token。
- `App.vue` 的 ant-design-vue `ConfigProvider` 种子色同步到新配色，并按明暗分别提供
  （ant token 需要真实色值参与派生计算，无法消费 CSS 变量，已在代码注释标明双向同步约束）。
- `stores/preferences.ts` 的 `theme-color` meta 同步为新主题色。

### Layer 2 · 字段列表密度（`InspectorFieldList.vue`）

- label 列从 `minmax(112px, 0.8fr)` 改为定宽 `128px`，value 列 `minmax(0, 1fr)` 紧跟左对齐，
  短字段（`Sequence → 3`、`Finish Reason → stop`）不再被比例列推开。
- 行高 `padding-block` 由 11px 压到 7px。
- 去掉逐行 `border-bottom`，改由分组卡片承载边界；每个分组一张浮在次级面板底色上的白卡。
- 该组件被 6 个 inspector 复用，改一处全部受益。
- `MessageInspector`、`GenericInspector`、`DebugJsonPane`、`RetrievalInspector`
  中原先坐在 `--admin-bg-deep` 上的内容块同步改为内容卡，保持右侧面板内部层次一致。

### Layer 3 · 高度策略

- `RunsView`、`ConversationsView`：去掉 `min-height: calc(100dvh - ...)` 与 `flex: 1 0 auto`，
  卡片按内容自适应，分页紧跟表格，下方露出页面底色；保留 `min-height: 180px` 兜底。
- `ConversationDetailView`：同类问题——transcript 区固定 `height` 撑满视口。
  改为 `max-height` + `min-height: 380px`，消息少时容器收缩，消息多时到上限后内部滚动。
- `RunTraceWorkspace`：硬编码的 `calc(100dvh - 156px)` 改为引用 header / tabs 高度变量，
  不再随 token 调整而失配。

### 视觉现代化（Issue 补充规格）

- 全局取消 10px 与 9px 字号，所有 `font-size` 改为引用 token 阶梯，无硬编码残留。
  表格与字段列表正文由 10-11px 提升到 12-13px。
- 表格行高 47px → 50px，表头 42px → 44px。
- `--admin-header-height` 50 → 52px，`--admin-tabs-height` 38 → 40px。
- 区域分隔改由背景色层级与留白承担，边框减弱；建立可实际生效的阴影层级。

## 验证

| 命令 | 结果 |
| --- | --- |
| `pnpm --filter @agent/admin typecheck` | 通过 |
| `pnpm --filter @agent/admin lint` | 通过 |
| `pnpm --filter @agent/admin test` | 通过（state / i18n / run-data 三项） |
| `pnpm --filter @agent/admin test:e2e` | 13 passed |
| `pnpm --filter @agent/admin build` | 通过 |
| `pnpm typecheck`（工作区全量） | 通过 |

浏览器核对：以 Playwright route fixture 驱动，对 Overview、Conversations、Conversation Detail、
Runs、Run Detail 五个页面在明暗两套主题下截图逐一核对，共 10 张。
截图脚本为临时验证用途，未纳入提交。

核对结论：
- Run Detail 右侧 Inspector 呈现「次级底色 + 白卡」层次，与左侧 Ledger 一眼可区分，面板内部背景统一。
- 短字段 label 与 value 间不再有大段空隙，Summary 20 余字段纵向长度明显缩短。
- 长值字段（`Attempt ID`、`Resolved Model`）不截断错位，`title` 提示保留。
- Runs / Conversations 在 2 条数据时卡片不再撑满视口，分页紧跟表格。
- 暗色主题下层次与对比度均正常。

## `/code-review high` findings 处理

6 项 findings 全部经源码核对确认为真问题，已在本次提交内修复。

| # | 位置 | 问题 | 处理 |
| --- | --- | --- | --- |
| 1 | `App.vue` Table | `headerBg` / `headerSplitColor` / `rowHoverBg` 在 ant-design-vue 4.2.6 中不存在（该版本用 `tableHeaderBg` / `tableHeaderCellSplitColor` / `tableRowHoverBg`，前者是 antd React v5.10+ 的名字），整段配置被浅合并静默丢弃，表头贴平与自定义 hover 均未生效 | 改为 4.2.6 的正确 token 名，已截图复核表头转为透明、hover 生效 |
| 2 | `App.vue` Button | `primaryShadow` / `defaultShadow` 同为该版本不认识的 token，按钮 `0 2px 0` 阴影原样保留 | 删除无效配置；该阴影源自全局 `controlOutline` / `controlTmpOutline`，同时被 input / select / radio / pagination / form / date-picker 的 focus ring 复用，不能全局改，改用 `.ant-btn { box-shadow: none }` 精确覆盖 |
| 3 | `App.vue` Segmented | `itemSelectedBg` 无效，4.2.6 用 `bgColorSelected`；暗色下选中态会落到 `colorBgElevated`（`#232630`）而非预期值 | 改为 `bgColorSelected` |
| 4 | `styles/index.css:46` | 亮色下 `--admin-hover` 与 `--admin-surface-muted` 撞成同值（均 `hsl(220deg 22% 96.5%)`），Ledger 请求分组行、Toolbar 按钮等 muted 底面上的 hover 反馈整体消失 | `--admin-hover` 下调为 `hsl(220deg 20% 93.5%)`，与 muted、bg-deep 三层分开 |
| 5 | `RunsView.vue` / `ConversationsView.vue` | 新增的 td `border-bottom` 是死代码：antd 用 `border-top` 画行分隔并把 `border-bottom` 设为 transparent，其选择器特异度 (0,4,2) 高于 scoped 侧 (0,3,2) | 移除死代码；分隔线颜色本就派生自同一个 `colorBorderSecondary`，视觉无变化。表头的 `border-bottom`（0,3,2 > antd 0,2,2）确实生效，保留 |
| 6 | `InspectorFieldList.vue:60` | 容器查询挂在整个 Trace 工作区上，而检查器面板宽度可被用户独立拖拽（最小 300px）；工作区仍宽时断点不触发，128px 定宽 label 会把值列压到约 92px | 在 `.run-trace-inspector` 上新建 `trace-inspector` 容器，断点改挂面板自身，已截图复核拖窄至 300px 时 label 列正确收缩 |

Review 同时核对通过（未构成问题）：删除的三个变量全仓无残留引用、`seedColors` 与 CSS 变量换算比对色差在 1-4/255 内、sticky 偏移新值更贴合实际头部高度、`calc(100dvh - 156px)` → token 表达式常量项一致、`ConversationDetailView` 的 flex 链 `min-height: 0` 完整且 IntersectionObserver 仍正常。

## 附带发现（未修，超出本 Issue 范围）

`apps/admin/e2e/retrieval-inspector.spec.ts` 的截图输出目录指向
`docs/tasks/phase-08-grounded-retrieval/assets/task-03c/`，该目录已在 `c2840e6` 随 Phase 8 归档删除。
每次跑 e2e 都会重新生成这个已归档目录，污染工作区。建议另开 Issue 调整输出路径或纳入 gitignore。
