### PR TITLE
fix(observability): 失败 sampling 保留部分模型响应

### DIFF
--- a/apps/admin/src/features/runs/run-data.check.ts
+++ b/apps/admin/src/features/runs/run-data.check.ts
@@ -395,6 +395,16 @@ function checkProductionSources(): void {
     /props\.item\.(?:prompt|reasoning|rawArguments|observationBody)\b/,
   )
 
+  const debugJsonPaneSource = readFileSync(
+    new URL('./trace/inspectors/DebugJsonPane.vue', import.meta.url),
+    'utf8',
+  )
+  assert.match(debugJsonPaneSource, /responseState === 'partial'/)
+  assert.match(debugJsonPaneSource, /capture\.state === 'empty'/)
+  assert.match(debugJsonPaneSource, /responseCapture/)
+  assert.match(debugJsonPaneSource, /state: props\.capture\.state/)
+  assert.match(debugJsonPaneSource, /debugCapture\.emptyResponse/)
+
   const ledgerSource = readFileSync(
     new URL('./trace/RunTraceLedger.vue', import.meta.url),
     'utf8',

--- a/apps/admin/src/features/runs/trace/inspectors/DebugJsonPane.vue
+++ b/apps/admin/src/features/runs/trace/inspectors/DebugJsonPane.vue
@@ -1,5 +1,8 @@
 <script setup lang="ts">
-import type { AdminDebugModelIOCapture } from '@agent/contracts'
+import type {
+  AdminDebugModelIOCapture,
+  AdminDebugModelResponseCapture,
+} from '@agent/contracts'
 import { Alert, Button, message } from 'ant-design-vue'
 import { computed } from 'vue'
 import { useI18n } from 'vue-i18n'
@@ -18,17 +21,47 @@ type JsonDataType
 
 // 旧 API 构建返回的 run 数据没有 debug 字段（undefined 而非 null），一并按未捕获处理。
 const props = defineProps<{
-  capture?: AdminDebugModelIOCapture | null
+  capture?: AdminDebugModelIOCapture | AdminDebugModelResponseCapture | null
+  responseCapture?: boolean
 }>()
 
 const { t } = useI18n()
 
-const jsonData = computed<JsonDataType>(() => (
-  props.capture && !props.capture.truncated ? props.capture.value : null
-) as JsonDataType)
+const responseState = computed(() => (
+  props.responseCapture && isResponseCapture(props.capture)
+    ? props.capture.state
+    : null
+))
+
+const jsonData = computed<JsonDataType>(() => {
+  const capture = props.capture
+
+  return (
+    capture
+    && !isEmptyResponseCapture(capture)
+    && !capture.truncated
+      ? capture.value
+      : null
+  ) as JsonDataType
+})
 
 const copyText = computed(() => {
   if (!props.capture)
+    return ''
+
+  if (props.responseCapture && isResponseCapture(props.capture)) {
+    if (props.capture.state === 'empty')
+      return JSON.stringify({ state: 'empty' }, null, 2)
+
+    return JSON.stringify({
+      state: props.capture.state,
+      ...(props.capture.truncated
+        ? { truncated: true, preview: props.capture.preview }
+        : { response: props.capture.value }),
+    }, null, 2)
+  }
+
+  if (isEmptyResponseCapture(props.capture))
     return ''
 
   return props.capture.truncated
@@ -48,6 +81,18 @@ async function copyJson() {
     message.error(t('runTrace.inspector.debugCapture.copyFailed'))
   }
 }
+
+function isResponseCapture(
+  capture: AdminDebugModelIOCapture | AdminDebugModelResponseCapture | null | undefined,
+): capture is AdminDebugModelResponseCapture {
+  return capture !== null && capture !== undefined && 'state' in capture
+}
+
+function isEmptyResponseCapture(
+  capture: AdminDebugModelIOCapture | AdminDebugModelResponseCapture,
+): capture is Extract<AdminDebugModelResponseCapture, { state: 'empty' }> {
+  return isResponseCapture(capture) && capture.state === 'empty'
+}
 </script>
 
 <template>
@@ -55,14 +100,28 @@ async function copyJson() {
     v-if="!capture"
     type="info"
     show-icon
-    :message="t('runTrace.inspector.debugCapture.empty')"
+    :message="t('runTrace.inspector.debugCapture.notCaptured')"
   />
 
   <div v-else class="debug-json-pane">
     <div class="debug-json-toolbar">
       <Alert
-        v-if="capture.truncated"
-        class="debug-json-truncated"
+        v-if="responseState === 'partial'"
+        class="debug-json-status"
+        type="warning"
+        show-icon
+        :message="t('runTrace.inspector.debugCapture.partial')"
+      />
+      <Alert
+        v-if="responseState === 'empty'"
+        class="debug-json-status"
+        type="info"
+        show-icon
+        :message="t('runTrace.inspector.debugCapture.emptyResponse')"
+      />
+      <Alert
+        v-if="!isEmptyResponseCapture(capture) && capture.truncated"
+        class="debug-json-status"
         type="warning"
         show-icon
         :message="t('runTrace.inspector.debugCapture.truncated')"
@@ -72,9 +131,12 @@ async function copyJson() {
       </Button>
     </div>
 
-    <pre v-if="capture.truncated" class="debug-json-preview">{{ capture.preview }}</pre>
+    <pre
+      v-if="!isEmptyResponseCapture(capture) && capture.truncated"
+      class="debug-json-preview"
+    >{{ capture.preview }}</pre>
     <VueJsonPretty
-      v-else
+      v-else-if="responseState !== 'empty'"
       class="debug-json-tree"
       :data="jsonData"
       :deep="4"
@@ -100,7 +162,7 @@ async function copyJson() {
   gap: 8px;
 }
 
-.debug-json-truncated {
+.debug-json-status {
   flex: 1;
 }
 

--- a/apps/admin/src/features/runs/trace/inspectors/RequestInspector.vue
+++ b/apps/admin/src/features/runs/trace/inspectors/RequestInspector.vue
@@ -214,7 +214,7 @@ function formatObservation(observation: AdminContextObservationSummary): string 
     </TabPane>
 
     <TabPane key="raw-response" :tab="t('runTrace.inspector.tabs.rawResponse')">
-      <DebugJsonPane :capture="item.debugRawResponse" />
+      <DebugJsonPane :capture="item.debugRawResponse" response-capture />
     </TabPane>
   </Tabs>
 </template>

--- a/apps/admin/src/i18n/messages.ts
+++ b/apps/admin/src/i18n/messages.ts
@@ -264,7 +264,9 @@ export const messages = {
           rawResponse: '原始响应',
         },
         debugCapture: {
-          empty: '未捕获。需要在 API 环境中开启 AGENT_DEBUG_CAPTURE_MODEL_IO 后重新运行。',
+          notCaptured: '未捕获。该运行没有可用的 debug 捕获数据。',
+          partial: '模型流未完整结束，以下仅为失败前已接收内容。',
+          emptyResponse: '请求已发起，但失败前未收到可捕获响应。',
           truncated: '内容超过截断上限，仅展示前缀预览。',
           copy: '复制 JSON',
           copied: '已复制',
@@ -786,7 +788,9 @@ export const messages = {
           rawResponse: 'Raw Response',
         },
         debugCapture: {
-          empty: 'Not captured. Enable AGENT_DEBUG_CAPTURE_MODEL_IO in the API environment and rerun.',
+          notCaptured: 'Not captured. This run has no available debug capture.',
+          partial: 'The model stream did not finish. Only content received before failure is shown.',
+          emptyResponse: 'The request started, but no capturable response arrived before failure.',
           truncated: 'Content exceeded the capture limit; only a prefix preview is shown.',
           copy: 'Copy JSON',
           copied: 'Copied',

--- a/apps/api/src/admin-runs/admin-run.projector.ts
+++ b/apps/api/src/admin-runs/admin-run.projector.ts
@@ -3,6 +3,7 @@ import type {
   AdminContextInspector,
   AdminContextObservationSummary,
   AdminDebugModelIOCapture,
+  AdminDebugModelResponseCapture,
   AdminGenericStep,
   AdminInitialHistoryExcludedReason,
   AdminLoadConversationHistoryStep,
@@ -360,7 +361,7 @@ function projectModelSampling(
     recordedDurationMs,
     contextInspector: projectContextInspector(input, output, step.status),
     debugRequestBody: readDebugModelIOCapture(output, 'debugRequestBody'),
-    debugRawResponse: readDebugModelIOCapture(output, 'debugRawResponse'),
+    debugRawResponse: readDebugModelResponseCapture(output),
     inputSummary: summarize([
       ['samplingIndex', samplingIndex],
       ['samplingAttemptId', samplingAttemptId],
@@ -1283,9 +1284,15 @@ function toSafeStepProjection(
  */
 function readDebugModelIOCapture(
   output: Record<string, unknown> | null,
-  key: 'debugRequestBody' | 'debugRawResponse',
+  key: 'debugRequestBody',
 ): AdminDebugModelIOCapture | null {
-  const envelope = readObject(output?.[key])
+  return readDebugModelIOCaptureEnvelope(output?.[key])
+}
+
+function readDebugModelIOCaptureEnvelope(
+  value: unknown,
+): AdminDebugModelIOCapture | null {
+  const envelope = readObject(value)
 
   if (envelope === null)
     return null
@@ -1300,6 +1307,32 @@ function readDebugModelIOCapture(
     return { truncated: false, value: envelope.value }
 
   return null
+}
+
+function readDebugModelResponseCapture(
+  output: Record<string, unknown> | null,
+): AdminDebugModelResponseCapture | null {
+  const envelope = readObject(output?.debugRawResponse)
+
+  if (envelope === null)
+    return null
+
+  if (envelope.state === 'empty') {
+    return Object.keys(envelope).length === 1
+      ? { state: 'empty' }
+      : null
+  }
+
+  const state = envelope.state === undefined
+    ? 'complete'
+    : envelope.state === 'complete' || envelope.state === 'partial'
+      ? envelope.state
+      : null
+  const capture = readDebugModelIOCaptureEnvelope(envelope)
+
+  return state && capture
+    ? { state, ...capture }
+    : null
 }
 
 function aggregateSamplingUsage(

--- a/apps/api/src/admin-runs/admin-runs.service.test.ts
+++ b/apps/api/src/admin-runs/admin-runs.service.test.ts
@@ -467,6 +467,80 @@ describe('Admin Run projector', () => {
     )
   })
 
+  it('Response debug capture 投影 complete / partial / empty，并兼容旧 complete 信封', () => {
+    const record = createRunRecord()
+    const samplings = record.steps
+      .filter(step => step.type === 'model_sampling')
+      .sort((left, right) => left.sequence - right.sequence)
+    const outputs = samplings.map(step => step.output as Record<string, unknown>)
+
+    outputs[0]!.debugRawResponse = {
+      truncated: false,
+      value: { choices: [{ message: { content: 'legacy complete' } }] },
+    }
+    outputs[1]!.debugRawResponse = {
+      state: 'partial',
+      truncated: true,
+      preview: '{"choices":[',
+    }
+    outputs[2]!.debugRawResponse = { state: 'empty' }
+
+    const detail = projectAdminRunDetail(record)
+    const projected = detail.timeline.filter(
+      item => item.kind === 'known' && item.type === 'model_sampling',
+    )
+
+    assert.deepEqual(projected.map(item => (
+      item.kind === 'known' && item.type === 'model_sampling'
+        ? item.debugRawResponse
+        : null
+    )), [
+      {
+        state: 'complete',
+        truncated: false,
+        value: { choices: [{ message: { content: 'legacy complete' } }] },
+      },
+      {
+        state: 'partial',
+        truncated: true,
+        preview: '{"choices":[',
+      },
+      { state: 'empty' },
+    ])
+    assert.deepEqual(
+      detail.safeRawData.agentSteps
+        .filter(step => step.type === 'model_sampling')
+        .map(step => step.debugRawResponse),
+      projected.map(item => (
+        item.kind === 'known' && item.type === 'model_sampling'
+          ? item.debugRawResponse
+          : null
+      )),
+    )
+  })
+
+  it('Response debug capture 状态或信封损坏时按未捕获降级', () => {
+    const record = createRunRecord()
+    const sampling = record.steps.find(step => step.type === 'model_sampling')!
+    const output = sampling.output as Record<string, unknown>
+
+    output.debugRawResponse = {
+      state: 'empty',
+      value: { choices: 'MUST_NOT_PROJECT' },
+    }
+
+    const detail = projectAdminRunDetail(record)
+    const projected = detail.timeline.find(item => item.id === sampling.id)
+
+    assert.equal(
+      projected?.kind === 'known' && projected.type === 'model_sampling'
+        ? projected.debugRawResponse
+        : undefined,
+      null,
+    )
+    assert.doesNotMatch(JSON.stringify(detail), /MUST_NOT_PROJECT/)
+  })
+
   it('按 Sampling 投影安全 Context Inspector，并区分三种 item count 与 Tool Exchange 0/1/2', () => {
     const record = createRunRecord()
     attachContextMetadata(record)

--- a/apps/api/src/agent-runtime/agent-runtime.service.test.ts
+++ b/apps/api/src/agent-runtime/agent-runtime.service.test.ts
@@ -1,3 +1,4 @@
+import type { ChatCompletionChunk } from 'openai/resources/chat/completions'
 import type { AgentRun, Message } from '../generated/prisma/client.js'
 import type { LLMService } from '../llm/llm.service.js'
 import type { ChatStreamOptions } from '../llm/llm.types.js'
@@ -37,6 +38,8 @@ import {
   MessageRole,
   MessageStatus,
 } from '../generated/prisma/client.js'
+import { teeRawResponseCapture } from '../llm/clients/openai-compatible-raw-capture.js'
+import { adaptOpenAICompatibleStream } from '../llm/clients/openai-compatible-stream.adapter.js'
 import { getModelProfile } from '../llm/model-profiles.js'
 import {
   DatabaseCommitOutcomeUnknownError,
@@ -1754,6 +1757,71 @@ describe('AgentRuntimeService model stream', () => {
     }
   })
 
+  it('text_delta 后迟到 Tool Call 时保留 partial capture，且原失败语义不变', async () => {
+    const secret = 'DO_NOT_LOG_RAW_RESPONSE'
+    const warnings: unknown[] = []
+    const harness = createHarness((_, options) =>
+      capturedLateToolCallModelStream(options, secret))
+
+    Object.defineProperty(harness.service, 'logger', {
+      value: {
+        error: () => {},
+        warn: (warning: unknown) => warnings.push(warning),
+      },
+    })
+
+    const events = await collectEvents(harness.run())
+    const failure = events.at(-1)
+    const samplingStep = findStep(harness, 'model_sampling')
+    const output = samplingStep?.output as Record<string, unknown>
+
+    assert.equal(failure?.type, 'run_failed')
+    assert.match(
+      failure?.type === 'run_failed' ? failure.message : '',
+      /最终回答文本之后又返回了 Tool Call/,
+    )
+    assert.equal(samplingStep?.status, AgentStepStatus.FAILED)
+    assert.equal(harness.toolInvocations.length, 0)
+    assert.deepEqual(output.debugRawResponse, {
+      state: 'partial',
+      truncated: false,
+      value: {
+        id: 'chunk-1',
+        object: 'chat.completion',
+        created: 1_756_000_000,
+        model: 'deepseek-v4-flash',
+        choices: [{
+          index: 0,
+          finish_reason: null,
+          message: {
+            role: 'assistant',
+            content: secret,
+            tool_calls: [{
+              id: 'call-1',
+              type: 'function',
+              function: {
+                name: 'search_articles',
+                arguments: '{"query":"seo"}',
+              },
+            }],
+          },
+        }],
+      },
+    })
+    assert.deepEqual(warnings, [{
+      event: 'model_sampling_debug_capture_closed',
+      runId: 'run-1',
+      samplingAttemptId: 'run-1:sampling-1',
+      termination: 'failure',
+      captureState: 'partial',
+      lastModelEvent: 'tool_call_delta',
+      textChars: secret.length,
+      toolCallCount: 1,
+    }])
+    assert.doesNotMatch(JSON.stringify(warnings), new RegExp(secret))
+    assertNoUnfinishedSteps(harness)
+  })
+
   it('第三轮再次请求工具时拒绝第三次执行且不发起第四轮 sampling', async () => {
     const streams: ModelStreamEvent[][] = [
       [
@@ -1902,7 +1970,7 @@ describe('AgentRuntimeService model stream', () => {
   it('AbortSignal 触发后只收口为 ABORTED', async () => {
     const abortController = new AbortController()
     const harness = createHarness(
-      () => abortingModelStream(abortController),
+      (_, options) => abortingModelStream(abortController, options),
       abortController.signal,
     )
 
@@ -1929,13 +1997,25 @@ describe('AgentRuntimeService model stream', () => {
         promptCacheMissTokens: 2,
       },
     )
+    assert.deepEqual(
+      (findStep(harness, 'model_sampling')?.output as Record<string, unknown>)
+        .debugRawResponse,
+      {
+        state: 'partial',
+        truncated: false,
+        value: { choices: [{ message: { content: '部分' } }] },
+      },
+    )
     assertNoUnfinishedSteps(harness)
   })
 
   it('Provider 完整结束后、Step 落库前 Abort 时仍保留已成立 Usage', async () => {
     const abortController = new AbortController()
     const harness = createHarness(
-      () => abortingAfterCompletionModelStream(abortController),
+      (_, options) => abortingAfterCompletionModelStream(
+        abortController,
+        options,
+      ),
       abortController.signal,
     )
 
@@ -1959,16 +2039,30 @@ describe('AgentRuntimeService model stream', () => {
       toolCallCount: 0,
       textChars: 2,
       intermediateTextChars: 0,
+      debugRequestBody: {
+        truncated: false,
+        value: { model: 'deepseek-v4-flash' },
+      },
+      debugRawResponse: {
+        state: 'complete',
+        truncated: false,
+        value: { choices: [{ message: { content: '完整' } }] },
+      },
     })
     assertNoUnfinishedSteps(harness)
   })
 
-  it('消费者在 delta 后提前 return() 时兜底收口为 ABORTED', async () => {
-    const harness = createHarness(() => toModelStream([
-      { type: 'text_delta', delta: '部' },
-      { type: 'text_delta', delta: '分' },
-      { type: 'response_completed', finishReason: 'stop' },
-    ]))
+  it('消费者在 delta 后提前 return() 时兜底收口为 ABORTED 并持久化 partial capture', async () => {
+    const warnings: unknown[] = []
+    const harness = createHarness((_, options) =>
+      capturedTextModelStream(options))
+
+    Object.defineProperty(harness.service, 'logger', {
+      value: {
+        error: () => {},
+        warn: (warning: unknown) => warnings.push(warning),
+      },
+    })
     const generator = harness.run()
 
     const first = await generator.next()
@@ -1987,6 +2081,85 @@ describe('AgentRuntimeService model stream', () => {
     assert.deepEqual(harness.recorder.failedRunIds, [])
     // 兜底收口必须同时取消在途模型请求，否则 provider 流会继续生成计费 token。
     assert.equal(harness.llmCalls[0]?.options?.signal?.aborted, true)
+    assert.deepEqual(
+      (findStep(harness, 'model_sampling')?.output as Record<string, unknown>)
+        .debugRawResponse,
+      {
+        state: 'partial',
+        truncated: false,
+        value: {
+          id: 'chunk-1',
+          object: 'chat.completion',
+          created: 1_756_000_000,
+          model: 'deepseek-v4-flash',
+          choices: [{
+            index: 0,
+            finish_reason: null,
+            message: { role: 'assistant', content: '部' },
+          }],
+        },
+      },
+    )
+    assert.deepEqual(warnings, [{
+      event: 'model_sampling_debug_capture_closed',
+      runId: 'run-1',
+      samplingAttemptId: 'run-1:sampling-1',
+      termination: 'consumer_return',
+      captureState: 'partial',
+      lastModelEvent: 'text_delta',
+      textChars: 1,
+      toolCallCount: 0,
+    }])
+    assert.equal(findStep(harness, 'model_sampling')?.errorMessage, null)
+    assertNoUnfinishedSteps(harness)
+  })
+
+  it('捕获未开启时消费者 return() 保持既有 Step 输出', async () => {
+    const harness = createHarness(() => toModelStream([
+      { type: 'text_delta', delta: '部' },
+      { type: 'text_delta', delta: '分' },
+      { type: 'response_completed', finishReason: 'stop' },
+    ]))
+    const generator = harness.run()
+
+    await generator.next()
+    await generator.next()
+    await generator.return(undefined)
+
+    assert.equal(findStep(harness, 'model_sampling')?.output, null)
+    assert.equal(findStep(harness, 'model_sampling')?.status, AgentStepStatus.ABORTED)
+    assert.equal(findStep(harness, 'model_sampling')?.errorMessage, null)
+    assertNoUnfinishedSteps(harness)
+  })
+
+  it('Abort 在已缓冲 delta 返回后生效时先关闭 iterator 再保存 partial capture', async () => {
+    const abortController = new AbortController()
+    const harness = createHarness(
+      (_, options) => abortingBeforeYieldModelStream(
+        abortController,
+        options,
+      ),
+      abortController.signal,
+    )
+
+    const events = await collectEvents(harness.run())
+    const samplingStep = findStep(harness, 'model_sampling')
+
+    assert.deepEqual(
+      events.map(event => event.type),
+      ['run_started', 'run_aborted'],
+    )
+    assert.equal(samplingStep?.status, AgentStepStatus.ABORTED)
+    assert.deepEqual(
+      (samplingStep?.output as Record<string, unknown>).debugRawResponse,
+      {
+        state: 'partial',
+        truncated: false,
+        value: { choices: [{ message: { content: '已缓冲' } }] },
+      },
+    )
+    assert.equal(harness.assistantMessage()?.content, '')
+    assert.equal(harness.toolInvocations.length, 0)
     assertNoUnfinishedSteps(harness)
   })
 
@@ -2083,6 +2256,7 @@ describe('AgentRuntimeService model stream', () => {
       (_, options) => waitForAbortModelStream(
         options?.signal,
         () => abortController.abort(),
+        options,
       ),
       abortController.signal,
       async () => ({
@@ -2108,6 +2282,11 @@ describe('AgentRuntimeService model stream', () => {
     assert.deepEqual(harness.recorder.failedRunIds, ['run-1'])
     assert.deepEqual(harness.recorder.abortedRunIds, [])
     assert.equal(findStep(harness, 'model_sampling')?.status, AgentStepStatus.FAILED)
+    assert.deepEqual(
+      (findStep(harness, 'model_sampling')?.output as Record<string, unknown>)
+        .debugRawResponse,
+      { state: 'empty' },
+    )
     assertNoUnfinishedSteps(harness)
   })
 
@@ -3147,6 +3326,7 @@ class FakeAgentRunRecorderService {
     _deadline: DatabaseOperationDeadline,
     assistantMessage?: { id: string, content: string },
     failedStep?: { id: string, errorMessage: string, output?: unknown },
+    metadataStep?: { id: string, output: unknown },
   ): Promise<void> {
     if (this.failRunDelayMs > 0) {
       await new Promise(resolve => setTimeout(resolve, this.failRunDelayMs))
@@ -3154,6 +3334,12 @@ class FakeAgentRunRecorderService {
     this.closeMessage(assistantMessage, MessageStatus.FAILED)
     if (failedStep) {
       this.transitionStep(failedStep.id, AgentStepStatus.FAILED, failedStep)
+    }
+    if (metadataStep && metadataStep.id !== failedStep?.id) {
+      this.transitionStep(metadataStep.id, AgentStepStatus.FAILED, {
+        errorMessage,
+        output: metadataStep.output,
+      })
     }
     this.closeUnfinishedSteps(runId, AgentStepStatus.FAILED, errorMessage)
     this.failedRunIds.push(runId)
@@ -3164,6 +3350,7 @@ class FakeAgentRunRecorderService {
     _deadline: DatabaseOperationDeadline,
     assistantMessage?: { id: string, content: string },
     abortedStep?: { id: string, errorMessage: string, output?: unknown },
+    metadataStep?: { id: string, output: unknown },
   ): Promise<void> {
     this.closeMessage(assistantMessage, MessageStatus.ABORTED)
     if (abortedStep) {
@@ -3172,6 +3359,11 @@ class FakeAgentRunRecorderService {
         AgentStepStatus.ABORTED,
         abortedStep,
       )
+    }
+    if (metadataStep && metadataStep.id !== abortedStep?.id) {
+      this.transitionStep(metadataStep.id, AgentStepStatus.ABORTED, {
+        output: metadataStep.output,
+      })
     }
     this.closeUnfinishedSteps(runId, AgentStepStatus.ABORTED)
     this.abortedRunIds.push(runId)
@@ -3283,6 +3475,72 @@ async function* toModelStream(
   yield* events
 }
 
+function capturedLateToolCallModelStream(
+  options: ChatStreamOptions | undefined,
+  content: string,
+): AsyncGenerator<ModelStreamEvent> {
+  options?.debugCapture?.onRequest({ model: 'deepseek-v4-flash' })
+
+  return adaptOpenAICompatibleStream(teeRawResponseCapture(
+    toProviderStream([
+      providerChunk({ content }),
+      providerChunk({
+        reasoning_content: 'DO_NOT_PERSIST_REASONING',
+        tool_calls: [{
+          index: 0,
+          id: 'call-1',
+          type: 'function',
+          function: {
+            name: 'search_articles',
+            arguments: '{"query":"seo"}',
+          },
+        }],
+      } as ChatCompletionChunk.Choice.Delta),
+      providerChunk({}, 'tool_calls'),
+    ]),
+    capture => options?.debugCapture?.onResponse(capture),
+  ))
+}
+
+function capturedTextModelStream(
+  options: ChatStreamOptions | undefined,
+): AsyncGenerator<ModelStreamEvent> {
+  options?.debugCapture?.onRequest({ model: 'deepseek-v4-flash' })
+
+  return adaptOpenAICompatibleStream(teeRawResponseCapture(
+    toProviderStream([
+      providerChunk({ content: '部' }),
+      providerChunk({ content: '分' }),
+      providerChunk({}, 'stop'),
+    ]),
+    capture => options?.debugCapture?.onResponse(capture),
+  ))
+}
+
+function providerChunk(
+  delta: ChatCompletionChunk.Choice.Delta,
+  finishReason: ChatCompletionChunk.Choice['finish_reason'] = null,
+): ChatCompletionChunk {
+  return {
+    id: 'chunk-1',
+    object: 'chat.completion.chunk',
+    created: 1_756_000_000,
+    model: 'deepseek-v4-flash',
+    choices: [{
+      index: 0,
+      delta,
+      finish_reason: finishReason,
+      logprobs: null,
+    }],
+  }
+}
+
+async function* toProviderStream(
+  chunks: ChatCompletionChunk[],
+): AsyncGenerator<ChatCompletionChunk> {
+  yield* chunks
+}
+
 async function* delayedCompletionModelStream(
   content: string,
   completionGate: Promise<void>,
@@ -3310,40 +3568,89 @@ async function* failingModelStream(): AsyncGenerator<ModelStreamEvent> {
 
 async function* abortingModelStream(
   abortController: AbortController,
+  options: ChatStreamOptions | undefined,
 ): AsyncGenerator<ModelStreamEvent> {
-  yield { type: 'text_delta', delta: '部分' }
-  yield {
-    type: 'usage',
-    usage: {
-      inputTokens: 7,
-      outputTokens: 3,
-      totalTokens: 10,
-      reasoningTokens: 2,
-      promptCacheHitTokens: 5,
-      promptCacheMissTokens: 2,
-    },
+  options?.debugCapture?.onRequest({ model: 'deepseek-v4-flash' })
+
+  try {
+    yield { type: 'text_delta', delta: '部分' }
+    yield {
+      type: 'usage',
+      usage: {
+        inputTokens: 7,
+        outputTokens: 3,
+        totalTokens: 10,
+        reasoningTokens: 2,
+        promptCacheHitTokens: 5,
+        promptCacheMissTokens: 2,
+      },
+    }
+    abortController.abort()
+    throw new Error('aborted')
   }
-  abortController.abort()
-  throw new Error('aborted')
+  finally {
+    options?.debugCapture?.onResponse({
+      state: 'partial',
+      lastEvent: 'text_delta',
+      textChars: 2,
+      toolCallCount: 0,
+      rawResponse: { choices: [{ message: { content: '部分' } }] },
+    })
+  }
+}
+
+async function* abortingBeforeYieldModelStream(
+  abortController: AbortController,
+  options: ChatStreamOptions | undefined,
+): AsyncGenerator<ModelStreamEvent> {
+  options?.debugCapture?.onRequest({ model: 'deepseek-v4-flash' })
+
+  try {
+    abortController.abort()
+    yield { type: 'text_delta', delta: '已缓冲' }
+  }
+  finally {
+    options?.debugCapture?.onResponse({
+      state: 'partial',
+      lastEvent: 'text_delta',
+      textChars: 3,
+      toolCallCount: 0,
+      rawResponse: { choices: [{ message: { content: '已缓冲' } }] },
+    })
+  }
 }
 
 async function* abortingAfterCompletionModelStream(
   abortController: AbortController,
+  options: ChatStreamOptions | undefined,
 ): AsyncGenerator<ModelStreamEvent> {
-  yield { type: 'text_delta', delta: '完整' }
-  yield {
-    type: 'usage',
-    usage: {
-      inputTokens: 7,
-      outputTokens: 3,
-      totalTokens: 10,
-      reasoningTokens: 2,
-      promptCacheHitTokens: 5,
-      promptCacheMissTokens: 2,
-    },
+  options?.debugCapture?.onRequest({ model: 'deepseek-v4-flash' })
+
+  try {
+    yield { type: 'text_delta', delta: '完整' }
+    yield {
+      type: 'usage',
+      usage: {
+        inputTokens: 7,
+        outputTokens: 3,
+        totalTokens: 10,
+        reasoningTokens: 2,
+        promptCacheHitTokens: 5,
+        promptCacheMissTokens: 2,
+      },
+    }
+    yield { type: 'response_completed', finishReason: 'stop' }
+    abortController.abort()
   }
-  yield { type: 'response_completed', finishReason: 'stop' }
-  abortController.abort()
+  finally {
+    options?.debugCapture?.onResponse({
+      state: 'complete',
+      lastEvent: 'finish_reason',
+      textChars: 2,
+      toolCallCount: 0,
+      rawResponse: { choices: [{ message: { content: '完整' } }] },
+    })
+  }
 }
 
 async function* abortingWithoutDeltaModelStream(
@@ -3357,11 +3664,24 @@ async function* abortingWithoutDeltaModelStream(
 async function* waitForAbortModelStream(
   signal: AbortSignal | undefined,
   afterAbort?: () => void,
+  options?: ChatStreamOptions,
 ): AsyncGenerator<ModelStreamEvent> {
   assert.ok(signal)
-  await waitForAbort(signal)
-  afterAbort?.()
-  signal.throwIfAborted()
+  options?.debugCapture?.onRequest({ model: 'deepseek-v4-flash' })
+
+  try {
+    await waitForAbort(signal)
+    afterAbort?.()
+    signal.throwIfAborted()
+  }
+  finally {
+    options?.debugCapture?.onResponse({
+      state: 'empty',
+      lastEvent: null,
+      textChars: 0,
+      toolCallCount: 0,
+    })
+  }
 }
 
 async function waitForAbort(signal: AbortSignal): Promise<void> {

--- a/apps/api/src/agent-runtime/agent-runtime.service.ts
+++ b/apps/api/src/agent-runtime/agent-runtime.service.ts
@@ -62,7 +62,10 @@ import {
   InitialContextSelectionService,
 } from './initial-context-selection.js'
 import { ModelContext } from './model-context.js'
-import { toModelIODebugCaptureEnvelope } from './model-io-debug-capture.js'
+import {
+  toModelIODebugCaptureEnvelope,
+  toModelIODebugResponseCaptureEnvelope,
+} from './model-io-debug-capture.js'
 import { streamModelSampling } from './model-sampling-decision.js'
 import {
   SamplingContextBudgetExceededError,
@@ -97,6 +100,12 @@ interface TerminalStepFailure {
 interface TerminalStepMetadata {
   id: string
   output: Prisma.InputJsonValue
+}
+
+interface ActiveSamplingClose {
+  close: () => Promise<void>
+  debugModelIO: DebugModelIOCaptured
+  toMetadata: () => TerminalStepMetadata | undefined
 }
 
 @Injectable()
@@ -136,10 +145,10 @@ export class AgentRuntimeService {
     // for-await break）会让 yield 点以 return 语义恢复、跳过 catch，
     // 此时只有 finally 有机会兜底收口。
     let terminalizationHandled = false
-    // finalization Step 的最新已知安全 output。一旦模型调用发生过，
-    // 无论 replay Abort、Step 启动失败还是终态事务回滚，都用它收口，
-    // 已经产生的 attempt 与 usage 不会从审计里消失。
-    let finalizationClose: TerminalStepMetadata | undefined
+    // 失败 / return 时仍需落库的最新安全 output；action sampling 与
+    // finalization 不会同时处于 RUNNING，因此复用一个 metadata 槽位。
+    let terminalStepMetadata: TerminalStepMetadata | undefined
+    let activeSamplingClose: ActiveSamplingClose | undefined
 
     try {
       await this.assertConversationExists(input.conversationId)
@@ -317,7 +326,10 @@ export class AgentRuntimeService {
         const samplingStartedAt = Date.now()
         // debug 捕获暂存：只有 AGENT_DEBUG_CAPTURE_MODEL_IO 开启时 client 才会回调，
         // 开关关闭时始终为空对象，落库输出与现状完全一致。
-        const debugModelIO: DebugModelIOCaptured = {}
+        const debugModelIO: DebugModelIOCaptured = {
+          runId: currentAgentRunId,
+          samplingAttemptId,
+        }
         let samplingDecision: SamplingDecision
         let completedSamplingSummary: ModelSamplingSummary | undefined
         let contextPlanSummary: SamplingContextPlanSummary | undefined
@@ -345,14 +357,47 @@ export class AgentRuntimeService {
                   onRequest: (requestBody) => {
                     debugModelIO.requestBody = requestBody
                   },
-                  onResponse: (rawResponse) => {
-                    debugModelIO.rawResponse = rawResponse
+                  onResponse: (responseCapture) => {
+                    debugModelIO.rawResponse = responseCapture
+                  },
+                  onCaptureError: (side) => {
+                    this.recordDebugCaptureFailure(debugModelIO, side)
                   },
                 },
               },
             ),
             samplingAttemptId,
           )
+          activeSamplingClose = {
+            debugModelIO,
+            close: async () => {
+              try {
+                await sampling.return(undefined as never)
+              }
+              catch {
+                this.logger.warn({
+                  event: 'model_sampling_iterator_close_failed',
+                  runId: currentAgentRunId,
+                  samplingAttemptId,
+                })
+              }
+            },
+            toMetadata: () => (
+              debugModelIO.requestBody !== undefined
+              || debugModelIO.rawResponse !== undefined
+                ? {
+                    id: samplingStep.id,
+                    output: this.toFailedSamplingStepOutput(
+                      undefined,
+                      Date.now() - samplingStartedAt,
+                      plannedMessageCount,
+                      contextPlanSummary,
+                      debugModelIO,
+                    ),
+                  }
+                : undefined
+            ),
+          }
           let samplingResult = await sampling.next()
 
           while (!samplingResult.done) {
@@ -393,8 +438,13 @@ export class AgentRuntimeService {
               ),
             },
           )
+          activeSamplingClose = undefined
         }
         catch (error) {
+          const closeSampling = activeSamplingClose
+
+          activeSamplingClose = undefined
+          await closeSampling?.close()
           terminalStepFailure = {
             id: samplingStep.id,
             errorMessage: this.toChatStreamErrorMessage(error),
@@ -415,6 +465,14 @@ export class AgentRuntimeService {
                 ),
           }
           claimRunTermination(runCancellation, error)
+          this.logSamplingDebugCaptureClosed(
+            debugModelIO,
+            runCancellation.source === 'user'
+              ? 'abort'
+              : runCancellation.source === 'deadline'
+                ? 'deadline'
+                : 'failure',
+          )
           throw error
         }
 
@@ -574,7 +632,7 @@ export class AgentRuntimeService {
         // 不依赖某一种错误类型是否恰好把 attempts 带出来。
         const finalizationAttempts: GroundedFinalizationAttemptSummary[] = []
         const closeFinalizationStep = (error?: unknown): void => {
-          finalizationClose = {
+          terminalStepMetadata = {
             id: finalizationStep.id,
             output: this.toFinalizationStepOutput(
               registry,
@@ -656,7 +714,7 @@ export class AgentRuntimeService {
             errorMessage: error instanceof GroundedFinalizationFailedError
               ? error.message
               : '回答引用校验未能安全完成。',
-            output: finalizationClose!.output,
+            output: terminalStepMetadata!.output,
           }
           claimRunTermination(runCancellation, error)
           throw error
@@ -741,7 +799,7 @@ export class AgentRuntimeService {
                 content,
               ),
               terminalStepFailure,
-              finalizationClose,
+              terminalStepMetadata,
             )
           }
           catch (terminalizationCause) {
@@ -782,7 +840,7 @@ export class AgentRuntimeService {
               content || errorMessage,
             ),
             terminalStepFailure,
-            finalizationClose,
+            terminalStepMetadata,
           )
         }
         catch (terminalizationCause) {
@@ -815,6 +873,18 @@ export class AgentRuntimeService {
         // 先取消在途模型请求：return() 路径不经过 claimRunTermination，
         // 不 abort 内部信号的话 provider 流会继续生成 token 直到自然结束。
         runCancellation?.claimFailure(new Error('流消费者提前终止了本次 Run'))
+        const samplingClose = activeSamplingClose
+
+        activeSamplingClose = undefined
+        await samplingClose?.close()
+
+        if (samplingClose) {
+          terminalStepMetadata = samplingClose.toMetadata()
+          this.logSamplingDebugCaptureClosed(
+            samplingClose.debugModelIO,
+            'consumer_return',
+          )
+        }
 
         try {
           await this.agentRunRecorderService.abortRun(
@@ -826,7 +896,7 @@ export class AgentRuntimeService {
               content,
             ),
             terminalStepFailure,
-            finalizationClose,
+            terminalStepMetadata,
           )
         }
         catch (terminalizationCause) {
@@ -1072,26 +1142,83 @@ export class AgentRuntimeService {
   ): Record<string, Prisma.InputJsonValue> {
     const output: Record<string, Prisma.InputJsonValue> = {}
 
-    for (const [capturedKey, outputKey] of [
-      ['requestBody', 'debugRequestBody'],
-      ['rawResponse', 'debugRawResponse'],
-    ] as const) {
-      const captured = debugModelIO?.[capturedKey]
+    if (debugModelIO?.requestBody !== undefined) {
+      const envelope = toModelIODebugCaptureEnvelope(debugModelIO.requestBody)
 
-      if (captured === undefined)
-        continue
-
-      const envelope = toModelIODebugCaptureEnvelope(captured)
-
-      if (envelope === undefined) {
-        this.logger.warn(`模型 I/O debug 捕获序列化失败，跳过 ${outputKey}`)
-        continue
+      if (envelope) {
+        output.debugRequestBody = envelope as unknown as Prisma.InputJsonValue
       }
+      else {
+        this.logger.warn({
+          event: 'model_sampling_debug_capture_serialization_failed',
+          runId: debugModelIO.runId,
+          samplingAttemptId: debugModelIO.samplingAttemptId,
+          captureSide: 'request',
+        })
+      }
+    }
 
-      output[outputKey] = envelope as unknown as Prisma.InputJsonValue
+    if (debugModelIO?.rawResponse !== undefined) {
+      const capture = debugModelIO.rawResponse
+      const envelope = toModelIODebugResponseCaptureEnvelope(capture)
+
+      if (envelope) {
+        output.debugRawResponse = envelope as unknown as Prisma.InputJsonValue
+      }
+      else {
+        this.logger.warn({
+          event: 'model_sampling_debug_capture_serialization_failed',
+          runId: debugModelIO.runId,
+          samplingAttemptId: debugModelIO.samplingAttemptId,
+          captureSide: 'response',
+          captureState: capture.state,
+          lastModelEvent: capture.lastEvent,
+          textChars: capture.textChars,
+          toolCallCount: capture.toolCallCount,
+        })
+      }
     }
 
     return output
+  }
+
+  private recordDebugCaptureFailure(
+    debugModelIO: DebugModelIOCaptured,
+    side: 'request' | 'response',
+  ): void {
+    debugModelIO.failedSides ??= []
+
+    if (debugModelIO.failedSides.includes(side))
+      return
+
+    debugModelIO.failedSides.push(side)
+    this.logger.warn({
+      event: 'model_sampling_debug_capture_failed',
+      runId: debugModelIO.runId,
+      samplingAttemptId: debugModelIO.samplingAttemptId,
+      captureSide: side,
+    })
+  }
+
+  private logSamplingDebugCaptureClosed(
+    debugModelIO: DebugModelIOCaptured,
+    termination: 'abort' | 'consumer_return' | 'deadline' | 'failure',
+  ): void {
+    const capture = debugModelIO.rawResponse
+
+    if (!capture)
+      return
+
+    this.logger.warn({
+      event: 'model_sampling_debug_capture_closed',
+      runId: debugModelIO.runId,
+      samplingAttemptId: debugModelIO.samplingAttemptId,
+      termination,
+      captureState: capture.state,
+      lastModelEvent: capture.lastEvent,
+      textChars: capture.textChars,
+      toolCallCount: capture.toolCallCount,
+    })
   }
 
   /**

--- a/apps/api/src/agent-runtime/model-io-debug-capture.test.ts
+++ b/apps/api/src/agent-runtime/model-io-debug-capture.test.ts
@@ -5,6 +5,7 @@ import { describe, it } from 'node:test'
 import {
   MODEL_IO_DEBUG_CAPTURE_MAX_JSON_CHARS,
   toModelIODebugCaptureEnvelope,
+  toModelIODebugResponseCaptureEnvelope,
 } from './model-io-debug-capture.js'
 
 describe('toModelIODebugCaptureEnvelope', () => {
@@ -84,5 +85,61 @@ describe('toModelIODebugCaptureEnvelope', () => {
       },
     })
     assert.doesNotMatch(JSON.stringify(envelope), /DO_NOT_LEAK|reasoning_content/)
+  })
+})
+
+describe('toModelIODebugResponseCaptureEnvelope', () => {
+  it('保留 complete / partial 状态并沿用响应截断信封', () => {
+    assert.deepEqual(toModelIODebugResponseCaptureEnvelope({
+      state: 'partial',
+      lastEvent: 'text_delta',
+      textChars: 2,
+      toolCallCount: 0,
+      rawResponse: { choices: [{ message: { content: '部分' } }] },
+    }), {
+      state: 'partial',
+      truncated: false,
+      value: { choices: [{ message: { content: '部分' } }] },
+    })
+  })
+
+  it('empty 只记录事实，不伪造 value / preview', () => {
+    assert.deepEqual(toModelIODebugResponseCaptureEnvelope({
+      state: 'empty',
+      lastEvent: null,
+      textChars: 0,
+      toolCallCount: 0,
+    }), {
+      state: 'empty',
+    })
+  })
+
+  it('partial 超限时状态保留在截断信封外层', () => {
+    const envelope = toModelIODebugResponseCaptureEnvelope({
+      state: 'partial',
+      lastEvent: 'text_delta',
+      textChars: MODEL_IO_DEBUG_CAPTURE_MAX_JSON_CHARS + 1,
+      toolCallCount: 0,
+      rawResponse: {
+        content: 'x'.repeat(MODEL_IO_DEBUG_CAPTURE_MAX_JSON_CHARS + 1),
+      },
+    })
+
+    assert.ok(envelope)
+    assert.equal(envelope.state, 'partial')
+    assert.equal('truncated' in envelope ? envelope.truncated : null, true)
+  })
+
+  it('响应序列化失败继续安全降级', () => {
+    const circular: Record<string, unknown> = {}
+
+    circular.self = circular
+    assert.equal(toModelIODebugResponseCaptureEnvelope({
+      state: 'partial',
+      lastEvent: 'text_delta',
+      textChars: 1,
+      toolCallCount: 0,
+      rawResponse: circular,
+    }), undefined)
   })
 })

--- a/apps/api/src/agent-runtime/model-io-debug-capture.ts
+++ b/apps/api/src/agent-runtime/model-io-debug-capture.ts
@@ -1,9 +1,19 @@
-import type { AdminDebugModelIOCapture } from '@agent/contracts'
+import type {
+  AdminDebugModelIOCapture,
+  AdminDebugModelResponseCapture,
+} from '@agent/contracts'
+import type {
+  ModelIODebugCaptureSide,
+  ModelRawResponseCapture,
+} from '../llm/llm.types.js'
 
-/** 一轮采样内暂存的 debug 捕获原始值；未开启捕获时两侧都为 undefined。 */
+/** 一轮采样内的关联信息与 debug 原始值；未开启时两侧载荷均为 undefined。 */
 export interface DebugModelIOCaptured {
+  runId: string
+  samplingAttemptId: string
   requestBody?: unknown
-  rawResponse?: unknown
+  rawResponse?: ModelRawResponseCapture
+  failedSides?: ModelIODebugCaptureSide[]
 }
 
 /** 单侧捕获 JSON 序列化后的截断上限（约 200KB，以字符数近似）。 */
@@ -53,4 +63,20 @@ export function toModelIODebugCaptureEnvelope(
     truncated: false,
     value: JSON.parse(json),
   }
+}
+
+export function toModelIODebugResponseCaptureEnvelope(
+  capture: ModelRawResponseCapture,
+): AdminDebugModelResponseCapture | undefined {
+  if (capture.state === 'empty')
+    return { state: 'empty' }
+
+  if (capture.rawResponse === undefined)
+    return undefined
+
+  const envelope = toModelIODebugCaptureEnvelope(capture.rawResponse)
+
+  return envelope
+    ? { state: capture.state, ...envelope }
+    : undefined
 }

--- a/apps/api/src/llm/clients/openai-compatible-raw-capture.test.ts
+++ b/apps/api/src/llm/clients/openai-compatible-raw-capture.test.ts
@@ -1,4 +1,5 @@
 import type { ChatCompletionChunk } from 'openai/resources/chat/completions'
+import type { ModelRawResponseCapture } from '../llm.types.js'
 import assert from 'node:assert/strict'
 // eslint-disable-next-line test/no-import-node-test
 import { describe, it } from 'node:test'
@@ -22,6 +23,7 @@ describe('teeRawResponseCapture', () => {
       }),
     ]
     let captured: unknown
+    let captureCount = 0
 
     const forwarded: ChatCompletionChunk[] = []
 
@@ -29,31 +31,39 @@ describe('teeRawResponseCapture', () => {
       toAsyncIterable(chunks),
       (rawResponse) => {
         captured = rawResponse
+        captureCount += 1
       },
     )) {
       forwarded.push(chunk)
     }
 
     assert.deepEqual(forwarded, chunks)
+    assert.equal(captureCount, 1)
     assert.deepEqual(captured, {
-      id: 'chunk-1',
-      object: 'chat.completion',
-      created: 1_756_000_000,
-      model: 'deepseek-v4-flash',
-      choices: [
-        {
-          index: 0,
-          finish_reason: 'stop',
-          message: {
-            role: 'assistant',
-            content: '你好',
+      state: 'complete',
+      lastEvent: 'usage',
+      textChars: 2,
+      toolCallCount: 0,
+      rawResponse: {
+        id: 'chunk-1',
+        object: 'chat.completion',
+        created: 1_756_000_000,
+        model: 'deepseek-v4-flash',
+        choices: [
+          {
+            index: 0,
+            finish_reason: 'stop',
+            message: {
+              role: 'assistant',
+              content: '你好',
+            },
           },
+        ],
+        usage: {
+          prompt_tokens: 10,
+          completion_tokens: 2,
+          total_tokens: 12,
         },
-      ],
-      usage: {
-        prompt_tokens: 10,
-        completion_tokens: 2,
-        total_tokens: 12,
       },
     })
   })
@@ -98,35 +108,41 @@ describe('teeRawResponseCapture', () => {
     }
 
     assert.deepEqual(captured, {
-      id: 'chunk-1',
-      object: 'chat.completion',
-      created: 1_756_000_000,
-      model: 'deepseek-v4-flash',
-      choices: [
-        {
-          index: 0,
-          finish_reason: 'tool_calls',
-          message: {
-            role: 'assistant',
-            content: null,
-            reasoning_content: '需要检索',
-            tool_calls: [
-              {
-                id: 'call_1',
-                type: 'function',
-                function: {
-                  name: 'search_articles',
-                  arguments: '{"query":"seo"}',
+      state: 'complete',
+      lastEvent: 'finish_reason',
+      textChars: 0,
+      toolCallCount: 1,
+      rawResponse: {
+        id: 'chunk-1',
+        object: 'chat.completion',
+        created: 1_756_000_000,
+        model: 'deepseek-v4-flash',
+        choices: [
+          {
+            index: 0,
+            finish_reason: 'tool_calls',
+            message: {
+              role: 'assistant',
+              content: null,
+              reasoning_content: '需要检索',
+              tool_calls: [
+                {
+                  id: 'call_1',
+                  type: 'function',
+                  function: {
+                    name: 'search_articles',
+                    arguments: '{"query":"seo"}',
+                  },
                 },
-              },
-            ],
+              ],
+            },
           },
-        },
-      ],
+        ],
+      },
     })
   })
 
-  it('流中途抛错时不产生捕获结果并透传错误', async () => {
+  it('流中途抛错时提交 partial 并透传原错误', async () => {
     let captured: unknown
     const failing = async function* (): AsyncGenerator<ChatCompletionChunk> {
       yield createChunk({ delta: { content: '部分' } })
@@ -141,7 +157,162 @@ describe('teeRawResponseCapture', () => {
       }
     }, /stream broken/)
 
-    assert.equal(captured, undefined)
+    assert.deepEqual(captured, {
+      state: 'partial',
+      lastEvent: 'text_delta',
+      textChars: 2,
+      toolCallCount: 0,
+      rawResponse: {
+        id: 'chunk-1',
+        object: 'chat.completion',
+        created: 1_756_000_000,
+        model: 'deepseek-v4-flash',
+        choices: [{
+          index: 0,
+          finish_reason: null,
+          message: {
+            role: 'assistant',
+            content: '部分',
+          },
+        }],
+      },
+    })
+  })
+
+  it('下游提前 return 时提交 partial，保留不完整 Tool Call 分片', async () => {
+    let captured: unknown
+    const stream = teeRawResponseCapture(toAsyncIterable([
+      createChunk({
+        delta: {
+          tool_calls: [{
+            index: 0,
+            id: 'call_1',
+            type: 'function',
+            function: { name: 'search_', arguments: '{"query"' },
+          }],
+        },
+      }),
+      createChunk({
+        delta: {
+          tool_calls: [{
+            index: 0,
+            function: { name: 'articles', arguments: ':"seo"}' },
+          }],
+        },
+      }),
+    ]), (capture) => {
+      captured = capture
+    })
+
+    assert.equal((await stream.next()).done, false)
+    await stream.return(undefined)
+
+    assert.deepEqual(captured, {
+      state: 'partial',
+      lastEvent: 'tool_call_delta',
+      textChars: 0,
+      toolCallCount: 1,
+      rawResponse: {
+        id: 'chunk-1',
+        object: 'chat.completion',
+        created: 1_756_000_000,
+        model: 'deepseek-v4-flash',
+        choices: [{
+          index: 0,
+          finish_reason: null,
+          message: {
+            role: 'assistant',
+            content: null,
+            tool_calls: [{
+              id: 'call_1',
+              type: 'function',
+              function: {
+                name: 'search_',
+                arguments: '{"query"',
+              },
+            }],
+          },
+        }],
+      },
+    })
+  })
+
+  it('Tool Call 分片后上游抛错时仍提交 partial', async () => {
+    let captured: ModelRawResponseCapture | undefined
+    const failing = async function* (): AsyncGenerator<ChatCompletionChunk> {
+      yield createChunk({
+        delta: {
+          tool_calls: [{
+            index: 0,
+            id: 'call_1',
+            type: 'function',
+            function: { name: 'search_', arguments: '{"query"' },
+          }],
+        },
+      })
+      throw new Error('tool stream broken')
+    }
+
+    await assert.rejects(async () => {
+      for await (const _ of teeRawResponseCapture(failing(), (capture) => {
+        captured = capture
+      })) {
+        // 只消费流
+      }
+    }, /tool stream broken/)
+
+    assert.equal(captured?.state, 'partial')
+    assert.equal(captured?.lastEvent, 'tool_call_delta')
+    assert.equal(captured?.toolCallCount, 1)
+    assert.match(JSON.stringify(captured?.rawResponse), /search_|call_1/)
+  })
+
+  it('首个 chunk 前失败时提交 empty，且不伪造响应字段', async () => {
+    let captured: unknown
+    const failing = async function* (): AsyncGenerator<ChatCompletionChunk> {
+      throw new Error('no response')
+    }
+
+    await assert.rejects(async () => {
+      for await (const _ of teeRawResponseCapture(failing(), (capture) => {
+        captured = capture
+      })) {
+        // 只消费流
+      }
+    }, /no response/)
+
+    assert.deepEqual(captured, {
+      state: 'empty',
+      lastEvent: null,
+      textChars: 0,
+      toolCallCount: 0,
+    })
+  })
+
+  it('捕获回调失败不覆盖正常流或原始流错误', async () => {
+    let captureFailures = 0
+
+    const collect = async (source: AsyncIterable<ChatCompletionChunk>) => {
+      for await (const _ of teeRawResponseCapture(
+        source,
+        () => {
+          throw new Error('capture callback failed')
+        },
+        () => {
+          captureFailures += 1
+        },
+      )) {
+        // 只消费流
+      }
+    }
+
+    await collect(toAsyncIterable([
+      createChunk({ delta: {}, finish_reason: 'stop' }),
+    ]))
+    await assert.rejects(collect((async function* () {
+      throw new Error('provider failed')
+    })()), /provider failed/)
+    assert.equal(captureFailures, 2)
   })
 })
 

--- a/apps/api/src/llm/clients/openai-compatible-raw-capture.ts
+++ b/apps/api/src/llm/clients/openai-compatible-raw-capture.ts
@@ -1,4 +1,8 @@
 import type { ChatCompletionChunk } from 'openai/resources/chat/completions'
+import type {
+  ModelRawResponseCapture,
+  ModelResponseCaptureEvent,
+} from '../llm.types.js'
 
 interface RawToolCallSlot {
   id?: string
@@ -11,91 +15,164 @@ interface RawToolCallSlot {
 
 /**
  * debug 捕获用的透传聚合器：原样转发每个 chunk，同时把流式 delta 组装成
- * 一份非流式形态的原始响应 JSON，流正常结束后交给 onResponse。
+ * 一份非流式形态的原始响应 JSON，并在任意关闭路径提交一次捕获结果。
  *
  * 只做字段拼接，不做业务校验（校验属于 stream adapter 的职责）；
- * 流中途抛错时不产生捕获结果。
+ * 捕获是旁路观测：回调失败不会改变原流的完成或异常语义。
  */
 export async function* teeRawResponseCapture(
   chunks: AsyncIterable<ChatCompletionChunk>,
-  onResponse: (rawResponse: unknown) => void,
+  onResponse: (capture: ModelRawResponseCapture) => void,
+  onCaptureError?: () => void,
 ): AsyncGenerator<ChatCompletionChunk> {
   let id: string | undefined
   let model: string | undefined
   let created: number | undefined
   let finishReason: string | null = null
   let usage: ChatCompletionChunk['usage'] | undefined
+  let receivedChunkCount = 0
+  let sawChoice = false
+  let sourceCompleted = false
+  let committed = false
+  let lastEvent: ModelResponseCaptureEvent | null = null
+  let textChars = 0
   const contentChunks: string[] = []
   const reasoningContentChunks: string[] = []
   const toolCalls: RawToolCallSlot[] = []
 
-  for await (const chunk of chunks) {
-    id ??= chunk.id
-    model ??= chunk.model
-    created ??= chunk.created
+  try {
+    for await (const chunk of chunks) {
+      receivedChunkCount += 1
+      id ??= chunk.id
+      model ??= chunk.model
+      created ??= chunk.created
 
-    const choice = chunk.choices[0]
+      const choice = chunk.choices[0]
 
-    if (choice) {
-      const delta = choice.delta as ChatCompletionChunk.Choice.Delta & {
-        reasoning_content?: string | null
+      if (choice) {
+        sawChoice = true
+        const delta = choice.delta as ChatCompletionChunk.Choice.Delta & {
+          reasoning_content?: string | null
+        }
+
+        if (delta.reasoning_content) {
+          reasoningContentChunks.push(delta.reasoning_content)
+          lastEvent = 'reasoning_delta'
+        }
+
+        for (const toolCallDelta of delta.tool_calls ?? []) {
+          const slot = toolCalls[toolCallDelta.index]
+            ?? (toolCalls[toolCallDelta.index] = { function: { name: '', arguments: '' } })
+
+          if (toolCallDelta.id)
+            slot.id = toolCallDelta.id
+          if (toolCallDelta.type)
+            slot.type = toolCallDelta.type
+          if (toolCallDelta.function?.name)
+            slot.function.name += toolCallDelta.function.name
+          if (toolCallDelta.function?.arguments)
+            slot.function.arguments += toolCallDelta.function.arguments
+          lastEvent = 'tool_call_delta'
+        }
+
+        if (delta.content) {
+          contentChunks.push(delta.content)
+          textChars += delta.content.length
+          lastEvent = 'text_delta'
+        }
+
+        if (choice.finish_reason) {
+          finishReason = choice.finish_reason
+          lastEvent = 'finish_reason'
+        }
       }
 
-      if (delta.content)
-        contentChunks.push(delta.content)
-      if (delta.reasoning_content)
-        reasoningContentChunks.push(delta.reasoning_content)
-
-      for (const toolCallDelta of delta.tool_calls ?? []) {
-        const slot = toolCalls[toolCallDelta.index]
-          ?? (toolCalls[toolCallDelta.index] = { function: { name: '', arguments: '' } })
-
-        if (toolCallDelta.id)
-          slot.id = toolCallDelta.id
-        if (toolCallDelta.type)
-          slot.type = toolCallDelta.type
-        if (toolCallDelta.function?.name)
-          slot.function.name += toolCallDelta.function.name
-        if (toolCallDelta.function?.arguments)
-          slot.function.arguments += toolCallDelta.function.arguments
+      if (chunk.usage) {
+        usage = chunk.usage
+        lastEvent = 'usage'
       }
 
-      if (choice.finish_reason)
-        finishReason = choice.finish_reason
+      yield chunk
     }
 
-    if (chunk.usage)
-      usage = chunk.usage
-
-    yield chunk
+    sourceCompleted = true
   }
+  finally {
+    if (!committed) {
+      committed = true
+      const compactToolCalls = toolCalls.filter(slot => slot !== undefined)
+      const capture: ModelRawResponseCapture = receivedChunkCount === 0
+        ? {
+            state: 'empty',
+            lastEvent: null,
+            textChars: 0,
+            toolCallCount: 0,
+          }
+        : {
+            state: sourceCompleted ? 'complete' : 'partial',
+            lastEvent,
+            textChars,
+            toolCallCount: compactToolCalls.length,
+            rawResponse: buildRawResponse({
+              id,
+              model,
+              created,
+              finishReason,
+              usage,
+              sawChoice,
+              content: contentChunks.join(''),
+              reasoningContent: reasoningContentChunks.join(''),
+              toolCalls: compactToolCalls,
+            }),
+          }
 
-  const content = contentChunks.join('')
-  const reasoningContent = reasoningContentChunks.join('')
-  // index 由 provider 提供，可能非 0 起始或有空洞；压缩稀疏位，避免序列化出 null 项。
-  const compactToolCalls = toolCalls.filter(slot => slot !== undefined)
+      try {
+        onResponse(capture)
+      }
+      catch {
+        try {
+          onCaptureError?.()
+        }
+        catch {
+          // 捕获失败不得覆盖 Provider 流的完成、异常或 return 语义。
+        }
+      }
+    }
+  }
+}
 
-  onResponse({
-    id,
+function buildRawResponse(input: {
+  id: string | undefined
+  model: string | undefined
+  created: number | undefined
+  finishReason: string | null
+  usage: ChatCompletionChunk['usage'] | undefined
+  sawChoice: boolean
+  content: string
+  reasoningContent: string
+  toolCalls: RawToolCallSlot[]
+}): unknown {
+  return {
+    id: input.id,
     object: 'chat.completion',
-    created,
-    model,
-    choices: [
-      {
-        index: 0,
-        finish_reason: finishReason,
-        message: {
-          role: 'assistant',
-          content: content.length > 0 ? content : null,
-          ...(reasoningContent.length > 0
-            ? { reasoning_content: reasoningContent }
-            : {}),
-          ...(compactToolCalls.length > 0
-            ? { tool_calls: compactToolCalls }
-            : {}),
-        },
-      },
-    ],
-    ...(usage ? { usage } : {}),
-  })
+    created: input.created,
+    model: input.model,
+    choices: input.sawChoice
+      ? [{
+          index: 0,
+          finish_reason: input.finishReason,
+          message: {
+            role: 'assistant',
+            content: input.content.length > 0 ? input.content : null,
+            ...(input.reasoningContent.length > 0
+              ? { reasoning_content: input.reasoningContent }
+              : {}),
+            ...(input.toolCalls.length > 0
+              ? { tool_calls: input.toolCalls }
+              : {}),
+          },
+        }]
+      : [],
+    ...(input.usage ? { usage: input.usage } : {}),
+  }
 }

--- a/apps/api/src/llm/clients/openai-compatible.client.test.ts
+++ b/apps/api/src/llm/clients/openai-compatible.client.test.ts
@@ -7,7 +7,7 @@ import OpenAI from 'openai'
 import {
   resolveLLMRuntimeConfig,
 } from '../llm-runtime-config.js'
-import { LLMConfigError } from '../llm.errors.js'
+import { LLMConfigError, LLMNetworkError } from '../llm.errors.js'
 import { OpenAICompatibleClient } from './openai-compatible.client.js'
 
 describe('OpenAICompatibleClient runtime config', () => {
@@ -131,6 +131,71 @@ describe('OpenAICompatibleClient runtime config', () => {
     )
     assert.equal(harness.calls.length, 0)
   })
+
+  it('请求已发起但 SDK 在首个 chunk 前失败时提交 empty capture', async () => {
+    const harness = createHarness(true)
+    let captured: unknown
+
+    Object.defineProperty(harness.client, 'createClient', {
+      configurable: true,
+      value: () => ({
+        chat: {
+          completions: {
+            create: async () => {
+              throw new Error('connection failed')
+            },
+          },
+        },
+      }),
+    })
+
+    await assert.rejects(
+      collectEvents(harness.client.chatStream(
+        [{ type: 'message', role: 'user', content: 'hello' }],
+        {
+          debugCapture: {
+            onRequest: () => {},
+            onResponse: (capture) => {
+              captured = capture
+            },
+          },
+        },
+      )),
+      LLMNetworkError,
+    )
+    assert.deepEqual(captured, {
+      state: 'empty',
+      lastEvent: null,
+      textChars: 0,
+      toolCallCount: 0,
+    })
+  })
+
+  it('debug 回调失败只通知安全失败侧，不影响正常模型事件', async () => {
+    const harness = createHarness(true)
+    const failedSides: string[] = []
+
+    const events = await collectEvents(harness.client.chatStream(
+      [{ type: 'message', role: 'user', content: 'hello' }],
+      {
+        debugCapture: {
+          onRequest: () => {
+            throw new Error('request capture failed')
+          },
+          onResponse: () => {
+            throw new Error('response capture failed')
+          },
+          onCaptureError: side => failedSides.push(side),
+        },
+      },
+    ))
+
+    assert.deepEqual(events, [
+      { type: 'text_delta', delta: 'ok' },
+      { type: 'response_completed', finishReason: 'stop' },
+    ])
+    assert.deepEqual(failedSides, ['request', 'response'])
+  })
 })
 
 interface ProviderCall {
@@ -139,13 +204,14 @@ interface ProviderCall {
   params?: Record<string, unknown>
 }
 
-function createHarness() {
+function createHarness(captureModelIO = false) {
   const calls: ProviderCall[] = []
   const runtimeConfig = {
     value: resolveLLMRuntimeConfig({
       LLM_API_KEY: 'test-api-key',
       LLM_BASE_URL: 'https://api.deepseek.com/v1',
       LLM_MODEL: 'deepseek-v4-flash',
+      ...(captureModelIO ? { AGENT_DEBUG_CAPTURE_MODEL_IO: 'true' } : {}),
     }),
   } as LLMRuntimeConfigService
   const client = new OpenAICompatibleClient(runtimeConfig)

--- a/apps/api/src/llm/clients/openai-compatible.client.ts
+++ b/apps/api/src/llm/clients/openai-compatible.client.ts
@@ -11,6 +11,9 @@ import type {
   ChatStreamOptions,
   DeepSeekBalanceResponse,
   DeepSeekModelsResponse,
+  ModelIODebugCapture,
+  ModelIODebugCaptureSide,
+  ModelRawResponseCapture,
 } from '../llm.types.js'
 import type { ModelInputItem } from '../model-input.types.js'
 import type { ModelStreamEvent } from '../model-stream.types.js'
@@ -118,6 +121,29 @@ export class OpenAICompatibleClient {
     const debugCapture = this.runtimeConfigService.value.captureModelIO
       ? options?.debugCapture
       : undefined
+    let requestStarted = false
+    let responseCaptureCommitted = false
+    const notifyCaptureError = (side: ModelIODebugCaptureSide): void => {
+      try {
+        debugCapture?.onCaptureError?.(side)
+      }
+      catch {
+        // debug 旁路连错误通知都不得改变模型调用。
+      }
+    }
+    const commitResponseCapture = (capture: ModelRawResponseCapture): void => {
+      if (!debugCapture || responseCaptureCommitted)
+        return
+
+      responseCaptureCommitted = true
+
+      try {
+        debugCapture.onResponse(capture)
+      }
+      catch {
+        notifyCaptureError('response')
+      }
+    }
 
     try {
       const requestParams = {
@@ -132,8 +158,9 @@ export class OpenAICompatibleClient {
         },
       }
 
-      debugCapture?.onRequest(requestParams)
+      safelyCaptureRequest(debugCapture, requestParams, notifyCaptureError)
 
+      requestStarted = true
       const stream = await client.chat.completions.create(
         requestParams as unknown as ChatCompletionCreateParamsStreaming,
         requestOptions,
@@ -141,11 +168,23 @@ export class OpenAICompatibleClient {
 
       yield* adaptOpenAICompatibleStream(
         debugCapture
-          ? teeRawResponseCapture(stream, debugCapture.onResponse)
+          ? teeRawResponseCapture(
+              stream,
+              commitResponseCapture,
+              () => notifyCaptureError('response'),
+            )
           : stream,
       )
     }
     catch (cause) {
+      if (requestStarted && debugCapture && !responseCaptureCommitted) {
+        commitResponseCapture({
+          state: 'empty',
+          lastEvent: null,
+          textChars: 0,
+          toolCallCount: 0,
+        })
+      }
       throw this.toLLMError(cause)
     }
   }
@@ -234,6 +273,22 @@ export class OpenAICompatibleClient {
     const message = error.message ? `: ${error.message}` : ''
 
     return `LLM API ${status} 错误${message}`
+  }
+}
+
+function safelyCaptureRequest(
+  debugCapture: ModelIODebugCapture | undefined,
+  requestParams: unknown,
+  onCaptureError: (side: ModelIODebugCaptureSide) => void,
+): void {
+  if (!debugCapture)
+    return
+
+  try {
+    debugCapture.onRequest(requestParams)
+  }
+  catch {
+    onCaptureError('request')
   }
 }
 

--- a/apps/api/src/llm/llm.types.ts
+++ b/apps/api/src/llm/llm.types.ts
@@ -32,6 +32,27 @@ export interface ChatOptions {
   responseFormat?: { type: 'json_object' } | { type: 'text' }
 }
 
+export type ModelResponseCaptureState = 'complete' | 'partial' | 'empty'
+
+export type ModelResponseCaptureEvent
+  = | 'text_delta'
+    | 'reasoning_delta'
+    | 'tool_call_delta'
+    | 'finish_reason'
+    | 'usage'
+
+/** Provider 原始响应的旁路聚合结果；安全计数仅供关联日志使用。 */
+export interface ModelRawResponseCapture {
+  state: ModelResponseCaptureState
+  lastEvent: ModelResponseCaptureEvent | null
+  textChars: number
+  toolCallCount: number
+  /** empty 时刻意缺失，避免伪造 choices / finish reason / usage。 */
+  rawResponse?: unknown
+}
+
+export type ModelIODebugCaptureSide = 'request' | 'response'
+
 /**
  * debug 模型 I/O 捕获回调。
  *
@@ -42,8 +63,10 @@ export interface ChatOptions {
 export interface ModelIODebugCapture {
   /** 请求真正发出前回调，body 为实际请求体（不含凭据）。 */
   onRequest: (requestBody: unknown) => void
-  /** 模型流正常结束后回调，raw 为流式组装出的完整原始响应。 */
-  onResponse: (rawResponse: unknown) => void
+  /** 模型流关闭时回调；明确区分完整、部分和未收到 chunk。 */
+  onResponse: (capture: ModelRawResponseCapture) => void
+  /** 捕获回调自身失败时的安全旁路通知，不携带原始 payload。 */
+  onCaptureError?: (side: ModelIODebugCaptureSide) => void
 }
 
 /** chatStream() 方法的可选参数。 */

--- a/docs/README.md
+++ b/docs/README.md
@@ -9,6 +9,7 @@
 Phase 8：Completed
 Active Agent Task：无
 DeepSeek 思考强度与 Usage（#94）：Completed
+失败 Sampling 部分响应可观测性（#98）：Completed
 Minimal Compaction：Gated
 Admin Task 4：Planned
 Phase 9：未定案
@@ -24,7 +25,7 @@ Phase 8 已完成：
 - Task 3B：Web Grounding 状态、Sources disclosure、Source cards 与 Chromium，#60 / #61 / `572ad206`；
 - Task 3C：Admin Retrieval / Finalization / Citation Inspector，#62 / #63 / `20f838fb`。
 
-当前仍处于 Phase 8 源码阅读阶段；独立横向任务 Issue #94（[DeepSeek 思考强度与 Usage](./tasks/deepseek-reasoning-usage.md)）已验收合并。下一阶段学习内容暂不定义，Phase 9 尚未定案。
+当前仍处于 Phase 8 源码阅读阶段；独立横向任务 Issue #98（[失败 Sampling 部分响应可观测性](./tasks/failed-sampling-debug-capture.md)）和 Issue #94（[DeepSeek 思考强度与 Usage](./tasks/deepseek-reasoning-usage.md)）均已通过验收。下一阶段学习内容暂不定义，Phase 9 尚未定案。
 
 ## 文档入口
 
@@ -32,6 +33,7 @@ Phase 8 已完成：
 | --- | --- |
 | [roadmap.md](./roadmap.md) | 阶段路线、学习闭环与 Phase 9 决策原则 |
 | [tasks/README.md](./tasks/README.md) | 正式任务看板和状态事实来源 |
+| [失败 Sampling 部分响应可观测性](./tasks/failed-sampling-debug-capture.md) | Completed：#98 / PR #100 |
 | [DeepSeek 思考强度与 Usage](./tasks/deepseek-reasoning-usage.md) | Completed：#94 / PR #95 / `2266fad` |
 | [Phase 8 归档](./tasks/completed/phase-08-grounded-retrieval.md) | Completed：Task 0-3C 全部内容、阶段不变量与边界 |
 | [Grounded Answer / Citation 研究](./research/phase-08-grounded-answer-citation-design.md) | Provider、开源方案与架构定案 |

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -9,8 +9,9 @@
 Phase 8：Completed
 Active Agent Task：无
 DeepSeek 思考强度与 Usage（#94）：Completed
+失败 Sampling 部分响应可观测性（#98）：Completed
 Minimal Compaction：Gated
-Admin Observability：Task 0-3、Enhancement 1、Phase 8 Task 3C Completed
+Admin Observability：Task 0-3、Enhancement 1、Phase 8 Task 3C、#98 Completed
 Admin Task 4：Planned
 Phase 9：未定案
 ```

--- a/docs/tasks/README.md
+++ b/docs/tasks/README.md
@@ -11,6 +11,7 @@ Task 0、1、2A、2B、3A、3B、3C：Completed
 Active Agent Task：无
 DeepSeek 思考强度与 Usage（#94）：Completed
 Run 配置解析边界（#92）：Completed
+失败 Sampling 部分响应可观测性（#98）：Completed
 Minimal Compaction：Gated
 Admin Task 4：Planned
 Phase 9：未定案
@@ -23,6 +24,7 @@ Phase 9：未定案
 | Agent 主线 | **阶段 1-8 Completed** | [roadmap.md](../roadmap.md) | 当前为 Phase 8 源码阅读阶段 |
 | DeepSeek 思考强度与 Usage（#94） | **Completed / #95 / `2266fad`** | [deepseek-reasoning-usage.md](./deepseek-reasoning-usage.md) | Web 单次选择、Run resolved config、Provider wire、Usage / Admin 闭环 |
 | Run 配置解析边界（#92） | **Completed / #93 / `f32cd48`** | [agent-run-configuration.md](./agent-run-configuration.md) | 横向 refactor：单次 Run 配置解析入口 + 配置地图 |
+| 失败 Sampling 部分响应可观测性（#98） | **Completed / #100** | [failed-sampling-debug-capture.md](./failed-sampling-debug-capture.md) | complete / partial / empty 捕获、失败终态保留与 Admin 三态展示 |
 | Phase 8：Grounded Retrieval / RAG Baseline | **Completed** | [completed/phase-08-grounded-retrieval.md](./completed/phase-08-grounded-retrieval.md) | Task 0-3C 全部完成，已归档 |
 | Phase 7：Context Engineering | **Completed** | [completed/phase-07-context-engineering.md](./completed/phase-07-context-engineering.md) | Task 0-3 Completed；Minimal Compaction Gated |
 | Phase 6：有界单 Agent Loop | **Completed** | [completed/phase-06-bounded-agent-loop.md](./completed/phase-06-bounded-agent-loop.md) | bounded loop、deadline、终态可靠性 |
@@ -48,9 +50,9 @@ Phase 8 全部 Task 文档已合并归档到 [completed/phase-08-grounded-retrie
 
 ## 当前正式动作
 
-当前没有 Active Agent Task。DeepSeek 思考强度与 Usage 可观测闭环（#94）已验收合并（PR #95 / `2266fad`）；Run 配置解析边界（#92）已于 2026-08-22 验收合并（PR #93 / `f32cd48`）。
+当前没有 Active Agent Task。失败 Sampling 部分响应可观测性（#98）已通过技术验收并获用户确认；DeepSeek 思考强度与 Usage（#94）和 Run 配置解析边界（#92）均已验收合并。
 
-Phase 8 源码阅读仍是当前学习阶段；#94 是独立横向正式任务，不定义或启动 Phase 9。下一阶段学习内容暂不定义。
+Phase 8 源码阅读仍是当前学习阶段；#98、#94、#92 均为独立横向正式任务，不定义或启动 Phase 9。下一阶段学习内容暂不定义。
 
 Admin Task 4、并行 Tool Call、Minimal Compaction、Memory、MCP、Multi-agent 和 Durable Recovery 均不得自动进入实现。
 

--- a/docs/tasks/failed-sampling-debug-capture.md
+++ b/docs/tasks/failed-sampling-debug-capture.md
@@ -1,0 +1,59 @@
+# Task：失败 Sampling 部分响应可观测性（Issue #98）
+
+- 实施状态：已实现
+- 验收状态：已通过（GPT 技术验收通过，用户 2026-08-26 确认并授权合并）
+- Issue：[#98](https://github.com/mufeiyu-ayu/agent/issues/98)
+- 分支：`codex/issue-98-partial-sampling-capture`
+- PR：[#100](https://github.com/mufeiyu-ayu/agent/pull/100)（合并授权已确认）
+
+## 目标
+
+补全 Issue #86 只捕获完整 Provider Response 的失败路径：开启 `AGENT_DEBUG_CAPTURE_MODEL_IO` 时，失败、提前关闭和中止的 action sampling 也保留有界、明确标记为不完整的聚合响应，并让 Admin 与安全日志区分 `complete`、`partial`、`empty`。
+
+## 已锁定边界
+
+- 捕获仍由 debug 开关控制并默认关闭；不扩大生产默认暴露面。
+- 只聚合已收到的 SSE chunk，不逐 chunk 落库。
+- 捕获是旁路观测，不覆盖原错误、Run / Message / Step 终态或 Tool 执行决策。
+- 沿用 200K 字符上限、代理对安全截断、`reasoning_content` 剥离和 Admin 白名单投影。
+- 复用 `AgentStep.output` JSON；无 Prisma migration、无新依赖。
+- 不修改混合文本 / Tool Call 状态机；对应兼容问题由 Issue #99 独立处理。
+
+## 实现结果
+
+- `teeRawResponseCapture()` 在正常 EOF、上游异常、下游 `return()` 和首 chunk 前失败时分别提交一次 `complete`、`partial` 或 `empty` 捕获；捕获回调失败不改变模型流。
+- `OpenAICompatibleClient` 在请求已发起但 SDK 未返回首 chunk 时补充 `empty` 事实，并保持原 LLM 错误转换。
+- `AgentRuntimeService` 在异常、用户 Abort、deadline 和消费者提前结束时先关闭活动 sampling iterator，再把已成立 capture 写入原 `model_sampling` Step。
+- 安全结构化日志只记录 `runId`、`samplingAttemptId`、终止分类、capture state、最后事件、文本字符数和 Tool Call 数。
+- Admin contract / projector / Request Inspector 支持三态 Response；legacy 捕获映射为 `complete`，损坏信封 fail closed；复制 JSON 携带 capture state。
+
+## 验收结果
+
+- [x] 正常文本与 Tool Call 流各提交一次 `complete` capture。
+- [x] 上游文本或 Tool Call 分片后断流提交 `partial`，原错误继续传播。
+- [x] `text_delta -> tool_call_started -> consumer rejects` 保留 partial capture，Run / Step 仍 FAILED，Tool invocation 为 0。
+- [x] 首 chunk 前失败提交 `empty`，不伪造 choices、finish reason 或 usage。
+- [x] Abort、deadline 和外层消费者 `return()` 保持原终态语义。
+- [x] debug 关闭、legacy、截断、循环引用与 malformed 信封确定性降级。
+- [x] Admin 分别展示 partial / empty 提示，复制结果保留状态。
+- [x] 无 Prisma、依赖、lockfile、自动重试或 Tool 协议变更。
+
+## 验证记录（2026-08-26，本地）
+
+| 验证 | 结果 |
+| --- | --- |
+| `pnpm --filter @agent/api test:model-stream` | 91 / 91 通过 |
+| `pnpm --filter @agent/api test:tool-loop` | 65 / 65 通过 |
+| `pnpm --filter @agent/api test:admin-runs` | 146 / 146 通过 |
+| `pnpm --filter @agent/api test:llm-config` | 23 / 23 通过 |
+| `pnpm --filter @agent/admin test` | 通过 |
+| API / Admin lint、API / Admin / workspace typecheck | 通过 |
+| Admin production build | 通过；保留既有大 chunk warning |
+| Chromium route fixture | partial / empty 提示与 partial 复制状态通过 |
+| `git diff --check` | 通过 |
+
+未执行真实 Provider 故障注入；相同事件顺序已由确定性 fixture 覆盖，不消耗真实模型额度或改写本地业务数据。
+
+## 收口结论
+
+Issue #98 的 AC-01～09 已通过技术验收，用户已明确确认并授权 docs 收口、PR 合并及分支清理。本任务作为独立横向可观测性修复 Completed，不启动 Phase 9。

--- a/docs/work-log.md
+++ b/docs/work-log.md
@@ -6,7 +6,7 @@
 
 | 类型 | 当前记录 | 下一步 |
 | --- | --- | --- |
-| Agent 主线 | 阶段 1-8 Completed；#94 / PR #95 已验收合并 | Phase 8 源码阅读；不启动 Phase 9 |
+| Agent 主线 | 阶段 1-8 Completed；#98 / PR #100 已验收并获合并授权 | Phase 8 源码阅读；不启动 Phase 9 |
 | Phase 8 | Task 0、1、2A、2B、3A、3B、3C 全部 Completed | [阶段归档](./tasks/completed/phase-08-grounded-retrieval.md) |
 | Minimal Compaction | Gated | 只有真实 Context 压力证据满足触发条件后才讨论 |
 | Admin Console | Task 0-3、Enhancement 1-3、Phase 8 Task 3C Completed；Task 4 Planned | 不自动启动 Auth / RBAC |
@@ -16,6 +16,7 @@
 
 | 日期 | 事项 | 结果 |
 | --- | --- | --- |
+| 2026-08-26 | 失败 Sampling 部分响应可观测性 #98 验收收口 | Issue #98 / PR #100；失败、Abort、deadline 与消费者 return 路径保存 complete / partial / empty 聚合事实；Admin 区分未捕获、部分响应和空响应，复制 JSON 保留状态；安全日志只记录关联 ID 与计数；确定性测试 91 + 65 + 146 + 23 全绿，Admin checks、lint、typecheck、build 与 Chromium route fixture 通过；GPT 技术验收通过，用户确认并授权合并与分支清理 |
 | 2026-08-23 | DeepSeek 思考强度与 Usage #94 收口 | Issue #94 / PR #95；Web Low / High / Max 单次选择贯穿 resolved Run 配置与全部 sampling；Provider 显式 thinking / reasoning_effort 并移除 temperature；reasoning / cache Usage 持久化到 AgentStep，Admin Run Detail 按指标独立 all-or-nothing 展示；debug safe projection 剥离 reasoning_content；用户确认 UI 验收通过，独立技术复核后修正 reasoning E2E 精确定位，完整 Web Chromium 10 / 10；PR #95 merge `2266fad`，Issue #94 Closed / Completed |
 | 2026-08-22 | Run 配置解析边界 #92 收口 | Issue #92 / PR #93；源码阅读阶段发现的横向 refactor：新增 `AgentRunConfigurationService` 收敛单次 Run 配置解析（policy getter 保 deadline 时序），`ResolvedChatRequestConfig` 补全 contextWindowTokens / temperature，Runtime 消除 `getModelProfile` 穿透与 `!` 断言，模型名单与 Profile 收敛进 `model-profiles.ts`，删除单行 `llm.constants.ts`；新增 `docs/research/configuration-map.md` 配置地图；commit 前 /code-review 15 项 findings（12 类修复并入提交，不修项在 PR 记录理由，含 model:'' 既有语义按规格保留）；验证 6 套件 383 项全绿 + lint + root typecheck；AC-01～09 逐项核对通过，用户确认验收并授权合并与清理；merge `f32cd48`，Issue #92 Closed，分支已删 |
 | 2026-08-22 | Admin Enhancement 3 Overview 仪表盘 #90 收口 | Issue #90 / PR #91；stats + balance API（应用层扫 30 天窗口聚合 step JSON usage；DeepSeek 余额服务端代理复用 LLM_API_KEY）+ ECharts 按需注册前端（stat bar、双趋势图、比例条分布列表，亮暗主题联动）；/code-review 一轮 5 项全处理（含 resolvedModel 落库路径确认级 bug，实调接口验证）；视觉验收反馈一轮重构后用户确认并授权合并；实测确认 DeepSeek 官方 API 仅开放 user/balance，平台用量页无公开 API；merge `3108a5f`，Issue #90 Closed，分支已删 |

--- a/packages/contracts/src/admin-run.ts
+++ b/packages/contracts/src/admin-run.ts
@@ -336,6 +336,11 @@ export type AdminDebugModelIOCapture
   = | { truncated: false, value: unknown }
     | { truncated: true, preview: string }
 
+/** Response 专用信封：旧捕获由 projector 安全映射为 complete。 */
+export type AdminDebugModelResponseCapture
+  = | ({ state: 'complete' | 'partial' } & AdminDebugModelIOCapture)
+    | { state: 'empty' }
+
 export interface AdminModelSamplingStep extends AdminRunKnownTimelineItemBase {
   type: 'model_sampling'
   samplingIndex: number | null
@@ -353,8 +358,8 @@ export interface AdminModelSamplingStep extends AdminRunKnownTimelineItemBase {
   contextInspector: AdminContextInspector
   /** debug 捕获：实际发给 provider 的请求体；未开启捕获或数据缺失为 null。 */
   debugRequestBody: AdminDebugModelIOCapture | null
-  /** debug 捕获：流式组装后的 provider 原始响应；未开启捕获或数据缺失为 null。 */
-  debugRawResponse: AdminDebugModelIOCapture | null
+  /** debug 捕获：完整、部分或空的 provider 响应事实；未捕获为 null。 */
+  debugRawResponse: AdminDebugModelResponseCapture | null
 }
 
 export interface AdminToolExecutionStep extends AdminRunKnownTimelineItemBase {
@@ -421,7 +426,7 @@ export interface AdminRunSafeStepProjection {
   hasError: boolean
   /** debug 捕获白名单字段：仅 model_sampling 且捕获存在时出现。 */
   debugRequestBody?: AdminDebugModelIOCapture
-  debugRawResponse?: AdminDebugModelIOCapture
+  debugRawResponse?: AdminDebugModelResponseCapture
 }
 
 export interface AdminRunSafeRawData {

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -19,6 +19,7 @@ export type {
   AdminContextInspectorOutcome,
   AdminContextObservationSummary,
   AdminDebugModelIOCapture,
+  AdminDebugModelResponseCapture,
   AdminGenericStep,
   AdminGroundedAnswerRejectionCode,
   AdminGroundedCitationCorrelation,


### PR DESCRIPTION
Closes #98

## 状态

- 实施状态：已实现
- 验收状态：待验收
- PR 状态：Draft

## 改动摘要

- Provider capture 在正常 EOF、上游异常、下游提前关闭和首 chunk 前失败时，分别提交一次 `complete`、`partial` 或 `empty` 聚合事实；捕获回调失败不覆盖原模型流。
- Runtime 在异常、Abort、deadline 与消费者 `return()` 路径关闭活动 sampling iterator，再把已成立 capture 写入原 `model_sampling` Step；原错误、Run / Step / Message 终态与 Tool 执行次数保持不变。
- 安全结构化日志只记录 `runId`、`samplingAttemptId`、终止分类、capture state、最后事件、字符数和 Tool Call 数。
- Contracts / safe projector / Request Inspector 支持三态响应；旧版无 state 的成功捕获映射为 `complete`，损坏数据 fail closed，partial / empty 使用独立提示，复制内容携带状态。

## 明确未做

- 未改变混合文本 / Tool Call 状态机、final answer 或 Tool 执行协议。
- 未增加自动重试、Provider fallback 或重新 sampling。
- 未逐 SSE chunk 落库，未扩大 debug 默认值或敏感字段范围。
- 未修改 grounded finalization 捕获边界。
- 未新增 Prisma migration、依赖或 telemetry framework。

## AC 与验证证据

- AC-01 / 03 / 05：`teeRawResponseCapture` 覆盖 complete、上游 text/tool partial、下游 return partial、empty、回调最多一次和原错误透传；Client 覆盖 SDK 首 chunk 前失败。
- AC-04：受控 `text_delta -> tool_call_started -> consumer rejects` fixture 保持 FAILED、Tool invocation = 0；Abort、deadline、外层 return 与 debug-off 基线均覆盖。
- AC-06：覆盖 200K 截断、Unicode 代理对、循环引用、reasoning_content 既有剥离、legacy 信封和 malformed fail closed。
- AC-02 / 07：Admin contract / projector / source checks 覆盖 complete、partial、empty、未捕获提示及复制状态。
- AC-08：Runtime 测试断言关联日志不包含原始响应正文。
- AC-09：提交不包含 Prisma、依赖、lockfile 或无关模块改动。

执行结果：

- `pnpm --filter @agent/api test:model-stream`：PASS，91 tests
- `pnpm --filter @agent/api test:tool-loop`：PASS，65 tests
- `pnpm --filter @agent/api test:admin-runs`：PASS，146 tests
- `pnpm --filter @agent/api test:llm-config`：PASS，23 tests
- `pnpm --filter @agent/api typecheck`：PASS
- `pnpm --filter @agent/api lint`：PASS
- `pnpm --filter @agent/admin test`：PASS
- `pnpm --filter @agent/admin typecheck`：PASS
- `pnpm --filter @agent/admin lint`：PASS
- `pnpm --filter @agent/admin build`：PASS；Vite 仍报告 >500 kB chunk warning，本 Issue 未调整分包
- `pnpm typecheck`：PASS
- `git diff --check`：PASS

未执行真实 Provider 故障注入或浏览器交互验收；失败顺序、Admin 状态与复制语义由确定性 fixture、projector/source checks、typecheck 和 production build 覆盖。

## commit 前 Review

- 第 1 轮：发现 2 项 P1——异常窗口未关闭活动 iterator、debug return 路径写入新 errorMessage；均已修复并补回归测试。
- 第 2 轮：P0 无、P1 无、P2/P3 无，No findings。

## 建议阅读顺序

1. `apps/api/src/llm/clients/openai-compatible-raw-capture.ts`
2. `apps/api/src/llm/clients/openai-compatible.client.ts`
3. `apps/api/src/agent-runtime/agent-runtime.service.ts`
4. `apps/api/src/agent-runtime/model-io-debug-capture.ts`
5. `packages/contracts/src/admin-run.ts` 与 `apps/api/src/admin-runs/admin-run.projector.ts`
6. `apps/admin/src/features/runs/trace/inspectors/DebugJsonPane.vue`

真实调用链：`OpenAICompatibleClient -> teeRawResponseCapture -> adaptOpenAICompatibleStream -> streamModelSampling -> AgentRuntimeService -> AgentStep.output -> Admin safe projector -> Request Inspector`。
